### PR TITLE
Test to-be-merged cuDF numba-cuda-mlir extension backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,6 +171,17 @@ jobs:
     with:
       host-platform: linux-aarch64
 
+  test-cudf-source-linux-64:
+    name: cudf source Test linux-64
+    if: ${{ github.repository_owner == 'nvidia' }}
+    permissions:
+      contents: read
+    needs:
+      - build-linux-64
+    uses: ./.github/workflows/test-cudf-source-linux.yml
+    with:
+      host-platform: linux-64
+
   # ============== old CI jobs (ci.yaml & pr.yaml) ==============
 
   build-docs:
@@ -211,6 +222,7 @@ jobs:
       - test-linux-aarch64
       - test-expensive-linux-64
       - test-expensive-linux-aarch64
+      - test-cudf-source-linux-64
       - build-docs
       # - coverage-report
       # - test-simulator
@@ -241,6 +253,8 @@ jobs:
                  needs.test-expensive-linux-64.result == 'failure' ||
                  needs.test-expensive-linux-aarch64.result == 'cancelled' ||
                  needs.test-expensive-linux-aarch64.result == 'failure' ||
+                 needs.test-cudf-source-linux-64.result == 'cancelled' ||
+                 needs.test-cudf-source-linux-64.result == 'failure' ||
                  needs.build-docs.result == 'cancelled' ||
                  needs.build-docs.result == 'failure' }}; then
           #        needs.coverage-report.result == 'cancelled' ||

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,17 @@ jobs:
     with:
       host-platform: linux-64
 
+  test-cudf-source-linux-aarch64:
+    name: cudf source Test linux-aarch64
+    if: ${{ github.repository_owner == 'nvidia' }}
+    permissions:
+      contents: read
+    needs:
+      - build-linux-aarch64
+    uses: ./.github/workflows/test-cudf-source-linux.yml
+    with:
+      host-platform: linux-aarch64
+
   # ============== old CI jobs (ci.yaml & pr.yaml) ==============
 
   build-docs:
@@ -223,6 +234,7 @@ jobs:
       - test-expensive-linux-64
       - test-expensive-linux-aarch64
       - test-cudf-source-linux-64
+      - test-cudf-source-linux-aarch64
       - build-docs
       # - coverage-report
       # - test-simulator
@@ -255,6 +267,8 @@ jobs:
                  needs.test-expensive-linux-aarch64.result == 'failure' ||
                  needs.test-cudf-source-linux-64.result == 'cancelled' ||
                  needs.test-cudf-source-linux-64.result == 'failure' ||
+                 needs.test-cudf-source-linux-aarch64.result == 'cancelled' ||
+                 needs.test-cudf-source-linux-aarch64.result == 'failure' ||
                  needs.build-docs.result == 'cancelled' ||
                  needs.build-docs.result == 'failure' }}; then
           #        needs.coverage-report.result == 'cancelled' ||

