### PR TITLE
Add support for type casting between CUDA vector types and complex numbers

### DIFF
--- a/src/numba_cuda_mlir/lowering/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/lowering/cuda_vector_types.py
@@ -77,6 +77,11 @@ def _constructor_lowering(lower_ctx: MLIRLower, target, args: list[Any], kwargs)
 
         if isinstance(arg_type, VectorType):
             scalars.extend(_extract_vector_elements(val))
+        elif isinstance(arg_type, types.Complex):
+            from numba_cuda_mlir._mlir.dialects import complex as complex_dialect
+
+            scalars.append(complex_dialect.re(val))
+            scalars.append(complex_dialect.im(val))
         else:
             scalars.append(val)
 
@@ -111,3 +116,27 @@ lower_getattr(VectorType, "x")(_make_attr_lowering("x"))
 lower_getattr(VectorType, "y")(_make_attr_lowering("y"))
 lower_getattr(VectorType, "z")(_make_attr_lowering("z"))
 lower_getattr(VectorType, "w")(_make_attr_lowering("w"))
+
+
+@_raw_lower(complex, VectorType)
+def _complex_from_vector_lowering(lower_ctx: MLIRLower, target, args: list[Any], kwargs):
+    """Lowering for complex(vector_type)."""
+    target_type = lower_ctx.get_numba_type(target.name)
+    mlir_target_type = lower_ctx.get_mlir_type(target_type)
+
+    val = lower_ctx.load_var(args[0])
+
+    real = vector.extract(val, [], [0])
+    imag = vector.extract(val, [], [1])
+
+    real = convert(real, mlir_target_type.element_type)
+    imag = convert(imag, mlir_target_type.element_type)
+
+    from numba_cuda_mlir._mlir.dialects import complex as complex_dialect
+
+    result = complex_dialect.create_(
+        complex=mlir_target_type,
+        real=real,
+        imaginary=imag,
+    )
+    lower_ctx.store_var(target, result)

--- a/src/numba_cuda_mlir/lowering/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/lowering/cuda_vector_types.py
@@ -19,6 +19,7 @@ from numba_cuda_mlir.cuda.vector_types import _vector_types
 from numba_cuda_mlir.type_defs.vector_types import VectorType
 from numba_cuda_mlir import types
 from numba_cuda_mlir._mlir.dialects import vector
+from numba_cuda_mlir._mlir.dialects import complex as complex_dialect
 from numba_cuda_mlir._mlir import ir
 
 ATTR_INDEX = {"x": 0, "y": 1, "z": 2, "w": 3}
@@ -78,8 +79,6 @@ def _constructor_lowering(lower_ctx: MLIRLower, target, args: list[Any], kwargs)
         if isinstance(arg_type, VectorType):
             scalars.extend(_extract_vector_elements(val))
         elif isinstance(arg_type, types.Complex):
-            from numba_cuda_mlir._mlir.dialects import complex as complex_dialect
-
             scalars.append(complex_dialect.re(val))
             scalars.append(complex_dialect.im(val))
         else:
