### PR TITLE
Set up pre-commit.ci and remove redundant GHA job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,15 +173,6 @@ jobs:
 
   # ============== old CI jobs (ci.yaml & pr.yaml) ==============
 
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
-        with:
-          extra_args: --all-files --show-diff-on-failure
-
   build-docs:
     needs:
       - should-skip
@@ -220,7 +211,6 @@ jobs:
       - test-linux-aarch64
       - test-expensive-linux-64
       - test-expensive-linux-aarch64
-      - pre-commit
       - build-docs
       # - coverage-report
       # - test-simulator
@@ -251,8 +241,6 @@ jobs:
                  needs.test-expensive-linux-64.result == 'failure' ||
                  needs.test-expensive-linux-aarch64.result == 'cancelled' ||
                  needs.test-expensive-linux-aarch64.result == 'failure' ||
-                 needs.pre-commit.result == 'cancelled' ||
-                 needs.pre-commit.result == 'failure' ||
                  needs.build-docs.result == 'cancelled' ||
                  needs.build-docs.result == 'failure' }}; then
           #        needs.coverage-report.result == 'cancelled' ||

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,32 +1,50 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+ci:
+    autofix_commit_msg: |
+      [pre-commit.ci] auto code formatting
+    autofix_prs: false
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: quarterly
+    submodules: false
+
+# Please update the rev: SHAs below with this command:
+# pre-commit autoupdate --freeze
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
-  hooks:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: c60c980e561ed3e73101667fe8365c609d19a438  # frozen: v0.15.9
+    hooks:
+      - id: ruff-check
+        args: [--fix, --show-fixes]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: check-spdx
+        name: Check SPDX Headers
+        entry: python ./toolshed/check_spdx.py
+        language: python
+        additional_dependencies:
+          - pathspec==0.12.1
+        args: ["--fix"]
+
+  # Standard hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
+    hooks:
     - id: check-added-large-files
     - id: check-ast
+    - id: check-case-conflict
+    - id: check-docstring-first
     - id: check-merge-conflict
+    - id: check-symlinks
     - id: check-toml
     - id: check-yaml
     - id: debug-statements
     - id: end-of-file-fixer
-    - id: trailing-whitespace
-      exclude: '.+\.patch'
     - id: mixed-line-ending
       args: ['--fix=lf']
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.2
-  hooks:
-    - id: ruff
-      args: [--fix]
-    - id: ruff-format
-- repo: local
-  hooks:
-    - id: check-spdx
-      name: Check SPDX Headers
-      entry: python ./toolshed/check_spdx.py
-      language: python
-      additional_dependencies:
-        - pathspec==0.12.1
+    - id: trailing-whitespace
+      exclude: '.+\.patch'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         entry: python ./toolshed/check_spdx.py
         language: python
         additional_dependencies:
-          - pathspec==0.12.1
+          - https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl
         args: ["--fix"]
 
   # Standard hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,6 @@ repos:
       args: ['--fix=lf']
     - id: trailing-whitespace
       exclude: '.+\.patch'
+
+default_language_version:
+      python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,8 @@ repos:
     - id: check-added-large-files
     - id: check-ast
     - id: check-case-conflict
-    - id: check-docstring-first
+    # TODO: re-enable after fixing inherited numba docstring patterns
+    # - id: check-docstring-first
     - id: check-merge-conflict
     - id: check-symlinks
     - id: check-toml

--- a/src/numba_cuda_mlir/numba_cuda/core/tracing.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/tracing.py
@@ -174,7 +174,7 @@ def dotrace(*args, **kwds):
                 dotrace(c, *args, recursive=recursive)
         elif inspect.isclass(arg0):
             for n, f in inspect.getmembers(
-                arg0, lambda x: (inspect.isfunction(x) or inspect.ismethod(x))
+                arg0, lambda x: inspect.isfunction(x) or inspect.ismethod(x)
             ):
                 setattr(arg0, n, decorator(f))
 

--- a/src/numba_cuda_mlir/numba_cuda/cpython/unicode.py
+++ b/src/numba_cuda_mlir/numba_cuda/cpython/unicode.py
@@ -2125,7 +2125,7 @@ def gen_isAlX(ascii_func, unicode_func):
 # https://github.com/python/cpython/blob/1d4b6ba19466aba0eb91c4ba01ba509acf18c723/Objects/unicodeobject.c#L11928-L11964    # noqa: E501
 overload_method(types.UnicodeType, "isalpha")(gen_isAlX(_Py_ISALPHA, _PyUnicode_IsAlpha))
 
-_unicode_is_alnum = register_jitable(lambda x: (_PyUnicode_IsNumeric(x) or _PyUnicode_IsAlpha(x)))
+_unicode_is_alnum = register_jitable(lambda x: _PyUnicode_IsNumeric(x) or _PyUnicode_IsAlpha(x))
 
 # https://github.com/python/cpython/blob/1d4b6ba19466aba0eb91c4ba01ba509acf18c723/Objects/unicodeobject.c#L11975-L12006    # noqa: E501
 overload_method(types.UnicodeType, "isalnum")(gen_isAlX(_Py_ISALNUM, _unicode_is_alnum))

--- a/toolshed/check_spdx.py
+++ b/toolshed/check_spdx.py
@@ -41,6 +41,9 @@ def has_spdx_or_is_empty(filepath):
 def main(args):
     assert args, "filepaths expected to be passed from pre-commit"
 
+    if "--fix" in args:
+        del args[args.index("--fix")]
+
     ignore_spec = load_spdx_ignore()
 
     returncode = 0


### PR DESCRIPTION
## Summary

- Add `ci:` section to `.pre-commit-config.yaml` to enable pre-commit.ci
- Align config with cuda-python: frozen revs, ruff-check, additional hooks, pinned pathspec wheel, `default_language_version`
- Fix `check_spdx.py` to handle `--fix` argument (was crashing with `FileNotFoundError`)
- Comment out `check-docstring-first` hook (inherited numba code has docstrings after imports throughout)
- Run `ruff format` on files flagged by the new config
- Remove the `pre-commit` job from `ci.yaml` (now redundant with pre-commit.ci)