### PR TITLE
Add discriminated-union debug info for polymorphic scalar variables

### DIFF
--- a/src/numba_cuda_mlir/mlir_debuginfo.py
+++ b/src/numba_cuda_mlir/mlir_debuginfo.py
@@ -77,7 +77,16 @@ def _complex_di_type(name, float_bits):
     )
 
 
-def _derived_di_type(tag, *, name=None, base_type=None, size_bits=None, offset_bits=None):
+def _derived_di_type(
+    tag,
+    *,
+    name=None,
+    base_type=None,
+    size_bits=None,
+    offset_bits=None,
+    flags=None,
+    extra_data=None,
+):
     params = [f"tag = {tag}"]
     if name is not None:
         params.append(f'name = "{name}"')
@@ -87,10 +96,23 @@ def _derived_di_type(tag, *, name=None, base_type=None, size_bits=None, offset_b
         params.append(f"sizeInBits = {size_bits}")
     if offset_bits is not None:
         params.append(f"offsetInBits = {offset_bits}")
+    if flags is not None:
+        params.append(f"flags = {flags}")
+    if extra_data is not None:
+        params.append(f"extraData = {extra_data} : i8")
     return f"#llvm.di_derived_type<{', '.join(params)}>"
 
 
-def _composite_di_type(tag, *, name=None, base_type=None, size_bits=None, elements=None):
+def _composite_di_type(
+    tag,
+    *,
+    name=None,
+    base_type=None,
+    size_bits=None,
+    elements=None,
+    identifier=None,
+    discriminator=None,
+):
     params = [f"tag = {tag}"]
     if name is not None:
         params.append(f'name = "{name}"')
@@ -98,6 +120,10 @@ def _composite_di_type(tag, *, name=None, base_type=None, size_bits=None, elemen
         params.append(f"baseType = {base_type}")
     if size_bits is not None:
         params.append(f"sizeInBits = {size_bits}")
+    if identifier is not None:
+        params.append(f'identifier = "{identifier}"')
+    if discriminator is not None:
+        params.append(f"discriminator = {discriminator}")
     if elements:
         params.append(f"elements = {', '.join(elements)}")
     return f"#llvm.di_composite_type<{', '.join(params)}>"
@@ -108,13 +134,12 @@ def _subrange_di_type(count):
 
 
 def _llvm_type_str(numba_type):
+    numba_type = _strip_literal_type(numba_type)
     match numba_type:
-        case types.Boolean() | types.BooleanLiteral():
+        case types.Boolean():
             return "i8"
         case types.Integer(bitwidth=bw):
             return f"i{bw}"
-        case types.IntegerLiteral():
-            return "i64"
         case types.Float(bitwidth=16):
             return "half"
         case types.Float(bitwidth=32):
@@ -142,13 +167,12 @@ def _align_to_bits(offset_bits, alignment_bits):
 
 
 def _type_alignment_bits(numba_type):
+    numba_type = _strip_literal_type(numba_type)
     match numba_type:
-        case types.Boolean() | types.BooleanLiteral():
+        case types.Boolean():
             return _BYTE_SIZE_BITS
         case types.Integer(bitwidth=bw) | types.Float(bitwidth=bw):
             return bw
-        case types.IntegerLiteral():
-            return _INT_LITERAL_BITS
         case types.UniTuple(dtype=dtype):
             return _type_alignment_bits(dtype)
         case types.BaseTuple():
@@ -177,13 +201,12 @@ def _llvm_struct_layout_bits(field_types):
 
 
 def _type_size_bits(numba_type):
+    numba_type = _strip_literal_type(numba_type)
     match numba_type:
-        case types.Boolean() | types.BooleanLiteral():
+        case types.Boolean():
             return _BYTE_SIZE_BITS
         case types.Integer(bitwidth=bw) | types.Float(bitwidth=bw):
             return bw
-        case types.IntegerLiteral():
-            return _INT_LITERAL_BITS
         case types.UniTuple(dtype=dtype, count=count):
             elem_bits = _type_size_bits(dtype)
             return None if elem_bits is None else elem_bits * count
@@ -194,6 +217,10 @@ def _type_size_bits(numba_type):
             return numba_type.size * _BYTE_SIZE_BITS
         case _:
             return None
+
+
+def _strip_literal_type(numba_type):
+    return getattr(numba_type, "literal_type", numba_type)
 
 
 def _uni_tuple_di_type(numba_type):
@@ -327,10 +354,59 @@ def _array_di_type(numba_type):
     )
 
 
+def _union_di_type(numba_type):
+    variants = numba_type.types
+    variant_sizes = [_type_size_bits(t) for t in variants]
+    if not variant_sizes or any(bits is None for bits in variant_sizes):
+        return None
+    size_bits = max(variant_sizes)
+
+    variant_members = []
+    for tag, (variant_type, variant_bits) in enumerate(zip(variants, variant_sizes, strict=True)):
+        variant_di = _numba_type_to_di_type_str(variant_type)
+        if variant_di is None or variant_bits is None:
+            return None
+        variant_members.append(
+            _derived_di_type(
+                "DW_TAG_member",
+                name=f"_{variant_type}",
+                base_type=variant_di,
+                size_bits=variant_bits,
+                offset_bits=variant_bits,
+                extra_data=tag,
+            )
+        )
+
+    variant_key = ".".join(str(t) for t in variants)
+    discriminator = _derived_di_type(
+        "DW_TAG_member",
+        name=f"discriminator-{variant_key}",
+        base_type=_basic_di_type("uint8", _BYTE_SIZE_BITS, "unsigned"),
+        size_bits=_BYTE_SIZE_BITS,
+        flags="Artificial",
+    )
+    variant_part = _composite_di_type(
+        "DW_TAG_variant_part",
+        name="variant_part",
+        size_bits=size_bits,
+        elements=variant_members,
+        identifier=f"variant-{variant_key}",
+        discriminator=discriminator,
+    )
+    return _composite_di_type(
+        "DW_TAG_structure_type",
+        name="variant_wrapper_struct",
+        size_bits=2 * size_bits,
+        elements=[discriminator, variant_part],
+        identifier=f"variant-wrapper-{variant_key}",
+    )
+
+
 def _numba_type_to_di_type_str(numba_type):
     """Map a Numba type to an MLIR #llvm.di_basic_type string."""
+    numba_type = _strip_literal_type(numba_type)
     match numba_type:
-        case types.Boolean() | types.BooleanLiteral():
+        case types.Boolean():
             return _basic_di_type("bool", _BYTE_SIZE_BITS, "boolean")
         case types.Float(bitwidth=bw):
             return _basic_di_type(f"float{bw}", bw, "float")
@@ -338,8 +414,6 @@ def _numba_type_to_di_type_str(numba_type):
             return _basic_di_type(f"int{bw}", bw, "signed")
         case types.Integer(signed=False, bitwidth=bw):
             return _basic_di_type(f"uint{bw}", bw, "unsigned")
-        case types.IntegerLiteral():
-            return _basic_di_type("int64", _INT_LITERAL_BITS, "signed")
         case types.CPointer():
             return _cpointer_di_type(numba_type)
         case types.EnumMember():
@@ -360,6 +434,8 @@ def _numba_type_to_di_type_str(numba_type):
             return _record_di_type(numba_type)
         case types.Array():
             return _array_di_type(numba_type)
+        case types.UnionType():
+            return _union_di_type(numba_type)
         case Bfloat16():
             return _basic_di_type("__nv_bfloat16", _BFLOAT16_BITS, "float")
         case GridGroup():

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -96,6 +96,8 @@ KERNEL_ERROR_CODES = {
     RuntimeError: 4,
     ZeroDivisionError: 5,
 }
+# MLIR LLVM dialect dynamic GEP sentinel, LLVM::GEPOp::kDynamicIndex / INT32_MIN.
+_GEP_DYNAMIC_INDEX = -2147483648
 
 
 def _is_omitted_arg(argty):
@@ -207,6 +209,7 @@ class MLIRLower(object):
         )
         self._di_subprogram = None
         self._di_builder = None
