### PR TITLE
Expose variables_used linker option

### DIFF
--- a/src/numba_cuda_mlir/linker.py
+++ b/src/numba_cuda_mlir/linker.py
@@ -20,6 +20,7 @@ class Linker(_Linker):
         debug: bool = False,
         lineinfo: bool = False,
         optimize_unused_variables: bool = True,
+        variables_used: str | tuple[str, ...] | list[str] | None = None,
         optimization_level: int = 3,
         ptxas_options: str | None = None,
         max_registers: int | None = None,
@@ -42,6 +43,7 @@ class Linker(_Linker):
             prec_sqrt=prec_sqrt,
             fma=fma,
             optimize_unused_variables=optimize_unused_variables,
+            variables_used=variables_used,
             optimization_level=optimization_level,
             ptxas_options=ptxas_options,
         )
@@ -65,6 +67,7 @@ class Linker(_Linker):
             debug=self._debug,
             lineinfo=self.lineinfo,
             optimize_unused_variables=self._optimize_unused_variables,
+            variables_used=self.variables_used,
             optimization_level=self._optimization_level,
             ptxas_options=self._ptxas_options,
             max_registers=self.max_registers,

--- a/src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py
+++ b/src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py
@@ -2220,14 +2220,6 @@ class _Linker:
     def variables_used(self, variables_used):
         self._variables_used = variables_used
 
-    @property
-    def variable_used(self):
-        return self.variables_used
-
-    @variable_used.setter
-    def variable_used(self, variable_used):
-        self.variables_used = variable_used
-
     def add_cu_file(self, path):
         cu = cached_file_read(path, how="rb")
         self.add_cu(cu, os.path.basename(path))

--- a/src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py
+++ b/src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py
@@ -2180,6 +2180,7 @@ class _Linker:
         prec_sqrt=None,
         fma=None,
         optimize_unused_variables=None,
+        variables_used=None,
         optimization_level=3,
         ptxas_options=None,
     ):
@@ -2207,8 +2208,25 @@ class _Linker:
         self._prec_sqrt = prec_sqrt
         self._fma = fma
         self._optimize_unused_variables = optimize_unused_variables
+        self.variables_used = variables_used
         self._optimization_level = optimization_level
         self._ptxas_options = ptxas_options
+
+    @property
+    def variables_used(self):
+        return self._variables_used
+
+    @variables_used.setter
+    def variables_used(self, variables_used):
+        self._variables_used = variables_used
+
+    @property
+    def variable_used(self):
+        return self.variables_used
+
+    @variable_used.setter
+    def variable_used(self, variable_used):
+        self.variables_used = variable_used
 
     def add_cu_file(self, path):
         cu = cached_file_read(path, how="rb")
@@ -2393,6 +2411,7 @@ class _Linker:
             prec_div=self._prec_div,
             prec_sqrt=self._prec_sqrt,
             fma=self._fma,
+            variables_used=self.variables_used,
             optimize_unused_variables=self._optimize_unused_variables,
             optimization_level=self._optimization_level,
             ptxas_options=self._ptxas_options,

--- a/tests/numba_cuda_tests/cudadrv/test_linker.py
+++ b/tests/numba_cuda_tests/cudadrv/test_linker.py
@@ -13,6 +13,7 @@ from numba_cuda_mlir.numba_cuda.testing import (
 )
 from numba_cuda_mlir.testing import NumbaCUDATestCase
 from numba_cuda_mlir.linker import Linker as NumbaCudaMLIRLinker
+from numba_cuda_mlir.numba_cuda.cudadrv import driver as cuda_driver
 from numba_cuda_mlir.numba_cuda.cudadrv.driver import _Linker, LinkerError
 from numba_cuda_mlir.numba_cuda import require_context
 from numba_cuda_mlir.numba_cuda import void, float64, int64, int32, float32
@@ -152,6 +153,40 @@ class TestLinker(NumbaCUDATestCase):
             linker._get_linker_options(ptx=False).variables_used,
             "updated_global",
         )
