### PR TITLE
Fix recreate_with_lto to use cuda.core.ObjectCode public API

### DIFF
--- a/src/numba_cuda_mlir/linker.py
+++ b/src/numba_cuda_mlir/linker.py
@@ -70,13 +70,13 @@ class Linker(_Linker):
             max_registers=self.max_registers,
         )
         for obj in existing:
-            code_type = getattr(obj, "_code_type", None)
+            code_type = getattr(obj, "code_type", None)
             if code_type == "ptx":
-                new_linker.add_ptx(obj._module)
+                new_linker.add_ptx(obj.code)
             elif code_type == "cubin":
-                new_linker.add_cubin(obj._module)
+                new_linker.add_cubin(obj.code)
             elif code_type == "ltoir":
-                new_linker.add_ltoir(obj._module)
+                new_linker.add_ltoir(obj.code)
             else:
                 new_linker._object_codes.append(obj)
         new_linker._ltoirs = dict(self._ltoirs)


### PR DESCRIPTION
## Fix `recreate_with_lto` to use `cuda.core.ObjectCode` public API
`recreate_with_lto()` used private attributes (`_code_type`, `_module`) to
identify and re-add object codes. These were removed in `cuda-core 0.7.0`
in favor of the public API (`code_type`, `code`). Since the private names
no longer exist, every object falls through to the `else` branch and is
appended raw without updating `_has_ltoir`, causing
`ERROR_LTO_NOT_ENABLED (18)` when the final nvjitlink session receives
LTOIR inputs but was created without `-lto`.