### PR TITLE
Update docs to use dependency groups (PEP 735) for dev/test install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ be applied to every commit.
 They can be installed with:
 
 ```
-pip install -e '.[dev]'
+pip install --group dev  # requires pip >= 25.1
 pre-commit install
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,9 +42,14 @@ where `<options>` can include:
 
 - `cu12`: Install CUDA toolkit dependencies matching CUDA 12 versions.
 - `cu13`: Install CUDA toolkit dependencies matching CUDA 13 versions.
-- `dev`: Includes pre-commit tools and linters.
-- `test`: Includes pytest and required plugins, and other packages used in the
-  test suite.
+
+Development and test dependencies are defined as
+[dependency groups](https://peps.python.org/pep-0735/) (requires pip >= 25.1):
+
+```shell
+pip install --group dev   # pre-commit tools and linters
+pip install --group test  # pytest and required plugins
+```
 
 Or, install with conda:
 
@@ -110,7 +115,7 @@ python3 -m venv numba-cuda-mlir-env && source numba-cuda-mlir-env/bin/activate
 
 MLIR_DIR=$PWD/llvm-modern-install/lib/cmake/mlir \
 LIBLLVM7=$PWD/llvm7-install/lib/libLLVM-7.so \
-  pip install -e '.[cu13,dev]' --config-settings editable_mode=compat
+  pip install -e '.[cu13]' --group dev --config-settings editable_mode=compat
 ```
 
 ### Option 3: Build LLVM from source
@@ -130,14 +135,15 @@ ci/build-llvm7.sh          # produces llvm7-install/
 # Then install numba-cuda-mlir as in Option 2:
 MLIR_DIR=$PWD/llvm-modern-install/lib/cmake/mlir \
 LIBLLVM7=$PWD/llvm7-install/lib/libLLVM-7.so \
-  pip install -e '.[cu13,dev]' --config-settings editable_mode=compat
+  pip install -e '.[cu13]' --group dev --config-settings editable_mode=compat
 ```
 
 ## Testing
 
 The Numba-CUDA-MLIR testsuite is in the `tests` directory. Use `pytest` from
-the project's root directory to run tests. `pytest-xdist` is installed with the
-`test` dependencies, so they may be run in parallel with:
+the project's root directory to run tests. Install the `test` dependency group
+first (`pip install --group test`), which includes `pytest-xdist` for parallel
+execution:
 
 ```
 pytest -n 4


### PR DESCRIPTION
dev and test are defined as `[dependency-groups]` in pyproject.toml, not `project.optional-dependencies]`. The previous docs used the extras syntax (`'.[cu13,dev]'`) which silently ignored these groups when using pip.

This PR updates `INSTALL.md` and `CONTRIBUTING.md` to use `pip install --group dev  --group test` (PEP 735, requires pip >= 25.1)