+
+    def test_variables_used_passed_to_cuda_core_linker(self):
+        captured = {}
+
+        class FakeCudaCoreLinker:
+            def __init__(self, *object_codes, options):
+                captured["object_codes"] = object_codes
+                captured["options"] = options
+
+            def link(self, kind):
+                captured["kind"] = kind
+                return object()
+
+            def get_info_log(self):
+                return ""
+
+            def get_error_log(self):
+                return ""
+
+            def close(self):
+                captured["closed"] = True
+
+        linker = _Linker(
+            max_registers=0,
+            cc=(7, 5),
+            variables_used=["retained_global"],
+        )
+
+        with unittest.mock.patch.object(cuda_driver, "Linker", FakeCudaCoreLinker):
+            linker.complete()
+
+        self.assertEqual(captured["options"].variables_used, ["retained_global"])
+        self.assertEqual(captured["kind"], "cubin")
+        self.assertTrue(captured["closed"])
 
     def test_public_linker_preserves_variables_used_when_recreated_with_lto(self):
         linker = NumbaCudaMLIRLinker(

--- a/tests/numba_cuda_tests/cudadrv/test_linker.py
+++ b/tests/numba_cuda_tests/cudadrv/test_linker.py
@@ -140,16 +140,14 @@ class TestLinker(NumbaCUDATestCase):
         )
 
         self.assertEqual(linker.variables_used, ["retained_global", "another_global"])
-        self.assertEqual(linker.variable_used, ["retained_global", "another_global"])
         self.assertEqual(
             linker._get_linker_options(ptx=False).variables_used,
             ["retained_global", "another_global"],
         )
 
-        linker.variable_used = "updated_global"
+        linker.variables_used = "updated_global"
 
         self.assertEqual(linker.variables_used, "updated_global")
-        self.assertEqual(linker.variable_used, "updated_global")
         self.assertEqual(
             linker._get_linker_options(ptx=False).variables_used,
             "updated_global",

--- a/tests/numba_cuda_tests/cudadrv/test_linker.py
+++ b/tests/numba_cuda_tests/cudadrv/test_linker.py
@@ -12,6 +12,7 @@ from numba_cuda_mlir.numba_cuda.testing import (
     skip_if_nvjitlink_missing,
 )
 from numba_cuda_mlir.testing import NumbaCUDATestCase
+from numba_cuda_mlir.linker import Linker as NumbaCudaMLIRLinker
 from numba_cuda_mlir.numba_cuda.cudadrv.driver import _Linker, LinkerError
 from numba_cuda_mlir.numba_cuda import require_context
 from numba_cuda_mlir.numba_cuda import void, float64, int64, int32, float32
@@ -130,6 +131,43 @@ class TestLinker(NumbaCUDATestCase):
         """Simply go through the constructor and destructor"""
         linker = _Linker(max_registers=0, cc=(7, 5))
         del linker
+
+    def test_variables_used_linker_option(self):
+        linker = _Linker(
+            max_registers=0,
+            cc=(7, 5),
+            variables_used=["retained_global", "another_global"],
+        )
+
+        self.assertEqual(linker.variables_used, ["retained_global", "another_global"])
+        self.assertEqual(linker.variable_used, ["retained_global", "another_global"])
+        self.assertEqual(
+            linker._get_linker_options(ptx=False).variables_used,
+            ["retained_global", "another_global"],
+        )
+
+        linker.variable_used = "updated_global"
+
+        self.assertEqual(linker.variables_used, "updated_global")
+        self.assertEqual(linker.variable_used, "updated_global")
+        self.assertEqual(
+            linker._get_linker_options(ptx=False).variables_used,
+            "updated_global",
+        )
+
+    def test_public_linker_preserves_variables_used_when_recreated_with_lto(self):
+        linker = NumbaCudaMLIRLinker(
+            cc=(7, 5),
+            variables_used=["retained_global"],
+        )
+
+        recreated = linker.recreate_with_lto()
+
+        self.assertEqual(recreated.variables_used, ["retained_global"])
+        self.assertEqual(
+            recreated._get_linker_options(ptx=False).variables_used,
+            ["retained_global"],
+        )
 
     def _test_linking(self, eager):
         global bar  # must be a global; other it is recognized as a freevar


### PR DESCRIPTION
Currently in Numba-CUDA's linker option, `optimize_unused_variables` option is set to default (False). So in nvshmem workflow, the required global variables are preserved after compilation. However, in numba-cuda-mlir, this option is set to true. Therefore we need to manually set them to make sure those global variables are preserved. We expose the setting function via `variables_used` attribute.