### PR TITLE
MLIR Translation: Implement Barrier0Op

### DIFF
--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -153,6 +153,7 @@ private:
   llvm::Error translateClusterArriveOp(mlir::Operation *op, bool isRelaxed);
   llvm::Error translateClusterWaitOp(mlir::Operation *op);
   llvm::Error translateBarrierOp(mlir::Operation *op);
+  llvm::Error translateBarrier0Op(mlir::Operation *op);
   llvm::Error translateCttzCtlzOp(mlir::Operation *op, llvm::StringRef intrBase,
                                   mlir::Value in, mlir::Value res,
                                   bool isZeroPoison);

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -1756,6 +1756,18 @@ llvm::Error MLIRToLLVM70::translateBarrierOp(Operation *op) {
   return llvm::Error::success();
 }
 
+llvm::Error MLIRToLLVM70::translateBarrier0Op(Operation *op) {
+  // NVVM::Barrier0Op takes no operands and is equivalent to bar.sync 0.
+  // Lower it to the LLVM 7 intrinsic llvm.nvvm.barrier0() : void.
+  const char *intrName = "llvm.nvvm.barrier0";
+  LLVMTypeRef fnTy = b.funcTy(b.voidTy(), nullptr, 0, false);
+  LLVMValueRef fn = b.getNamedFunction(intrName);
+  if (!fn)
+    fn = b.addFunction(intrName, fnTy);
+  b.buildCall(fn, nullptr, 0, "");
+  return llvm::Error::success();
+}
+
 llvm::Error MLIRToLLVM70::translateCttzCtlzOp(Operation *op,
                                               llvm::StringRef intrBase,
                                               Value in, Value res,
@@ -2412,6 +2424,8 @@ llvm::Error MLIRToLLVM70::translateNVVMOp(Operation *op) {
           [&](auto) { return this->translateClusterWaitOp(op); })
       .Case<NVVM::BarrierOp>(
           [&](auto) { return this->translateBarrierOp(op); })
+      .Case<NVVM::Barrier0Op>(
+          [&](auto) { return this->translateBarrier0Op(op); })
       .Case<NVVM::Breakpoint>([&](auto) {
         LLVMTypeRef fnTy = b.funcTy(b.voidTy(), nullptr, 0, false);
         LLVMValueRef asmVal =


### PR DESCRIPTION
**EDIT:** I think maybe the git history was rewritten after I built llvm-modern, so although there was only one commit to llvm-version.env, I think the version changed out from under my existing build.

Locally I'm getting a lot of failures like:

```
FAILED tests/numba_cuda_tests/cudapy/test_atomics.py::TestCudaAtomics::test_atomic_add - RuntimeError: llvm70 translation failed: unsupported NVVM op: nvvm.barrier0
```

I see it was removed last week in https://github.com/llvm/llvm-project/pull/195608, so I'm not sure if this is because I have some misconfiguration in my setup (non-matching versions of libraries / LLVMs) or because my setup is just a little different from that in CI and I'm running into a legitimate issue, but adding an implementation of the `NVVM::Barrier0Op` seems to resolve it - making this PR for comments / discussion.

