### PR TITLE
Add float16 vector support

### DIFF
--- a/src/numba_cuda_mlir/cuda/vector_types.py
+++ b/src/numba_cuda_mlir/cuda/vector_types.py
@@ -40,6 +40,7 @@ def make_vector_type_stubs():
         "uint16",
         "uint32",
         "uint64",
+        "float16",
         "float32",
         "float64",
     )
@@ -86,6 +87,7 @@ def map_vector_type_stubs_to_alias(vector_type_stubs):
         "uint": f"uint{np.dtype(np.uintc).itemsize * 8}",
         "ulong": f"uint{np.dtype(np.uint).itemsize * 8}",
         "ulonglong": f"uint{np.dtype(np.ulonglong).itemsize * 8}",
+        "half": "float16",
         "float": f"float{np.dtype(np.single).itemsize * 8}",
         "double": f"float{np.dtype(np.double).itemsize * 8}",
     }

--- a/src/numba_cuda_mlir/numba_cuda/stubs.py
+++ b/src/numba_cuda_mlir/numba_cuda/stubs.py
@@ -550,6 +550,7 @@ def make_vector_type_stubs():
         "uint16",
         "uint32",
         "uint64",
+        "float16",
         "float32",
         "float64",
     )
@@ -600,6 +601,7 @@ def map_vector_type_stubs_to_alias(vector_type_stubs):
         "uint": f"uint{np.dtype(np.uintc).itemsize * 8}",
         "ulong": f"uint{np.dtype(np.uint).itemsize * 8}",
         "ulonglong": f"uint{np.dtype(np.ulonglong).itemsize * 8}",
+        "half": "float16",
         "float": f"float{np.dtype(np.single).itemsize * 8}",
         "double": f"float{np.dtype(np.double).itemsize * 8}",
     }

--- a/src/numba_cuda_mlir/typing/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/typing/cuda_vector_types.py
@@ -28,6 +28,7 @@ BASE_TYPE_MAP = {
     "uint16": types.uint16,
     "uint32": types.uint32,
     "uint64": types.uint64,
+    "float16": types.float16,
     "float32": types.float32,
     "float64": types.float64,
 }

--- a/tests/test_vector_types.py
+++ b/tests/test_vector_types.py
@@ -284,6 +284,10 @@ def test_cuda_vector_closure_capture():
 @pytest.mark.parametrize(
     "vec_type,num_elements,dtype",
     [
+        (cuda.float16x1, 1, np.float16),
+        (cuda.float16x2, 2, np.float16),
+        (cuda.float16x3, 3, np.float16),
+        (cuda.float16x4, 4, np.float16),
         (cuda.float32x1, 1, np.float32),
         (cuda.float32x2, 2, np.float32),
         (cuda.float32x3, 3, np.float32),

--- a/tests/test_vector_types.py
+++ b/tests/test_vector_types.py
@@ -236,6 +236,20 @@ def test_cuda_vector_alias_float4():
     np.testing.assert_allclose(arr, [5.0, 6.0, 7.0, 8.0])
 
 
+def test_cuda_vector_alias_half2():
+    """Test C-style alias half2 -> float16x2."""
+
+    @cuda.jit
+    def kernel(arr):
+        v = cuda.half2(1.5, 2.5)
+        arr[0] = v.x
+        arr[1] = v.y
+
+    arr = np.zeros(2, dtype=np.float16)
+    kernel[1, 1](arr)
+    np.testing.assert_allclose(arr, [1.5, 2.5])
+
+
 def test_cuda_vector_alias_int2():
     """Test C-style alias int2 -> int32x2."""
 


### PR DESCRIPTION
Add float16 vector support. Minimal changes. Almost everything was already there

What I did not check - if the generated instructions are performant:
https://docs.nvidia.com/cuda/cuda-math-api/cuda_math_api/group__CUDA__MATH____HALF2__ARITHMETIC.html
However, I guess that should've been handled by mlir cuda dialect