+        self._poly_dbg_types = self._collect_poly_dbg_types() if self._debug_full else {}
         if self._debug_full or self._line_only:
             ctx = numba_cuda_mlir_context.get_context()
             opt_level = int(self.targetoptions.get("opt_level", 3))
@@ -244,6 +247,7 @@ class MLIRLower(object):
         self._total_shared_memory_bytes: ir.Value | None = None
         self._deferred_dbg_declare_vars: set[str] = set()
         self._debug_forced_alloca: set[str] = set()
+        self._poly_dbg_alloca: dict[str, ir.Value] = {}
 
         self.nrt = MLIRNRTContext(context.data_model_manager)
 
@@ -257,6 +261,45 @@ class MLIRLower(object):
             **self._linker_config,
             optimize_unused_variables=True,
         )
+
+    def _collect_poly_dbg_types(self):
+        """Scan function body to collect polymorphic debug types."""
+        poly_map = {}
+        for block in self.blocks.values():
+            for inst in block.body:
+                if not isinstance(inst, numba_ir.Assign) or inst.target.name.startswith("$"):
+                    continue
+                base_name = self._canonical_dbg_var_name(inst.target.name)
+                if base_name in poly_map:
+                    continue
+                names = inst.target.all_names
+                if len(names) <= 1:
+                    continue
+                for name in names:
+                    numba_type = self.get_numba_type(name)
+                    if isinstance(numba_type, types.NoneType):
+                        continue
+                    poly_map.setdefault(base_name, set()).add(
+                        mlir_debuginfo._strip_literal_type(numba_type)
+                    )
+
+        poly_types = {}
+        for name, type_set in poly_map.items():
+            if len(type_set) <= 1:
+                continue
+            if not all(self._is_poly_dbg_variant_type(t) for t in type_set):
+                continue
+            # UnionType is used here as a DI/tag container only;
+            # the lowered value is stored in a shared canonical slot.
+            poly_types[name] = types.UnionType(type_set)
+        return poly_types
+
+    @staticmethod
+    def _is_poly_dbg_variant_type(numba_type):
+        numba_type = mlir_debuginfo._strip_literal_type(numba_type)
+        if not isinstance(numba_type, (types.Boolean, types.Integer, types.Float)):
+            return False
+        return True
 
     def _collect_debug_variables(self):
         """Scan fndesc.args and fndesc.typemap to add debug variables to the DIBuilder."""
