### PR TITLE
Try to fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -132,20 +132,14 @@ jobs:
           fi
 
   build-docs:
-    uses: ./.github/workflows/docs-build.yaml
-
-  deploy-docs:
-    needs: build-docs
+    needs:
+      - build-wheels-linux-64
+    if: ${{ github.repository_owner == 'nvidia' }}
     permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      actions: read
+      contents: write
+    uses: ./.github/workflows/build-docs.yml
+    with:
+      host-platform: linux-64
+      git-tag: ${{ github.ref_name }}
+      is-release: true


### PR DESCRIPTION
The previous attempt to trigger the publish workflow has failed:
https://github.com/NVIDIA/numba-cuda-mlir/actions/runs/25764823361
because the old workflow was removed and the filename does not pass the syntax check. Try to bring the workflow up-to-date to unblock v0.3.0.