### PR TITLE
Fix ICE for raise-only kernel

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -870,8 +870,20 @@ extern "C" __global__ void
         exc_class = static_raise_inst.exc_class
         error_code = KERNEL_ERROR_CODES.get(exc_class, 4)  # Default to RuntimeError
         self.set_error_code(error_code)
-        return_block = self.blkmap[max(self.blkmap.keys())]
-        cf.br([], return_block)
+
+        # Branch to the highest-offset Return block if available.
+        return_offsets = [
+            offset
+            for offset, block in self.blocks.items()
+            if block.body and isinstance(block.body[-1], numba_ir.Return)
+        ]
+        if return_offsets:
+            cf.br([], self.blkmap[max(return_offsets)])
+            return
+
+        # Terminate the current block if no reachable Return block is found.
+        return_ctor = gpu.ReturnOp if isinstance(self.mlir_funcOp, gpu.GPUFuncOp) else func.ReturnOp
+        return_ctor([])
 
     def lower_assign(self, assign_inst):
         """

--- a/tests/test_kernel_exceptions.py
+++ b/tests/test_kernel_exceptions.py
@@ -56,3 +56,23 @@ def test_error_global_in_ptx():
 
     assert "__numba_cuda_mlir_error_code" in ptx, "Error global not found in PTX"
     assert ".visible .global" in ptx, "Error global should be visible"
+
+
+@pytest.mark.parametrize(
+    "debug, opt",
+    [
+        (False, False),
+        (False, True),
+        (True, False),
+    ],
+)
+def test_raise_only_kernel(debug, opt):
+    """Test that raise-only kernel compiles and surfaces RuntimeError to host."""
+
+    @cuda.jit(debug=debug, opt=opt)
+    def k():
+        raise RuntimeError("Error")
+
+    with pytest.raises(RuntimeError, match="Runtime error in kernel"):
+        k[1, 1]()
+        cuda.synchronize()


### PR DESCRIPTION
A kernel whose only statement is `raise` ICE'd with `entry block of region may not have predecessors`.

MLIRLower.lower_static_raise unconditionally emitted `cf.br ^bb<max>` assuming the highest-offset block was a Return block; for a raise-only kernel that block is the entry block, producing an illegal self-loop.

Fix: branch to the highest-offset Return block when one exists; otherwise terminate the current block in place with `gpu.return` (kernels) or `func.return` (device functions).

Add a regression test.