### PR TITLE
Clean up pyproject.toml dependencies and align CI with cuda-python/numba-cuda

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.repository_owner == 'NVIDIA'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.repository_owner == 'NVIDIA'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -157,11 +157,6 @@ jobs:
           # we use self-hosted runners on which setup-python behaves weirdly...
           AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
 
-      - name: Create virtual environment
-        run: |
-          python -m venv test-venv
-          echo "$(pwd)/test-venv/bin" >> "$GITHUB_PATH"
-
       - name: Set up mini CTK
         if: ${{ matrix.LOCAL_CTK == '1' }}
         uses: ./.github/actions/fetch_ctk

--- a/ci/tools/run-expensive-tests
+++ b/ci/tools/run-expensive-tests
@@ -102,12 +102,12 @@ fi
 wheel="${wheels[0]}"
 
 if [[ "${LOCAL_CTK}" == 1 ]]; then
-  "${PIP}" install "${wheel}" \
+  "${PIP}" install "${wheel}" --group "test-cu${TEST_CUDA_MAJOR}" \
     "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.28.1" \
     "cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "cuda-core[cu${TEST_CUDA_MAJOR}]"
 else
-  "${PIP}" install "${wheel}[cu${TEST_CUDA_MAJOR}]" \
+  "${PIP}" install "${wheel}[cu${TEST_CUDA_MAJOR}]" --group "test-cu${TEST_CUDA_MAJOR}" \
     "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.28.1" \
     "cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "cuda-core[cu${TEST_CUDA_MAJOR}]" \

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -30,11 +30,11 @@ if [[ "${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}" == "12.2" ]]; then
 fi
 
 if [[ "${LOCAL_CTK}" == 1 ]]; then
-  pip install "${wheel}" \
+  pip install "${wheel}" --group "test-cu${TEST_CUDA_MAJOR}" \
     "${CUDA_BINDINGS_SPEC}" "cuda-core[cu${TEST_CUDA_MAJOR}]" \
     "${coverage_packages[@]}"
 else
-  pip install "${wheel}[cu${TEST_CUDA_MAJOR}]" \
+  pip install "${wheel}[cu${TEST_CUDA_MAJOR}]" --group "test-cu${TEST_CUDA_MAJOR}" \
     "${CUDA_BINDINGS_SPEC}" "cuda-core[cu${TEST_CUDA_MAJOR}]" \
     "cuda-toolkit[cccl,cudart]==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "${coverage_packages[@]}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,8 @@ build-backend = "setuptools.build_meta"
 requires = [
     "setuptools",
     "wheel",
-    "pip",
     "ninja",
     "cmake",
-    "pybind11",
-    "nanobind",
-    "numpy",
 ]
 
 [project]
@@ -26,30 +22,40 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "numpy",
-    "tabulate",
-    "typeguard",
-    "cloudpickle",
-    "pytest",
-    "pytest-xdist",
-    "pytest-rerunfailures",
-    "pytest-benchmark",
-    "filecheck",
-    "cffi",
-    "ml-dtypes",
     "llvmlite",
+    "typeguard",
+    "cuda-bindings>=12.9.1,<14.0.0",
+    "cuda-core>=0.5.1,<1.0.0",
 ]
 
 [project.optional-dependencies]
 cu12 = [
-    "cuda-cccl[cu12]",
+    "cuda-bindings>=12.9.1,<13.0.0",
+    "cuda-toolkit[cudart,nvcc,nvrtc,nvjitlink,cccl]==12.*",
+    "nvidia-nvjitlink-cu12>=12.3.0,<13.0.0",
 ]
 cu13 = [
-    "cuda-cccl[cu13]",
+    "cuda-bindings==13.*",
+    "cuda-toolkit[cudart,nvcc,nvrtc,nvjitlink,cccl]==13.*",
 ]
+
+[dependency-groups]
 dev = [
     "pre-commit",
     "ruff",
 ]
+test = [
+    "pytest>=8,<9",
+    "pytest-xdist",
+    "pytest-benchmark",
+    "pytest-rerunfailures",
+    "pytest-subtests",
+    "filecheck",
+    "cffi",
+    "ml-dtypes",
+]
+test-cu12 = [{include-group = "test"}]
+test-cu13 = [{include-group = "test"}]
 
 [project.urls]
 Homepage = "https://github.com/NVIDIA/numba-cuda-mlir"