@@ -279,6 +322,7 @@ class MLIRLower(object):
                 continue
             seen.add(var_name)
             var_loc = self._find_var_def_line(var_name)
+            numba_type = self._poly_dbg_types.get(var_name, numba_type)
             self._di_builder.add_local_variable(var_name, var_loc, numba_type)
 
     def _find_var_def_line(self, var_name):
@@ -695,6 +739,37 @@ extern "C" __global__ void
                         memref=memref_type, dynamic_sizes=[], symbol_operands=[]
                     )
                     self._tag_alloca_for_deferred_dbg_declare(var_name, self.varmap[var_name])
+        if self._debug_full and self._di_builder is not None and self._di_builder.valid:
+            self._allocate_poly_dbg_slots()
+
+    def _poly_dbg_data_bits(self, union_type):
+        variant_sizes = [mlir_debuginfo._type_size_bits(t) for t in union_type.types]
+        if not variant_sizes or any(size is None for size in variant_sizes):
+            return None
+        return max(variant_sizes)
+
+    def _poly_dbg_storage_type(self, union_type):
+        data_bits = self._poly_dbg_data_bits(union_type)
+        if data_bits is None:
+            return None
+        data_type = ir.IntegerType.get_signless(data_bits)
+        # Element 0 holds the i8 discriminator; element 1 holds the active payload.
+        return ir.Type.parse(f"!llvm.array<2 x {data_type}>")
+
+    def _allocate_poly_dbg_slots(self):
+        """Allocate canonical storage for polymorphic variables."""
+        for base_name, union_type in self._poly_dbg_types.items():
+            var_attr = self._di_builder.di_local_vars.get(base_name)
+            storage_type = self._poly_dbg_storage_type(union_type)
+            if var_attr is None or storage_type is None:
+                continue
+            alloca_ptr = self.alloca(storage_type, count=1)
+            self._poly_dbg_alloca[base_name] = alloca_ptr
+            llvm.intr_dbg_declare(
+                alloca_ptr,
+                var_attr,
+                location_expr=self._di_builder.di_expression,
+            )
 
     @staticmethod
     def _canonical_dbg_var_name(var_name: str) -> str:
@@ -2794,6 +2869,8 @@ extern "C" __global__ void
             return
         # Numba SSA renames: foo.1, foo.2, etc. Map back to the user name.
         base_name = self._canonical_dbg_var_name(var_name)
+        if base_name in self._poly_dbg_types:
+            return
         var_attr = self._di_builder.di_local_vars.get(base_name)
         if var_attr is None:
             return
@@ -2879,6 +2956,9 @@ extern "C" __global__ void
 
         assert self.var_lowered(var), f"Var {var.name} not found in varmap."
 
