### PR TITLE
Fix ExternFunction capture in overloads and linker cuda.core compat

### DIFF
--- a/src/numba_cuda_mlir/compiler.py
+++ b/src/numba_cuda_mlir/compiler.py
@@ -11,6 +11,8 @@ from numba_cuda_mlir.numba_cuda.typing.templates import (
     AttributeTemplate,
     Registry,
 )
+from numba_cuda_mlir.numba_cuda.typing.typeof import typeof_impl
+from numba_cuda_mlir.numba_cuda.core.imputils import lower_builtin
 from pathlib import Path
 from numba_cuda_mlir.mlir_optimization import optimize
 from numba_cuda_mlir.numba_cuda.codegen import ExternalCodeLibrary
@@ -476,6 +478,26 @@ class ExternFunction:
         self.use_cooperative = use_cooperative
         self.link = link
         self.abi = abi
+
+
+@typeof_impl.register(ExternFunction)
+def typeof_extern_function(val, c):
+    class device_function_template(ConcreteTemplate):
+        key = val
+        cases = [val.sig]
+
+        def get_impl_key(self, sig):
+            return ExternFunction
+
+    return types.Function(device_function_template)
+
+
+@lower_builtin(ExternFunction, types.VarArg(types.Any))
+def extern_function_dummy_lowering(context, builder, sig, args):
+    return context.get_dummy_value()
+
+
+extern_function_dummy_lowering.__module__ = "numba_cuda_mlir.numba_cuda.compiler"
 
 
 def declare_device_function(name, restype, argtypes, link, use_cooperative, abi="numba"):

