### PR TITLE
Fix sporadic  bitcode signature nvJitLink error in LTO path

### DIFF
--- a/src/numba_cuda_mlir/linker.py
+++ b/src/numba_cuda_mlir/linker.py
@@ -49,13 +49,13 @@ class Linker(_Linker):
         self._numba_cuda_mlir_temp_ptx_files: list[str] = []
         self._ltoirs: dict[int, bytes] = {}
 
-    def recreate_with_lto(self) -> Self:
-        """Recreate the linker with LTO enabled, copying over existing object codes."""
+    def recreate_with_lto(self, lto: bool = True) -> Self:
+        """Recreate the linker, re-adding all object codes from raw bytes."""
         existing = list(getattr(self, "_object_codes", []))
         new_linker = Linker(
             cc=self.cc,
             additional_flags=self.additional_flags,
-            lto=True,
+            lto=lto,
             arch=self.arch,
             verbose=self._verbose,
             ftz=self._ftz,

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import copy
 import ctypes
 import os
 from io import StringIO
@@ -471,7 +470,7 @@ def optimize(cres):
         if target_options.get("dump_ptx", False):
             print(f"=============== PTX ===============\n\n{cres.metadata['ptx']}\n\n")
 
-        linker = copy.deepcopy(cres.metadata["linker"])
+        linker = cres.metadata["linker"].recreate_with_lto()
 
         if is_lto:
             if use_llvm70:


### PR DESCRIPTION
This MR replaces `copy.deepcopy` of the `Linker` in `optimize()` with `recreate_with_lto()`, which rebuilds the linker from raw bytes instead of deep-copying `cuda.core.ObjectCode` Cython wrappers. `copy.deepcopy` on `ObjectCode` does not reliably duplicate the underlying native memory buffers. When the original objects are garbage-collected before the copied linker calls `link("cubin")`, nvJitLink reads invalid memory, producing a sporadic `ERROR_NVVM_COMPILE` / "Invalid bitcode signature" failure seen in #11.

### Changes
- `linker.py`: Add `lto` parameter to `recreate_with_lto()`
- `mlir_optimization.py`: Replace `copy.deepcopy(cres.metadata["linker"])` with `cres.metadata["linker"].recreate_with_lto()`; remove unused `import copy`

Closes #11.