### PR TITLE
Add CodeQL and Bandit code scanning workflows

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -28,8 +28,8 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Get ignore codes
-        id: ignore-codes
+      - name: Compute ruff args
+        id: ruff-args
         # This are computed so that we can run only the `S` (bandit)
         # checks. Passing --select to ruff overrides any config files
         # (ruff.toml, pyproject.toml, etc), so to avoid having keep everything
@@ -38,16 +38,16 @@ jobs:
           set -euxo pipefail
 
           CODES="$(uvx toml2json ./pyproject.toml | jq -r '.tool.ruff.lint.ignore | map(select(test("^S\\d+"))) | join(",")')"
-          echo "codes=${CODES}" >> "$GITHUB_OUTPUT"
+          ARGS="check --select S"
           if [ -n "${CODES}" ]; then
-            echo "ignore_flag=--ignore ${CODES}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ignore_flag=" >> "$GITHUB_OUTPUT"
+            ARGS="${ARGS} --ignore ${CODES}"
           fi
+          ARGS="${ARGS} --output-format sarif --output-file results.sarif"
+          echo "args=${ARGS}" >> "$GITHUB_OUTPUT"
       - name: Perform Bandit Analysis using Ruff
         uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6  # v3.6.1
         with:
-          args: "check --select S ${{ steps.ignore-codes.outputs.ignore_flag }} --output-format sarif --output-file results.sarif"
+          args: "${{ steps.ruff-args.outputs.args }}"
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4.35.1
         with:

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -17,6 +17,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       security-events: write
     steps:

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Static Analysis: Bandit Scan"
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+      - "main"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          enable-cache: false
+
+      - name: Get ignore codes
+        id: ignore-codes
+        # This are computed so that we can run only the `S` (bandit)
+        # checks. Passing --select to ruff overrides any config files
+        # (ruff.toml, pyproject.toml, etc), so to avoid having keep everything
+        # in sync we grab them from the TOML programmatically
+        run: |
+          set -euxo pipefail
+
+          CODES="$(uvx toml2json ./pyproject.toml | jq -r '.tool.ruff.lint.ignore | map(select(test("^S\\d+"))) | join(",")')"
+          echo "codes=${CODES}" >> "$GITHUB_OUTPUT"
+          if [ -n "${CODES}" ]; then
+            echo "ignore_flag=--ignore ${CODES}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ignore_flag=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Perform Bandit Analysis using Ruff
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6  # v3.6.1
+        with:
+          args: "check --select S ${{ steps.ignore-codes.outputs.ignore_flag }} --output-format sarif --output-file results.sarif"
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v4.35.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           args: "${{ steps.ruff-args.outputs.args }}"
       - name: Upload SARIF file
-        if: always()
         uses: github/codeql-action/upload-sarif@v4.35.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           args: "${{ steps.ruff-args.outputs.args }}"
       - name: Upload SARIF file
+        if: always()
         uses: github/codeql-action/upload-sarif@v4.35.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -17,6 +17,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Static Analysis: CodeQL Scan"
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+      - "main"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: python
+          build-mode: none
+        - language: c-cpp
+          build-mode: autobuild
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@34950e1b113b30df4edee1a6d3a605242df0c40b  # v3.31.8
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        queries: security-extended
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@34950e1b113b30df4edee1a6d3a605242df0c40b  # v3.31.8
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
 
     strategy:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       security-events: write
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ include-package-data = true
 
 [tool.ruff]
 line-length = 100
+# TODO: update requires-python to >=3.12 (code uses PEP 695 type params)
+target-version = "py312"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,16 @@ ignore = [
     "B904",
     "B905",
     "B019",
+    # flake8-bandit (S) rules suppressed project-wide
+    "S101",   # assert usage (fundamental to test suite)
+    "S102",   # exec() used intentionally in compiler/codegen
+    "S110",   # try-except-pass for optional feature detection
+    "S301",   # pickle used for compiler serialization
+    "S603",   # subprocess calls are internal tooling
+    "S607",   # partial executable paths in subprocess (same as S603)
 ]
 select = ["B"]
-extend-select = ["PERF"]
+extend-select = ["PERF", "S"]
 fixable = ["ALL"]
 
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,10 @@ ignore = [
     "S301",   # pickle used for compiler serialization
     "S603",   # subprocess calls are internal tooling
     "S607",   # partial executable paths in subprocess (same as S603)
+    # TODO: fix violations and remove these suppressions
+    "S108",   # insecure /tmp paths (4 hits in scripts/ci/)
+    "S307",   # eval() usage (2 hits in compiler)
+    "S314",   # xml.parse without defusedxml (4 hits in scripts/ci/)
 ]
 select = ["B"]
 extend-select = ["PERF", "S"]

--- a/src/cusimt/cuda/libdevice.pyi
+++ b/src/cusimt/cuda/libdevice.pyi
@@ -1,1 +1,1 @@
-cusimt/cuda/libdevice.py
+libdevice.py


### PR DESCRIPTION
## Summary

Migrate the static analysis pipelines from cuda-python to keep code scanning infrastructure consistent across our repos:

- **CodeQL** (`codeql.yml`): Python (build-mode: `none`) + C/C++ (build-mode: `autobuild`) with `security-extended` queries.
- **Bandit** (`bandit.yml`): Ruff S-rules scan with SARIF upload to GitHub Security tab. Adapted from cuda-python to read ignore codes from `pyproject.toml` (instead of `ruff.toml`) and to handle the empty-ignores case gracefully.
- **Ruff config** (`pyproject.toml`): Enable flake8-bandit (`S`) rules via `extend-select`, with project-appropriate suppressions (S101 assert, S102 exec, S110 try-except-pass, S301 pickle, S603/S607 subprocess, S108/S307/S314 TODO for follow-up). Set `target-version = "py312"` so ruff can parse PEP 695 type parameter syntax used throughout the codebase.
- **Symlink fix** (`src/cusimt/cuda/libdevice.pyi`): Fix pre-existing broken symlink that pointed to `cusimt/cuda/libdevice.py` instead of `libdevice.py` (same directory). This was causing ruff to exit non-zero with a cache-key error.

Both workflows trigger on pushes to `pull-request/[0-9]+` and `main`, matching the existing `ci.yaml`.

## CI status

All scanning workflows pass:
- ✅ CodeQL Analyze (python)
- ✅ CodeQL Analyze (c-cpp)
- ✅ Bandit (analyze)
- ✅ pre-commit

## Notes

- Action versions and pin SHAs are kept in sync with cuda-python.
- The Bandit workflow dynamically reads S-prefixed ignore codes from `pyproject.toml` via `toml2json | jq`, so adding/removing suppressions in the ruff config is automatically reflected in CI without touching the workflow file.
- TODO items for follow-up: remove S108/S307/S314 suppressions after fixing the 10 underlying violations; update `requires-python` to `>=3.12`.

-- Leo's bot