### PR TITLE
Enable extending linkage test

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1815,9 +1815,6 @@ extern "C" __global__ void
             self._teardown_callbacks.append(link_item.teardown_callback)
         self.linker.add_file_guess_ext(link_item)
 
-    def _link_external_item(self, link_item):
-        return self.link_external_item(link_item)
-
     @staticmethod
     def _external_link_item_key(link_item):
         try:

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -187,7 +187,7 @@ class MLIRLower(object):
         self._setup_callbacks = []
         self._teardown_callbacks = []
         for link_file in link_files:
-            self._link_external_item(link_file)
+            self.link_external_item(link_file)
 
         self._capi_sym_name = None
         if capi := self.targetoptions.get("capi", False):
@@ -1800,9 +1800,10 @@ extern "C" __global__ void
             )
 
         for link_item in fn_value.link:
-            self._link_external_item(link_item)
+            self.link_external_item(link_item)
 
-    def _link_external_item(self, link_item):
+    def link_external_item(self, link_item):
+        """Register an external code object with the active linker."""
         key = self._external_link_item_key(link_item)
         if key in self._linked_external_items:
             return
@@ -1813,6 +1814,9 @@ extern "C" __global__ void
         if hasattr(link_item, "teardown_callback") and link_item.teardown_callback:
             self._teardown_callbacks.append(link_item.teardown_callback)
         self.linker.add_file_guess_ext(link_item)
+
+    def _link_external_item(self, link_item):
+        return self.link_external_item(link_item)
 
     @staticmethod
     def _external_link_item_key(link_item):

--- a/tests/numba_cuda_tests/cudapy/test_extending.py
+++ b/tests/numba_cuda_tests/cudapy/test_extending.py
@@ -7,6 +7,9 @@ import numpy as np
 import numba_cuda_mlir
 from numba_cuda_mlir import cuda
 
+from numba_cuda_mlir._mlir import ir as mlir_ir
+from numba_cuda_mlir._mlir.dialects import func
+from numba_cuda_mlir.lowering_utilities import convert, get_or_insert_function
 from numba_cuda_mlir.numba_cuda import types
 
 import inspect
@@ -274,10 +277,6 @@ class TestExtendingLinkage(NumbaCUDATestCase):
 
             @lower_builtin(external_add, types.uint32, types.uint32)
             def lower_external_add(builder, target, args, kwargs):
-                from numba_cuda_mlir._mlir import ir as mlir_ir
-                from numba_cuda_mlir._mlir.dialects import func
-                from numba_cuda_mlir.lowering_utilities import convert, get_or_insert_function
-
                 builder.link_external_item(code_object)
                 i32 = builder.get_mlir_type(types.uint32)
                 fnty = mlir_ir.FunctionType.get([i32, i32], [i32])

--- a/tests/numba_cuda_tests/cudapy/test_extending.py
+++ b/tests/numba_cuda_tests/cudapy/test_extending.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from numba_cuda_mlir.testing import NumbaCUDATestCase
-from llvmlite import ir
 
 import numpy as np
 import numba_cuda_mlir
@@ -239,7 +238,6 @@ class TestExtending(NumbaCUDATestCase):
 
 
 class TestExtendingLinkage(NumbaCUDATestCase):
-    @pytest.mark.xfail(True, reason="NVVM verify error")
     @pytest.mark.numba_cuda_test_binaries("a", "cubin", "cu", "fatbin", "o", "ptx", "ltoir")
     def test_extension_adds_linkable_code(self):
         binaries = self.numba_cuda_test_binaries
@@ -275,12 +273,22 @@ class TestExtendingLinkage(NumbaCUDATestCase):
                 return typer
 
             @lower_builtin(external_add, types.uint32, types.uint32)
-            def lower_external_add(context, builder, sig, args):
-                context.active_code_library.add_linking_file(code_object)
-                i32 = ir.IntType(32)
-                fnty = ir.FunctionType(i32, [i32, i32])
-                fn = cgutils.get_or_insert_function(builder.module, fnty, "add_cabi")
-                return builder.call(fn, args)
+            def lower_external_add(builder, target, args, kwargs):
+                from numba_cuda_mlir._mlir import ir as mlir_ir
+                from numba_cuda_mlir._mlir.dialects import func
+                from numba_cuda_mlir.lowering_utilities import convert, get_or_insert_function
+
+                builder.link_external_item(code_object)
+                i32 = builder.get_mlir_type(types.uint32)
+                fnty = mlir_ir.FunctionType.get([i32, i32], [i32])
+                fn = get_or_insert_function("add_cabi", fnty, builder.mlir_gpu_module)
+                operands = [convert(arg, i32) for arg in builder.load_vars(args)]
+                result = func.call(
+                    result=[i32],
+                    callee=fn.name.value,
+                    operands_=operands,
+                )
+                builder.store_var(target, result)
 
             @numba_cuda_mlir.cuda.jit(lto=lto)
             def use_external_add(r, x, y):


### PR DESCRIPTION
## Summary
- Add public `MLIRLower.link_external_item()` API and route internal linking through it
- Convert `TestExtendingLinkage.test_extension_adds_linkable_code` to the cuSIMT lowering callback signature and enable it

## Testing
- `LD_PRELOAD=/usr/local/cuda/lib64/libnvJitLink.so.13 .venv/bin/python -X faulthandler -m pytest -p no:rerunfailures -o addopts= tests/numba_cuda_tests/cudapy/test_extending.py::TestExtendingLinkage -vv`
- `LD_PRELOAD=/usr/local/cuda/lib64/libnvJitLink.so.13 .venv/bin/python -X faulthandler -m pytest -p no:rerunfailures -o addopts= tests/numba_cuda_tests/cudapy/test_extending.py -vv`