### PR TITLE
Fix array.view dtype resolution, typing, and lowering

### DIFF
--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -958,14 +958,18 @@ def lower_array_slice_getitem(builder, target, args, kwargs):
 
 def lower_array_view_cg(builder, target, args, kwargs):
     _self, dtype = [builder.load_var(arg) for arg in args]
-    dtype = lowering_utilities.mlir_type_from_numpy_dtype(dtype)
+    dtype = lowering_utilities.to_mlir_type(dtype)
     mr_ty: ir.MemRefType = _self.type
     assert mr_ty.has_rank, "NYI: unranked memrefs"
-    tens = memref_to_tensor(_self)
-    newty = T.tensor(*tens.type.shape, dtype)
-    value = tensor.bitcast(newty, tens)
-    value = tensor_to_memref(value)
-    builder.store_var(target, value)
+
+    if mr_ty.element_type == dtype:
+        builder.store_var(target, _self)
+        return
+
+    target_numba_type = builder.get_numba_type(target.name)
+    memref_type = builder.get_mlir_type(target_numba_type)
+    result = builtin.unrealized_conversion_cast([memref_type], [_self])
+    builder.store_var(target, result)
 
 
 @lower_getattr(types.Array, "view")

--- a/src/numba_cuda_mlir/typing/numpy.py
+++ b/src/numba_cuda_mlir/typing/numpy.py
@@ -990,14 +990,7 @@ class NumpyArrayViewMethodTemplate(AbstractTemplate):
         if len(args) == 1:
             arr = self.this
             dtype = args[0]
-
-            if isinstance(dtype, types.DTypeSpec):
-                element_type = dtype.dtype
-            elif isinstance(dtype, types.NumberClass):
-                element_type = dtype.dtype
-            else:
-                element_type = dtype
-
+            element_type = dtype.dtype if isinstance(dtype, types.DTypeSpec) else dtype
             ret = types.Array(element_type, arr.ndim, arr.layout)
             return signature(ret, dtype, recvr=self.this)
         return None

--- a/src/numba_cuda_mlir/typing/numpy.py
+++ b/src/numba_cuda_mlir/typing/numpy.py
@@ -990,8 +990,16 @@ class NumpyArrayViewMethodTemplate(AbstractTemplate):
         if len(args) == 1:
             arr = self.this
             dtype = args[0]
-            # Return array with potentially different dtype
-            return signature(arr, dtype, recvr=self.this)
+
+            if isinstance(dtype, types.DTypeSpec):
+                element_type = dtype.dtype
+            elif isinstance(dtype, types.NumberClass):
+                element_type = dtype.dtype
+            else:
+                element_type = dtype
+
+            ret = types.Array(element_type, arr.ndim, arr.layout)
+            return signature(ret, dtype, recvr=self.this)
         return None
 
 

--- a/tests/test_array_methods.py
+++ b/tests/test_array_methods.py
@@ -39,6 +39,68 @@ def tests_array_view():
     assert output[0] == expect, f"output: {output} != {expect}"
 
 
+def test_array_view_same_dtype():
+    """view() with the same element type is a no-op and must not fail."""
+
+    @cuda.jit
+    def kernel(arr):
+        v = arr.view(np.int64)
+        v[0] = 42
+
+    d = cuda.to_device(np.zeros(4, dtype=np.int64))
+    kernel[1, 1](d)
+    out = d.copy_to_host()
+    assert out[0] == 42, f"expected 42, got {out[0]}"
+
+
+def test_array_view_reinterpret_dtype():
+    """view() with a different same-sized dtype reinterprets the bits."""
+
+    @cuda.jit
+    def kernel(arr, out):
+        v = arr.view(np.int32)
+        out[0] = v[0]
+
+    d = cuda.to_device(np.array([1.5], dtype=np.float32))
+    out_d = cuda.to_device(np.zeros(1, dtype=np.int32))
+    kernel[1, 1](d, out_d)
+
+    expected = np.array([1.5], dtype=np.float32).view(np.int32)[0]
+    result = out_d.copy_to_host()[0]
+    assert result == expected, f"expected {expected}, got {result}"
+
+
+def test_array_view_custom_dtype():
+    """view() dispatches through to_mlir_type for externally-registered types."""
+    from numba_cuda_mlir.lowering_utilities import to_mlir_type
+    from numba_cuda_mlir._mlir.extras import types as T
+    from numba_cuda_mlir.numba_cuda.extending import typeof_impl
+    from numba_cuda_mlir.numba_cuda import types as nb_types
+
+    class _MyBoxedDtype:
+        pass
+
+    my_dtype = _MyBoxedDtype()
+
+    @typeof_impl.register(_MyBoxedDtype)
+    def _typeof_my(val, c):
+        return nb_types.NumberClass(nb_types.int64)
+
+    @to_mlir_type.register(_MyBoxedDtype)
+    def _my_to_mlir(val):
+        return T.i64()
+
+    @cuda.jit
+    def kernel(arr):
+        v = arr.view(my_dtype)
+        v[0] = 42
+
+    d = cuda.to_device(np.zeros(4, dtype=np.int64))
+    kernel[1, 1](d)
+    out = d.copy_to_host()
+    assert out[0] == 42, f"expected 42, got {out[0]}"
+
+
 if __name__ == "__main__":
     import logging
 


### PR DESCRIPTION
### Summary
- Route `array.view()` dtype resolution through the `to_mlir_type` singledispatch instead of the bare `np_dtype_to_mlir_type` handler, making externally-registered type converters reachable
- Short-circuit same-element-type views as a no-op to avoid emitting an identity `tensor.bitcast` that downstream MLIR pass `one-shot-bufferize` cannot handle
- Fix `NumpyArrayViewMethodTemplate` to return `Array(new_dtype, ndim, layout)` instead of the receiver's type, so the view carries the correct element type through typing and into lowering
- Replace the `tensor.bitcast` lowering path with a `unrealized_conversion_cast` between memref types, which resolves cleanly through the MLIR pass pipeline that includes `one-shot-bufferize`
- Add 3 new tests:
  - `test_array_view_same_dtype` — `int64` viewed as `int64`
  - `test_array_view_reinterpret_dtype` — `float32` viewed as `int32`
  - `test_array_view_custom_dtype` — custom boxed dtype via `@to_mlir_type.register`