--- a/src/numba_cuda_mlir/extending/__init__.py
+++ b/src/numba_cuda_mlir/extending/__init__.py
@@ -6,6 +6,7 @@ from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir.numba_cuda.typing.templates import (
     Registry,
     _OverloadAttributeTemplate,
+    _OverloadFunctionTemplate,
     _OverloadMethodTemplate,
     make_overload_template,
     make_overload_attribute_template,
@@ -32,6 +33,26 @@ __all__ = [
 _overload_default_jit_options = {"no_cpython_wrapper": True, "nopython": True}
 
 
+class _NumbaCudaMlirOverloadFunctionTemplate(_OverloadFunctionTemplate):
+    def _get_jit_decorator(self):
+        from numba_cuda_mlir import cuda
+        from numba_cuda_mlir.mlir_compiler import _get_compiler_class
+
+        def jit_with_mlir_pipeline(**jit_options):
+            jit_decorator = cuda.jit(**jit_options)
+
+            def decorate(pyfunc):
+                disp = jit_decorator(pyfunc)
+                fcomp = getattr(disp, "_compiler", None)
+                if fcomp is not None and getattr(fcomp, "pipeline_class", None) is None:
+                    fcomp.pipeline_class = _get_compiler_class(disp.targetoptions)
+                return disp
+
+            return decorate
+
+        return jit_with_mlir_pipeline
+
+
 def overload(
     func,
     jit_options=MappingProxyType({}),
@@ -46,7 +67,14 @@ def overload(
 
     def decorate(overload_func):
         template = make_overload_template(
-            func, overload_func, opts, strict, inline, prefer_literal, **kwargs
+            func,
+            overload_func,
+            opts,
+            strict,
+            inline,
+            prefer_literal,
+            base=_NumbaCudaMlirOverloadFunctionTemplate,
+            **kwargs,
         )
         typing_registry.register(template)
         if callable(func):

--- a/src/numba_cuda_mlir/numba_cuda/typing/templates.py
+++ b/src/numba_cuda_mlir/numba_cuda/typing/templates.py
@@ -892,6 +892,7 @@ def make_overload_template(
     strict,
     inline,
     prefer_literal=False,
+    base=_OverloadFunctionTemplate,
     **kwargs,
 ):
     """
@@ -900,7 +901,6 @@ def make_overload_template(
     """
     func_name = getattr(func, "__name__", str(func))
     name = "OverloadTemplate_%s" % (func_name,)
-    base = _OverloadFunctionTemplate
     dct = dict(
         key=func,
         _overload_func=staticmethod(overload_func),

--- a/tests/test_numba_cuda_mlir_extending.py
+++ b/tests/test_numba_cuda_mlir_extending.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from numba_cuda_mlir import cuda, extending, types, testing
+from numba_cuda_mlir.models import PrimitiveModel, register_model
+from numba_cuda_mlir.numba_cuda.extending import overload as numba_cuda_overload
+from numba_cuda_mlir.numba_cuda.extending import typeof_impl
+from numba_cuda_mlir.numba_cuda.typing.typeof import typeof
 import numpy as np
+import pytest
 
 
 def test_extending_intrinsic():
@@ -104,6 +109,85 @@ def test_extending_overload_method():
     out = np.zeros(1, dtype=np.float64)
     kernel[1, 1](arr, out)
     assert out[0] == 42.0
+
+
+def test_extern_function_typeof():
+    from numba_cuda_mlir.descriptor import mlir_target
+
+    sig = types.void(types.int64)
+    device_func = cuda.declare_device("my_device_func", sig)
+
+    function_type = typeof(device_func)
+
+    assert isinstance(function_type, types.Function)
+    assert function_type.get_call_type(mlir_target.typing_context, sig.args, {}) == sig
+
+
+def test_numba_cuda_overload_captures_extern_function():
+    sig = types.void(types.int64)
+    device_func = cuda.declare_device("my_device_func", sig)
+
+    def my_func(val):
+        pass
+
+    @numba_cuda_overload(my_func)
+    def ol_my_func(val):
+        def impl(val):
+            device_func(val)
+
+        return impl
+
+    @cuda.jit
+    def kernel(val):
+        my_func(val)
+
+    with pytest.raises(Exception, match="Undefined reference to 'my_device_func'"):
+        kernel[1, 1](1)
+
+
+def test_overload_method_custom_type_uses_mlir_model_only():
+    class MyObj:
+        pass
+
+    class MyObjType(types.Type):
+        def __init__(self, obj):
+            self.obj = obj
+            super().__init__(name="MyObjType")
+
+    @typeof_impl.register(MyObj)
+    def typeof_myobj(val, c):
+        return MyObjType(val)
+
+    from numba_cuda_mlir.lowering_utilities import constant, unverified_convert
+
+    @unverified_convert.register(MyObj)
+    def convert_myobj(_val, target_type, **_kwargs):
+        return constant(0, target_type)
+
+    @register_model(MyObjType)
+    class MyObjMlirModel(PrimitiveModel):
+        def __init__(self, dmm, fe_type):
+            from numba_cuda_mlir._mlir.extras import types as T
+
+            super().__init__(dmm, fe_type, T.i8())
+
+    @extending.overload_method(MyObjType, "execute")
+    def ol_execute(obj, val):
+        def impl(obj, val):
+            pass
+
+        return impl
+
+    obj = MyObj()
+
+    @cuda.jit
+    def kernel(out, val):
+        obj.execute(val)
+        out[0] = val
+
+    out = np.zeros(1, dtype=np.int64)
+    kernel[1, 1](out, 7)
+    assert out[0] == 7
 
 
 def test_register_jitable():


### PR DESCRIPTION
1.) Register `typeof_impl` for `ExternFunction` so that captured extern function
references (from `cuda.declare_device`) can be typed during closure
analysis. Add a dummy `lower_builtin` for `ExternFunction` calls so numba's
legacy LLVM trial-compilation in `_build_impl` can lower overload
implementations that call extern functions without hitting a
`NotImplementedError`. Together these let `ExternFunction` work as a captured
value inside `@overload` and `@overload_method` implementations. (Fixes #117)

2.) Override `_get_jit_decorator` in a new `_NumbaCudaMlirOverloadFunctionTemplate`
subclass so that the dispatcher created during overload probing uses the
MLIR compilation pipeline. Without this, `get_call_type` triggers
`CUDADispatcher.compile_device` through the default numba-cuda pipeline,
which looks up argument data models in the legacy LLVM data model manager
and crashes with a `KeyError` for types that are only registered with
`numba_cuda_mlir`'s MLIR model registry. The `make_overload_template` helper
gains a `base=` parameter to support this injection. (Fixes #118)

These are bundled since 2.) also partially fixes the bug causing 1.)