@@ -140,6 +146,18 @@ exclude = [
 "**/test*.py" = ["PERF", "B007", "B018", "B023"]
 "src/numba_cuda_mlir/__init__.py" = ["F401", "F403", "F405", "E402"]
 "src/cuda/**/__init__.py" = ["F401", "F403"]
+
+[tool.uv]
+conflicts = [
+    [
+        {extra = "cu12"},
+        {extra = "cu13"},
+    ],
+    [
+        {group = "test-cu12"},
+        {group = "test-cu13"},
+    ],
+]
 
 [tool.pytest.ini_options]
 testpaths = [ "tests" ]

--- a/src/numba_cuda_mlir/decorators.py
+++ b/src/numba_cuda_mlir/decorators.py
@@ -4,7 +4,6 @@ from typing import Any, Callable
 from collections.abc import Callable as CallableABC
 from numba_cuda_mlir import typing
 from io import StringIO
-from tabulate import tabulate
 from numba_cuda_mlir.numba_cuda.core import sigutils
 from numba_cuda_mlir.numba_cuda import types as numba_types
 from numba_cuda_mlir.numba_cuda.core.typeinfer import register_dispatcher
@@ -404,11 +403,17 @@ def _target_options_help(why: str | None = None):
 
     """
     )
-    formatted_options = filter(None, map(_format_option, _get_schema()))
-    return prelude + tabulate(
-        headers=["Name", "Types", "Default Value", "Help"],
-        tabular_data=formatted_options,
+    formatted_options = list(filter(None, map(_format_option, _get_schema())))
+    headers = ["Name", "Types", "Default Value", "Help"]
+    all_rows = [headers] + list(formatted_options)
+    col_widths = [max(len(str(row[i])) for row in all_rows) for i in range(len(headers))]
+    header_line = "  ".join(h.ljust(w) for h, w in zip(headers, col_widths))
+    separator = "  ".join("-" * w for w in col_widths)
+    lines = [header_line, separator]
+    lines.extend(
+        "  ".join(str(v).ljust(w) for v, w in zip(row, col_widths)) for row in formatted_options
     )
+    return prelude + "\n".join(lines)
 
 
 def _extract_signature_from_annotations(func):

--- a/src/numba_cuda_mlir/mlir/ast/util.py
+++ b/src/numba_cuda_mlir/mlir/ast/util.py
@@ -7,7 +7,7 @@ import io
 import types
 from typing import Dict
 
-from cloudpickle import cloudpickle
+from numba_cuda_mlir.numba_cuda.cloudpickle import cloudpickle
 
 from numba_cuda_mlir._mlir.ir import Type
 


### PR DESCRIPTION
## Summary

Audit and clean up build-time, run-time, and optional dependencies to match the patterns used in numba-cuda and cuda-python (cuda-core). Also fix CI workflows to consume test dependencies via PEP 735 dependency groups.

### Build-system requires
- Remove `pip` (the installer itself, not a build dependency)
- Remove `pybind11` and `nanobind` (only needed for building LLVM/MLIR, not the Python package)
- Remove `numpy` (no NumPy C API headers are used in `cext/`)

### Runtime dependencies
- Remove test-only packages from `dependencies`: `pytest`, `pytest-xdist`, `pytest-rerunfailures`, `pytest-benchmark`, `filecheck`
- Remove `tabulate` — replaced with an inline table formatter in `decorators.py`
- Remove `cloudpickle` — switched `mlir/ast/util.py` to use the vendored copy at `numba_cuda_mlir.numba_cuda.cloudpickle`
- Remove `cffi` and `ml-dtypes` from runtime deps (both are optional, guarded by `try/except ImportError`; moved to test dependency group)
- Keep `typeguard` — used extensively in `lowering_utilities/`, `mlir_lowering.py`, and other compiler internals
- Add `cuda-bindings>=12.9.1,<14.0.0` and `cuda-core>=0.5.1,<1.0.0` — used in 13+ and 125+ source files respectively but were missing from runtime deps

### cu12/cu13 optional extras
- Expand from just `cuda-cccl[cuXX]` to the full set following numba-cuda's pattern:
  - `cuda-bindings` (pinned to CUDA major)
  - `cuda-toolkit[cudart,nvcc,nvrtc,nvjitlink,cccl]`
  - For cu12 only: explicit `nvidia-nvjitlink-cu12>=12.3.0` (needs >=12.3 lower bound)

### Dependency groups (new)
- Add `[dependency-groups]` section with `dev`, `test`, `test-cu12`, `test-cu13` — following the numba-cuda and cuda-core pattern
- Move `dev` from `[project.optional-dependencies]` to `[dependency-groups]`
- Add `pytest-subtests` to test group (required by `test_numpy.py`)

### CI workflows
- Add `if: github.repository_owner == 'NVIDIA'` to `codeql.yml` and `bandit.yml` so they don't run on fork PRs
- Remove test-venv creation from `test-wheel-linux.yml` — the venv's `ensurepip` installs pip 25.0.1 which predates `--group` support (pip 25.1+); aligns with cuda-python and numba-cuda which don't create a test venv
- Update `ci/tools/run-tests` and `ci/tools/run-expensive-tests` to install test dependencies via `pip install --group "test-cu${TEST_CUDA_MAJOR}"`

### Other
- Update `[project.urls]` from GitLab to GitHub
- Add `[tool.uv] conflicts` for cu12/cu13 extras and test groups