@@ -131,8 +130,6 @@ def _complex_from_vector_lowering(lower_ctx: MLIRLower, target, args: list[Any],
 
     real = convert(real, mlir_target_type.element_type)
     imag = convert(imag, mlir_target_type.element_type)
-
-    from numba_cuda_mlir._mlir.dialects import complex as complex_dialect
 
     result = complex_dialect.create_(
         complex=mlir_target_type,

--- a/src/numba_cuda_mlir/typing/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/typing/cuda_vector_types.py
@@ -162,7 +162,10 @@ def typeof_vector_type(val, c):
 class ComplexBuiltinTemplate(AbstractTemplate):
     def generic(self, args, kws):
         if len(args) == 1 and isinstance(args[0], VectorType) and args[0].length == 2:
-            if args[0].dtype == types.float32:
+            dtype = args[0].dtype
+            if (isinstance(dtype, types.Float) and dtype.bitwidth <= 32) or (
+                isinstance(dtype, types.Integer) and dtype.bitwidth <= 16
+            ):
                 return signature(types.complex64, args[0])
             else:
                 return signature(types.complex128, args[0])

--- a/src/numba_cuda_mlir/typing/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/typing/cuda_vector_types.py
@@ -86,6 +86,9 @@ def make_constructor_template(vec_type):
                 # Scalar broadcast
                 if isinstance(arg, (types.Integer, types.Float)):
                     return signature(vec_type, arg)
+                # Complex broadcast/cast
+                if isinstance(arg, types.Complex) and num_elements == 2:
+                    return signature(vec_type, arg)
 
             # All scalar arguments matching element count
             if len(args) == num_elements:
@@ -153,3 +156,14 @@ def typeof_vector_type(val, c):
     """Create a typeof implementation for a vector type."""
     template = make_constructor_template(val)
     return VectorTypeClass(val, template)
+
+
+@registry.register_global(complex)
+class ComplexBuiltinTemplate(AbstractTemplate):
+    def generic(self, args, kws):
+        if len(args) == 1 and isinstance(args[0], VectorType) and args[0].length == 2:
+            if args[0].dtype == types.float32:
+                return signature(types.complex64, args[0])
+            else:
+                return signature(types.complex128, args[0])
+        return None

--- a/tests/numba_cuda_tests/cudapy/test_vector_type_complex_cast.py
+++ b/tests/numba_cuda_tests/cudapy/test_vector_type_complex_cast.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import numpy as np
+
+from numba_cuda_mlir.testing import NumbaCUDATestCase
+
+from numba_cuda_mlir import cuda
+from numba_cuda_mlir import types
+
+
+class TestVectorTypeComplexCast(NumbaCUDATestCase):
+    def test_vector_to_complex(self):
+        @cuda.jit("void(complex64[:], complex128[:])")
+        def kernel(arr64, arr128):
+            v1 = cuda.float2(1.5, 2.5)
+            v2 = cuda.double2(3.5, 4.5)
+
+            c1 = complex(v1)
+            c2 = complex(v2)
+
+            arr64[0] = c1
+            arr128[0] = c2
+
+        res64 = np.zeros(1, dtype=np.complex64)
+        res128 = np.zeros(1, dtype=np.complex128)
+
+        kernel[1, 1](res64, res128)
+
+        self.assertEqual(res64[0], complex(1.5, 2.5))
+        self.assertEqual(res128[0], complex(3.5, 4.5))
+
+    def test_int_vector_to_complex(self):
+        @cuda.jit("void(complex128[:])")
+        def kernel(arr):
+            v = cuda.int2(1, 2)
+            arr[0] = complex(v)
+
+        res = np.zeros(1, dtype=np.complex128)
+        kernel[1, 1](res)
+
+        self.assertEqual(res[0], complex(1.0, 2.0))
+
+    def test_invalid_complex_cast(self):
+        from numba_cuda_mlir.errors import TypingError
+
+        with self.assertRaises(TypingError):
+
+            @cuda.jit("void(complex128[:])")
+            def kernel(arr):
+                v = cuda.float4(1, 2, 3, 4)
+                arr[0] = complex(v)
+
+    def test_complex_to_vector(self):
+        @cuda.jit("void(float32[:], float64[:])")
+        def kernel(arr32, arr64):
+            c1 = complex(1.5, 2.5)
+            c2 = complex(3.5, 4.5)
+
+            # Need to cast to specific complex type to ensure it's complex64/128
+            # but Numba will type complex(1.5, 2.5) as complex128 by default.
+            # Let's rely on the input complex type or just use complex128 for both.
+
+            v1 = cuda.float2(c1)
+            v2 = cuda.double2(c2)
+
+            arr32[0] = v1.x
+            arr32[1] = v1.y
+            arr64[0] = v2.x
+            arr64[1] = v2.y
+
+        res32 = np.zeros(2, dtype=np.float32)
+        res64 = np.zeros(2, dtype=np.float64)
+
+        kernel[1, 1](res32, res64)
+
+        self.assertEqual(res32[0], 1.5)
+        self.assertEqual(res32[1], 2.5)
+        self.assertEqual(res64[0], 3.5)
+        self.assertEqual(res64[1], 4.5)
+
+    def test_complex_arg_to_vector(self):
+        @cuda.jit("void(complex64, complex128, float32[:], float64[:])")
+        def kernel(c64, c128, arr32, arr64):
+            v1 = cuda.float2(c64)
+            v2 = cuda.double2(c128)
+
+            arr32[0] = v1.x
+            arr32[1] = v1.y
+            arr64[0] = v2.x
+            arr64[1] = v2.y
+
+        res32 = np.zeros(2, dtype=np.float32)
+        res64 = np.zeros(2, dtype=np.float64)
+
+        c64 = np.complex64(1.5 + 2.5j)
+        c128 = np.complex128(3.5 + 4.5j)
+
+        kernel[1, 1](c64, c128, res32, res64)
+
+        self.assertEqual(res32[0], 1.5)
+        self.assertEqual(res32[1], 2.5)
+        self.assertEqual(res64[0], 3.5)
+        self.assertEqual(res64[1], 4.5)

--- a/tests/test_vector_type_complex_cast.py
+++ b/tests/test_vector_type_complex_cast.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
 
 from numba_cuda_mlir.testing import NumbaCUDATestCase
+from numba_cuda_mlir.errors import TypingError
 
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir import types
@@ -42,8 +43,6 @@ class TestVectorTypeComplexCast(NumbaCUDATestCase):
         self.assertEqual(res[0], complex(1.0, 2.0))
 
     def test_invalid_complex_cast(self):
-        from numba_cuda_mlir.errors import TypingError
-
         with self.assertRaises(TypingError):
 
             @cuda.jit("void(complex128[:])")


### PR DESCRIPTION
## Summary
This PR introduces the ability to cast 2-element CUDA vector types (e.g., `float2`, `double2`, `int2`) to Python `complex` types and vice versa. This improves interoperability between CUDA vector types and complex math operations.

## Changes
* **Typing (`typing/cuda_vector_types.py`)**: 
  * Registered the `complex` builtin for 2-element vector types. It automatically resolves to `complex64` for `float32` based vectors and `complex128` for other types.
  * Updated the vector constructor templates to accept `types.Complex` as an argument when constructing 2-element vectors.
* **Lowering (`lowering/cuda_vector_types.py`)**: 
  * Implemented MLIR lowering for `complex(vector)` which extracts the `x` and `y` components, converts them to the target precision, and constructs an MLIR complex value using the `complex` dialect.
  * Updated vector constructor lowering to properly extract the real and imaginary parts when a complex number is passed as an argument.
* **Testing (`tests/numba_cuda_tests/cudapy/test_vector_type_complex_cast.py`)**: 
  * Added a new test suite to verify vector-to-complex casts, complex-to-vector casts, and complex argument handling.
  * Added negative tests to ensure that invalid casts (e.g., trying to cast a 4-element vector like `float4` to `complex`) correctly raise a `TypingError`.

## Test Plan
- Run the newly added test suite: `pytest tests/numba_cuda_tests/cudapy/test_vector_type_complex_cast.py`
- All tests pass successfully.