+        if self._is_poly_debug_var(var.name):
+            return self._load_poly_debug_var(var.name)
+
         if var.name in self.var_assign_count and self.var_assign_count[var.name] > 1:
             # if variable is stack allocated (multiple assigned),
             # load the variable from stack
@@ -2904,11 +2984,61 @@ extern "C" __global__ void
             # load the value from varmap
             return self.varmap[var.name]
 
+    def _is_poly_debug_var(self, var_name):
+        base_name = self._canonical_dbg_var_name(var_name)
+        return base_name in self._poly_dbg_alloca
+
+    def _poly_dbg_byte_ptr(self, slot, offset_bytes):
+        """Return a byte pointer at a dynamic offset within a polymorphic slot."""
+        return llvm.getelementptr(
+            llvm.PointerType.get(),
+            slot,
+            [i64_of(offset_bytes)],
+            [_GEP_DYNAMIC_INDEX],
+            T.i8(),
+            None,
+        )
+
+    def _poly_dbg_payload_offset_bytes(self, numba_type):
+        size_bits = mlir_debuginfo._type_size_bits(numba_type)
+        return size_bits // mlir_debuginfo._BYTE_SIZE_BITS
+
+    def _load_poly_debug_var(self, var_name):
+        base_name = self._canonical_dbg_var_name(var_name)
+        slot = self._poly_dbg_alloca[base_name]
+        numba_type = self._get_numba_type_for_dbg_var(var_name)
+        offset_bytes = self._poly_dbg_payload_offset_bytes(numba_type)
+        return llvm.load(
+            res=self.get_mlir_type(numba_type),
+            addr=self._poly_dbg_byte_ptr(slot, offset_bytes),
+        )
+
+    def _store_poly_dbg_var(self, var_name, value):
+        base_name = self._canonical_dbg_var_name(var_name)
+        union_type = self._poly_dbg_types[base_name]
+        slot = self._poly_dbg_alloca[base_name]
+        numba_type = mlir_debuginfo._strip_literal_type(self._get_numba_type_for_dbg_var(var_name))
+        tag = union_type.get_type_tag(numba_type)
+        offset_bytes = self._poly_dbg_payload_offset_bytes(numba_type)
+        mlir_value = self._unwrap_mlir_value(value)
+        target_type = self.get_mlir_type(numba_type)
+        if mlir_value.type != target_type:
+            mlir_value = self.mlir_convert(mlir_value, target_type)
+        # Store the active variant tag first, then the variant's value at its
+        # size-based payload offset in the shared canonical slot.
+        llvm.store(value=arith.constant(T.i8(), tag), addr=self._poly_dbg_byte_ptr(slot, 0))
+        llvm.store(value=mlir_value, addr=self._poly_dbg_byte_ptr(slot, offset_bytes))
+
     def store_var(self, var, value):
         """
         Store the value (MLIR Op) into the given variable.
         """
         trace("var=%s value=%s", var, value)
+        if self._debug_full:
+            base_name = self._canonical_dbg_var_name(var.name)
+            if self._poly_dbg_alloca.get(base_name) is not None:
+                self._store_poly_dbg_var(var.name, value)
+                return
         if var.name in self.var_assign_count and self.var_assign_count[var.name] > 1:
             # if variable is stack allocated (multiple assigned),
             # store the value to stack
@@ -3020,7 +3150,8 @@ extern "C" __global__ void
                     raise TypeError(f"Cannot convert type {str(ty)} to MLIR type.") from e
 
     def var_lowered(self, var):
-        return var.name in self.varmap
+        # Polymorphic var is considered lowered if a canonical shared slot is allocated.
+        return var.name in self.varmap or self._is_poly_debug_var(var.name)
 
     def _count_flat_elements(self, numba_type) -> int:
         """Count how many flat MLIR arguments a type expands to."""

--- a/tests/test_debuginfo.py
+++ b/tests/test_debuginfo.py
@@ -754,3 +754,35 @@ def test_mlir_poly_scalar_var():
         """,
         mlir,
     )
+
+
+def test_mlir_poly_scalar_var_runtime_debug():
+    """Polymorphic scalar locals preserve runtime values under debug=True."""
+
+    def k_poly_scalar_var_runtime(out, use_float, use_uint, use_bool):
+        x = 1
+        if use_float:
+            x = 2.5
+        elif use_uint:
+            x = np.uint32(3)
+        elif use_bool:
+            x = True
+        else:
+            x = x + 10
+        out[0] = x
+
+    kernel = cuda.jit(
+        types.void(types.float64[:], types.boolean, types.boolean, types.boolean),
+        debug=True,
+        opt=False,
+    )(k_poly_scalar_var_runtime)
+
+    for flags, expected in [
+        ((False, False, False), 11.0),
+        ((True, False, False), 2.5),
+        ((False, True, False), 3.0),
+        ((False, False, True), 1.0),
+    ]:
+        out = cuda.device_array(1, dtype=np.float64)
+        kernel[1, 1](out, *flags)
+        assert out.copy_to_host()[0] == expected

--- a/tests/test_debuginfo.py
+++ b/tests/test_debuginfo.py
@@ -704,3 +704,53 @@ def test_mlir_local_array_type():
         """,
         mlir,
     )
