### PR TITLE
Refactor `get_type_width` to dynamically compute ABI size using MLIR LLVM dialect

### DIFF
--- a/src/numba_cuda_mlir/lowering_utilities/__init__.py
+++ b/src/numba_cuda_mlir/lowering_utilities/__init__.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from abc import abstractmethod
 import functools
 import numpy as np
+import re
 from numba_cuda_mlir.numba_cuda import types, typing
 from numba_cuda_mlir.annotations import AnyCallable, PS
 from numba_cuda_mlir.lowering_utilities import type_conversions
@@ -16,8 +17,10 @@ from numba_cuda_mlir.lowering_utilities.type_conversions import (
     np_dtype_to_mlir_type as mlir_type_from_numpy_dtype,
     to_mlir_type,
 )
+from numba_cuda_mlir.lowering_utilities.llvm_utils import NVPTX64_DATALAYOUT
 from numba_cuda_mlir.type_defs.float_types import BFloat16Type
 from numba_cuda_mlir._mlir import ir
+import numba_cuda_mlir._mlir.passmanager as pm
 from numba_cuda_mlir._mlir.dialects import (
     arith,
     memref,
@@ -141,18 +144,30 @@ def tensor_to_memref(tensor):
             raise NotImplementedError(f"Not implemented for type {tensor.type}")
 
 
+@functools.cache
 def get_type_width(ty: ir.Type) -> int:
-    match ty:
-        case ir.IntegerType():
-            return ty.width
-        case ir.IndexType():
-            return 64
-        case ir.FloatType():
-            return ty.width
-        case ir.ComplexType():
-            return ir.ComplexType(ty).element_type.width
-        case _:
-            raise NotImplementedError(f"Not implemented for type {ty}")
+    # Create a temporary module to compute the size using GEP
+    module = ir.Module.create()
+    module.operation.attributes["llvm.data_layout"] = ir.StringAttr.get(NVPTX64_DATALAYOUT)
+    with ir.InsertionPoint(module.body):
+        fnty = ir.TypeAttr.get(ir.Type.parse("!llvm.func<i64 ()>"))
+        func = llvm.LLVMFuncOp("get_size", fnty)
+        block = ir.Block.create_at_start(func.body)
+        with ir.InsertionPoint(block):
+            null_ptr = llvm.mlir_zero(ir.Type.parse("!llvm.ptr"))
+            gep = llvm.getelementptr(ir.Type.parse("!llvm.ptr"), null_ptr, [], [1], ty, None)
+            size = llvm.PtrToIntOp(ir.Type.parse("i64"), gep)
+            llvm.ReturnOp(arg=size)
+
+    pm.PassManager.parse("builtin.module(canonicalize)").run(module.operation)
+    llvm_module = llvm.translate_module_to_llvmir(module.operation)
+
+    match = re.search(r"ret i64 (\d+)", llvm_module)
+    if match:
+        width = int(match.group(1)) * 8
+        return width
+    else:
+        raise RuntimeError(f"Could not extract size from module: {llvm_module}")
 
 
 @singledispatch


### PR DESCRIPTION
## Refactor `get_type_width` to dynamically compute ABI size using MLIR LLVM dialect

### Summary
This PR refactors the `get_type_width` utility function to dynamically determine the bit width of any MLIR `ir.Type`. Previously, the function relied on a hardcoded `match` statement that explicitly checked for specific type classes (`IntegerType`, `FloatType`, `ComplexType`, etc.) and manually calculated their widths. 

This manual approach was brittle and required constant updating whenever new types (like `VectorType` or structs) were introduced. The new implementation leverages the underlying LLVM data layout for the NVPTX64 target to automatically and accurately compute the ABI size for *any* given type.

### Implementation Details
The new `get_type_width` implementation uses a standard LLVM trick to compute type sizes at compile time:
1. It creates a temporary MLIR module and assigns it the `NVPTX64_DATALAYOUT` (`e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128`).
2. It constructs a dummy `llvm.func` containing an `llvm.getelementptr` (GEP) operation. The GEP advances a null pointer by exactly `1` element of the target type.
3. It uses `llvm.ptrtoint` to cast the resulting pointer to a 64-bit integer, which effectively yields the ABI size of the type in bytes.
4. It runs the MLIR `canonicalize` pass, which evaluates the GEP and `ptrtoint` operations at compile-time and folds them into a constant integer.
5. It translates the module to an LLVM IR string, extracts the constant size via regex, multiplies by 8 to get the bit width, and caches the result using `@functools.cache` for performance.

### Alternatives Considered & Why They Didn't Work

During the exploration of this issue, several alternative approaches were attempted but ultimately discarded:

1. **Directly using MLIR's `DataLayout` API in Python**
   * *Attempt:* We tried to instantiate `mlir::DataLayout` and call `getTypeSizeInBits(ty)` directly on the MLIR type.
   * *Why it failed:* The MLIR Python bindings currently do not expose the `DataLayout` class or its sizing methods. While these exist in the C++ core, they are inaccessible from the Python frontend without writing custom C++ binding extensions.

2. **Using Numba's `ContextAwareDataModelManager` (`mlir_data_manager`)**
   * *Attempt:* We tried to look up the size by querying the registered Numba data models.
   * *Why it failed:* The `mlir_data_manager` maps Numba frontend types (`fe_type`) to `DataModel` instances. It does not support reverse lookups from MLIR backend types (`be_type` / `ir.Type`) back to the data model. Furthermore, the manager populates its cache lazily and uses `WeakKeyDictionary` for Numba types, making it impossible to reliably query it using raw MLIR `ir.Type` objects.

3. **Using `llvmlite`'s `get_abi_sizeof`**
   * *Attempt:* Numba's `BaseContext` has a `get_abi_sizeof(ty)` method that uses `llvmlite.binding.TargetData`.
   * *Why it failed:* This method expects an `llvmlite` IR type (`llvmir.Type`), not an MLIR `ir.Type`. Converting individual MLIR types to `llvmlite` types on the fly is non-trivial and bypasses the MLIR lowering pipeline.

### Testing
- Verified that all tests in `tests/numba_cuda_tests/cudapy/` (including `test_vector_type.py`, `test_complex.py`, `test_array.py`, and `test_array_methods.py`) pass successfully when executed on the GPU.