--- a/.github/workflows/test-cudf-source-linux.yml
+++ b/.github/workflows/test-cudf-source-linux.yml
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "CI: Test cudf source"
+
+on:
+  workflow_call:
+    inputs:
+      host-platform:
+        type: string
+        required: true
+      matrix_filter:
+        type: string
+        default: "."
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -xeuo pipefail {0}
+
+jobs:
+  compute-matrix:
+    runs-on: ubuntu-latest
+    env:
+      ARCH: ${{ (inputs.host-platform == 'linux-64' && 'amd64') ||
+                (inputs.host-platform == 'linux-aarch64' && 'arm64') }}
+    outputs:
+      MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
+    steps:
+      - name: Checkout ${{ github.event.repository.name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Compute cudf source test matrix
+        id: compute-matrix
+        run: |
+          TEST_MATRIX=$(yq -o json ".linux.cudf-source // [] | map(select(.ARCH == \"${ARCH}\"))" ci/test-matrix.yml)
+          MATRIX=$(echo "$TEST_MATRIX" | jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end')
+          echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
+
+  test:
+    name: cudf-source, py${{ matrix.PY_VER }}, ${{ matrix.CUDA_VER }}, ${{ matrix.GPU }}
+    needs: compute-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
+    runs-on: "${{ matrix.FLAVOR || 'linux' }}-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-${{ matrix.GPU_COUNT }}"
+    if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
+    container:
+      options: -u root --security-opt seccomp=unconfined --shm-size 16g
+      image: ubuntu:22.04
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+        PIP_CACHE_DIR: "/tmp/pip-cache"
+    steps:
+      - name: Ensure GPU is working
+        run: nvidia-smi
+
+      - name: Checkout ${{ github.event.repository.name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        continue-on-error: true
+        with:
+          enable-apt: true
+
+      - name: Install dependencies
+        uses: ./.github/actions/install_unix_deps
+        continue-on-error: false
+        with:
+          dependencies: "jq wget git cmake"
+          dependent_exes: "jq wget git cmake"
+
+      - name: Set environment variables
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          HOST_PLATFORM: ${{ inputs.host-platform }}
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+          PY_VER: ${{ matrix.PY_VER }}
+          SHA: ${{ github.sha }}
+        run: ./ci/tools/env-vars test
+
+      - name: Download numba-cuda-mlir build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: ${{ env.NUMBA_CUDA_MLIR_CUDA_ARTIFACT_NAME }}
+          path: ${{ env.NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR }}
+
+      - name: Display structure of downloaded numba-cuda-mlir artifacts
+        run: |
+          pwd
+          ls -lahR $NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR
+
+      - name: Set up Python ${{ matrix.PY_VER }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ matrix.PY_VER }}
+        env:
+          AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
+
+      - name: Set up mini CTK
+        if: ${{ matrix.LOCAL_CTK == '1' }}
+        uses: ./.github/actions/fetch_ctk
+        continue-on-error: false
+        with:
+          host-platform: ${{ inputs.host-platform }}
+          cuda-version: ${{ matrix.CUDA_VER }}
+          cuda-components: "cuda_nvcc,cuda_cudart,cuda_crt,libnvvm,cuda_nvrtc,cuda_cccl,libnvjitlink,cuda_cuobjdump"
+
+      - name: Run cudf source tests
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+          CUDF_REPO: ${{ matrix.CUDF_REPO || 'https://github.com/brandon-b-miller/cudf.git' }}
+          CUDF_BRANCH: ${{ matrix.CUDF_BRANCH || 'cudf-numba-cuda-mlir-extension-backend' }}
+        run: run-cudf-source-tests
+
+      - name: Upload cudf source test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cudf-source-test-results-${{ inputs.host-platform }}-py${{ matrix.PY_VER }}-cu${{ env.TEST_CUDA_MAJOR }}
+          path: |
+            cudf-source-junit-results.xml
+            cudf-source-junit-groupby.xml
+          if-no-files-found: ignore

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -69,4 +69,7 @@ linux:
   expensive:
     - { ARCH: 'amd64', PY_VER: '3.13',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'h100',       GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'arm64', PY_VER: '3.13',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
+  cudf-source:
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
   nightly: []

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -72,4 +72,6 @@ linux:
   cudf-source:
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
+    - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
+    - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
   nightly: []

--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -171,8 +171,10 @@ print(f'  Failed:  {total_failures}')
 print(f'  Errors:  {total_errors}')
 print(f'  Skipped: {total_skipped}')
 total = total_passed + total_failures + total_errors
-if total > 0:
-    print(f'  Pass rate: {total_passed/total*100:.1f}%')
+if total == 0:
+    print('ERROR: No test results found — tests may not have run')
+    sys.exit(1)
+print(f'  Pass rate: {total_passed/total*100:.1f}%')
 if total_failures > 0 or total_errors > 0:
     sys.exit(1)
 "

--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Build cudf from source against a public branch and run UDF tests with
+# numba-cuda-mlir installed.
+
+set -euo pipefail
+
+: "${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR:?NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR must be set by ci/tools/env-vars}"
+: "${LOCAL_CTK:?LOCAL_CTK must be set by the workflow}"
+: "${TEST_CUDA_MAJOR:?TEST_CUDA_MAJOR must be set by ci/tools/env-vars}"
+: "${TEST_CUDA_MINOR:?TEST_CUDA_MINOR must be set by ci/tools/env-vars}"
+
+CUDF_REPO="${CUDF_REPO:-https://github.com/brandon-b-miller/cudf.git}"
+CUDF_BRANCH="${CUDF_BRANCH:-cudf-numba-cuda-mlir-extension-backend}"
+
+export CUDA_VERSION="${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}"
+
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh"
+CONDA_ENV_NAME="cudf_build"
+
+declare -A CUDA_TO_ENV_YAML=(
+  ["12.9"]="all_cuda-129_arch-x86_64.yaml"
+  ["13.2"]="all_cuda-132_arch-x86_64.yaml"
+)
+
+ARCH=$(uname -m)
+if [[ "${ARCH}" == "aarch64" ]]; then
+  CUDA_TO_ENV_YAML["12.9"]="all_cuda-129_arch-aarch64.yaml"
+  CUDA_TO_ENV_YAML["13.2"]="all_cuda-132_arch-aarch64.yaml"
+fi
+
+# Map CUDA major.minor to the env yaml key (e.g. 12.9)
+ENV_YAML_KEY="${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}"
+if [[ -z "${CUDA_TO_ENV_YAML[${ENV_YAML_KEY}]+_}" ]]; then
+  echo "ERROR: No cudf conda environment YAML for CUDA ${ENV_YAML_KEY}"
+  echo "Supported versions: ${!CUDA_TO_ENV_YAML[*]}"
+  exit 1
+fi
+ENV_YAML_NAME="${CUDA_TO_ENV_YAML[${ENV_YAML_KEY}]}"
+
+# --- Locate numba-cuda-mlir wheel ---
+wheels=("${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR}"/*.whl)
+if [[ ${#wheels[@]} -ne 1 ]]; then
+  echo "Expected exactly one numba-cuda-mlir wheel in ${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR}, found ${#wheels[@]}"
+  printf '%s\n' "${wheels[@]}"
+  exit 1
+fi
+wheel="${wheels[0]}"
+
+# Extract Python version from wheel filename (e.g. ...cp312-cp312-... -> 3.12)
+PY_VER=$(echo "${wheel}" | grep -oP 'cp\K\d+' | head -1 | sed 's/\(.\)\(.*\)/\1.\2/')
+echo "numba-cuda-mlir wheel: $(basename "${wheel}") (Python ${PY_VER})"
+
+# --- Install Miniforge ---
+MAMBA_DIR="/tmp/miniforge"
+if [[ ! -x "${MAMBA_DIR}/bin/mamba" ]]; then
+  echo "Installing Miniforge..."
+  wget -q "${MINIFORGE_URL}" -O /tmp/miniforge.sh
+  bash /tmp/miniforge.sh -b -p "${MAMBA_DIR}"
+  rm /tmp/miniforge.sh
+fi
+export PATH="${MAMBA_DIR}/bin:${PATH}"
+
+# --- Clone cudf ---
+CUDF_DIR="/tmp/cudf"
+if [[ ! -d "${CUDF_DIR}" ]]; then
+  echo "Cloning cudf (branch: ${CUDF_BRANCH})..."
+  git clone --single-branch --branch "${CUDF_BRANCH}" "${CUDF_REPO}" "${CUDF_DIR}"
+fi
+echo "cudf commit:"
+git -C "${CUDF_DIR}" log -1 --format='%H %h %s'
+
+# --- Create conda environment ---
+ENV_YAML="${CUDF_DIR}/conda/environments/${ENV_YAML_NAME}"
+if [[ ! -f "${ENV_YAML}" ]]; then
+  echo "ERROR: Environment YAML not found: ${ENV_YAML}"
+  ls "${CUDF_DIR}/conda/environments/"
+  exit 1
+fi
+
+if [[ ! -d "${MAMBA_DIR}/envs/${CONDA_ENV_NAME}" ]]; then
+  echo "Creating conda environment '${CONDA_ENV_NAME}' from ${ENV_YAML_NAME}..."
+  mamba env create -f "${ENV_YAML}" -n "${CONDA_ENV_NAME}" "python=${PY_VER}" -y
+fi
+
+# Ensure nvidia-smi is accessible inside conda env
+ENV_BIN="${MAMBA_DIR}/envs/${CONDA_ENV_NAME}/bin"
+if [[ ! -e "${ENV_BIN}/nvidia-smi" ]]; then
+  HOST_SMI=$(command -v nvidia-smi 2>/dev/null || true)
+  if [[ -n "${HOST_SMI}" ]]; then
+    ln -sf "${HOST_SMI}" "${ENV_BIN}/nvidia-smi"
+  fi
+fi
+
+# --- Build cudf from source ---
+echo "Building cudf from source..."
+conda run -n "${CONDA_ENV_NAME}" --no-banner bash -c "cd ${CUDF_DIR} && bash build.sh libcudf pylibcudf cudf"
+
+# --- Install numba-cuda-mlir wheel ---
+echo "Installing numba-cuda-mlir wheel into conda env..."
+EXTRAS="cu${TEST_CUDA_MAJOR}"
+conda run -n "${CONDA_ENV_NAME}" --no-banner pip install "${wheel}[${EXTRAS}]"
+conda run -n "${CONDA_ENV_NAME}" --no-banner pip list
+
+# --- Run cudf UDF tests ---
+echo "Running cudf UDF tests for CUDA ${CUDA_VERSION}"
+
+SCALAR_UDF="${CUDF_DIR}/python/cudf/cudf/tests/dataframe/methods/test_apply.py"
+GROUPBY_UDF="${CUDF_DIR}/python/cudf/cudf/tests/groupby/test_apply.py"
+NRT_STATS="${CUDF_DIR}/python/cudf/cudf/tests/private_objects/test_nrt_stats.py"
+
+COMMON_ARGS=(-W "ignore::UserWarning" -v --tb=short)
+
+conda run -n "${CONDA_ENV_NAME}" --no-banner python -m pytest \
+  "${SCALAR_UDF}" \
+  "${NRT_STATS}" \
+  "${COMMON_ARGS[@]}" \
+  --junit-xml=cudf-source-junit-results.xml \
+  -o addopts= \
+  "$@" || true
+
+conda run -n "${CONDA_ENV_NAME}" --no-banner python -m pytest \
+  "${GROUPBY_UDF}" \
+  -k "test_groupby_apply" \
+  "${COMMON_ARGS[@]}" \
+  --junit-xml=cudf-source-junit-groupby.xml \
+  -o addopts= \
+  "$@" || true
+
+# --- Print summary ---
+echo ""
+echo "========================================"
+echo "cudf source test run complete"
+echo "========================================"
+echo "Junit results: cudf-source-junit-results.xml"
+echo "Junit groupby: cudf-source-junit-groupby.xml"
+
+# Fail the job if either xml has failures
+python3 -c "
+import xml.etree.ElementTree as ET
+import sys
+from pathlib import Path
+
+total_failures = 0
+total_errors = 0
+total_passed = 0
+total_skipped = 0
+
+for xml_file in ['cudf-source-junit-results.xml', 'cudf-source-junit-groupby.xml']:
+    p = Path(xml_file)
+    if not p.exists():
+        print(f'WARNING: {xml_file} not found')
+        continue
+    tree = ET.parse(p)
+    for ts in tree.iter('testsuite'):
+        tests = int(ts.get('tests', 0))
+        failures = int(ts.get('failures', 0))
+        errors = int(ts.get('errors', 0))
+        skipped = int(ts.get('skipped', 0))
+        total_failures += failures
+        total_errors += errors
+        total_skipped += skipped
+        total_passed += tests - failures - errors - skipped
+
+print(f'  Passed:  {total_passed}')
+print(f'  Failed:  {total_failures}')
+print(f'  Errors:  {total_errors}')
+print(f'  Skipped: {total_skipped}')
+total = total_passed + total_failures + total_errors
+if total > 0:
+    print(f'  Pass rate: {total_passed/total*100:.1f}%')
+if total_failures > 0 or total_errors > 0:
+    sys.exit(1)
+"

--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -98,13 +98,13 @@ fi
 
 # --- Build cudf from source ---
 echo "Building cudf from source..."
-conda run -n "${CONDA_ENV_NAME}" --no-banner bash -c "cd ${CUDF_DIR} && bash build.sh libcudf pylibcudf cudf"
+conda run -n "${CONDA_ENV_NAME}" bash -c "cd ${CUDF_DIR} && bash build.sh libcudf pylibcudf cudf"
 
 # --- Install numba-cuda-mlir wheel ---
 echo "Installing numba-cuda-mlir wheel into conda env..."
 EXTRAS="cu${TEST_CUDA_MAJOR}"
-conda run -n "${CONDA_ENV_NAME}" --no-banner pip install "${wheel}[${EXTRAS}]"
-conda run -n "${CONDA_ENV_NAME}" --no-banner pip list
+conda run -n "${CONDA_ENV_NAME}" pip install "${wheel}[${EXTRAS}]"
+conda run -n "${CONDA_ENV_NAME}" pip list
 
 # --- Run cudf UDF tests ---
 echo "Running cudf UDF tests for CUDA ${CUDA_VERSION}"
@@ -115,7 +115,7 @@ NRT_STATS="${CUDF_DIR}/python/cudf/cudf/tests/private_objects/test_nrt_stats.py"
 
 COMMON_ARGS=(-W "ignore::UserWarning" -v --tb=short)
 
-conda run -n "${CONDA_ENV_NAME}" --no-banner python -m pytest \
+conda run -n "${CONDA_ENV_NAME}" python -m pytest \
   "${SCALAR_UDF}" \
   "${NRT_STATS}" \
   "${COMMON_ARGS[@]}" \
@@ -123,7 +123,7 @@ conda run -n "${CONDA_ENV_NAME}" --no-banner python -m pytest \
   -o addopts= \
   "$@" || true
 
-conda run -n "${CONDA_ENV_NAME}" --no-banner python -m pytest \
+conda run -n "${CONDA_ENV_NAME}" python -m pytest \
   "${GROUPBY_UDF}" \
   -k "test_groupby_apply" \
   "${COMMON_ARGS[@]}" \


### PR DESCRIPTION
This PR creates a CI job that builds an unmerged branch of _my fork_ of `cudf` from source. This branch contains an MLIR version of cuDF's numba-cuda extension. We'll need to build it from source to test it until it's officially merged and the code appears in nightlies we can pull rather than build. 