+
+
+def test_mlir_poly_scalar_var():
+    """Polymorphic scalar locals use discriminated-union DI and dbg.declare."""
+
+    def k_poly_scalar_var(out, flag1, flag2):
+        x = 1
+        if flag1:
+            x = 2.5
+        elif flag2:
+            x = np.uint32(3)
+        else:
+            x = True
+        out[0] = x
+
+    mlir = compiler.compile_mlir(
+        k_poly_scalar_var,
+        types.void(types.float64[:], types.boolean, types.boolean),
+        debug=True,
+        opt=False,
+    )
+    testing.filecheck(
+        """
+        CHECK-DAG: #[[DISCRIM:di_derived_type[0-9]*]] = #llvm.di_derived_type<tag = DW_TAG_member, name = "discriminator-bool.float64.int64.uint32"
+        CHECK-SAME: flags = Artificial
+        CHECK-DAG: #[[BOOL_MEMBER:di_derived_type[0-9]*]] = #llvm.di_derived_type<tag = DW_TAG_member, name = "_bool"
+        CHECK-SAME: sizeInBits = 8
+        CHECK-SAME: extraData = 0 : i8
+        CHECK-DAG: #[[FLOAT_MEMBER:di_derived_type[0-9]*]] = #llvm.di_derived_type<tag = DW_TAG_member, name = "_float64"
+        CHECK-SAME: sizeInBits = 64
+        CHECK-SAME: extraData = 1 : i8
+        CHECK-DAG: #[[INT_MEMBER:di_derived_type[0-9]*]] = #llvm.di_derived_type<tag = DW_TAG_member, name = "_int64"
+        CHECK-SAME: sizeInBits = 64
+        CHECK-SAME: extraData = 2 : i8
+        CHECK-DAG: #[[UINT_MEMBER:di_derived_type[0-9]*]] = #llvm.di_derived_type<tag = DW_TAG_member, name = "_uint32"
+        CHECK-SAME: sizeInBits = 32
+        CHECK-SAME: extraData = 3 : i8
+        CHECK-DAG: #[[VARIANT_PART:di_composite_type[0-9]*]] = #llvm.di_composite_type<tag = DW_TAG_variant_part, name = "variant_part"
+        CHECK-SAME: discriminator = #[[DISCRIM]]
+        CHECK-SAME: elements = #[[BOOL_MEMBER]], #[[FLOAT_MEMBER]], #[[INT_MEMBER]], #[[UINT_MEMBER]]
+        CHECK-DAG: #[[WRAPPER_TYPE:di_composite_type[0-9]*]] = #llvm.di_composite_type<tag = DW_TAG_structure_type, name = "variant_wrapper_struct"
+        CHECK-SAME: elements = #[[DISCRIM]], #[[VARIANT_PART]]
+        CHECK: di_local_variable<{{.*}}name = "x"
+        CHECK-SAME: type = #[[WRAPPER_TYPE]]
+        CHECK: %[[POLY_SLOT:[0-9]+]] = llvm.alloca
+        CHECK-SAME: !llvm.array<2 x i64>
+        CHECK: llvm.intr.dbg.declare {{.*}} = %[[POLY_SLOT]] : !llvm.ptr
+        """,
+        mlir,
+    )


### PR DESCRIPTION
- Emit DWARF discriminated-union metadata for supported polymorphic scalar locals using `DW_TAG_variant_part` and per-variant `extraData` discriminator values.
- Allocate one canonical LLVM stack slot per polymorphic source variable and route debug declaration, stores, and loads through that storage.
- Adds tests: 
  - test_mlir_poly_scalar_var with validation for the emitted discriminated-union DI
  - test_mlir_poly_scalar_var_runtime_debug with validation for runtime output value when `debug=True, opt=False`, so the canonical debug slot load/store path is covered.
