### PR TITLE
Add PR doc preview infrastructure

### DIFF
--- a/.github/actions/doc_preview/action.yml
+++ b/.github/actions/doc_preview/action.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/actions/doc_preview/action.yml
+++ b/.github/actions/doc_preview/action.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Docs in PRs
+description: Preview or clean up docs built from PRs
+
+# A re-implementation based on the logic of https://github.com/rossjrw/pr-preview-action/blob/41a957c44a456a34718e9bcf825363194db5e6d5/README.md, due to limitations illustrated in NVIDIA/cuda-python#380.
+
+inputs:
+  source-folder:
+    required: true
+    description: "Source code directory"
+    type: string
+  pr-number:
+    required: true
+    description: "Pull request number"
+    type: string
+
+runs:
+  using: composite
+  steps:
+    # The steps below are executed only when testing in a PR.
+    # Note: the PR previews will be removed once merged to main or release/* (see below)
+    - name: Deploy doc preview
+      if: ${{ github.ref_name != 'main' && !startsWith(github.ref_name, 'release/') }}
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4.8.0
+      with:
+        folder: ${{ inputs.source-folder }}
+        target-folder: pr-preview/pr-${{ inputs.pr-number }}/
+        commit-message: "Deploy doc preview for PR ${{ inputs.pr-number }} (${{ github.sha }})"
+
+    - name: Leave a comment after deployment
+      if: ${{ github.ref_name != 'main' && !startsWith(github.ref_name, 'release/') }}
+      uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff  # v3.0.3
+      with:
+        header: pr-preview
+        number: ${{ inputs.pr-number }}
+        skip_unchanged: true
+        message: |
+          Doc Preview CI
+          :---:
+          | <p></p> :rocket: View preview at <br> https://nvidia.github.io/numba-cuda-mlir/pr-preview/pr-${{ inputs.pr-number }}/ <br><br>
+          | <h6><br> Preview will be ready when the GitHub Pages deployment is complete. <br><br></h6>
+
+    # The steps below are executed only when building on main or release/*.
+    - name: Remove doc preview
+      if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') }}
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4.8.0
+      with:
+        folder: ${{ inputs.source-folder }}
+        target-folder: pr-preview/pr-${{ inputs.pr-number }}/
+        commit-message: "Clean up doc preview for PR ${{ inputs.pr-number }} (${{ github.sha }})"
+
+    - name: Leave a comment after removal
+      if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') }}
+      uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff  # v3.0.3
+      with:
+        header: pr-preview
+        number: ${{ inputs.pr-number }}
+        hide_and_recreate: true
+        hide_classify: "OUTDATED"
+        message: |
+          Doc Preview CI
+          :---:
+          Preview removed because the pull request was closed or merged.

--- a/.github/actions/get_pr_number/action.yml
+++ b/.github/actions/get_pr_number/action.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Get the PR number
+
+description: Get the PR number without relying on the pull_request* event triggers.
+
+runs:
+  using: composite
+  steps:
+    - name: Get PR info (non-main, non-release branch)
+      if: ${{ github.ref_name != 'main' && !startsWith(github.ref_name, 'release/') }}
+      uses: nv-gha-runners/get-pr-info@main
+      id: get-pr-info
+
+    - name: Extract PR number (non-main, non-release branch)
+      if: ${{ github.ref_name != 'main' && !startsWith(github.ref_name, 'release/') }}
+      shell: bash --noprofile --norc -xeuo pipefail {0}
+      run: |
+        trap 'echo "Error at line $LINENO"; exit 1' ERR
+        PR_NUMBER="${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}"
+        if [[ -z "$PR_NUMBER" ]]; then
+          echo "Cannot extract PR number for ref: ${{ github.ref_name }}"
+          exit 1
+        fi
+        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        echo "BUILD_PREVIEW=1" >> $GITHUB_ENV
+
+    - name: Get PR data (main or release/* branch)
+      if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') }}
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      id: get-pr-data
+      with:
+        script: |
+          const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            commit_sha: context.sha,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          if (!prs.data.length) {
+            core.setFailed("No PR associated with this commit on 'main' or 'release/*'.");
+          } else {
+            return prs.data[0];
+          }
+
+    - name: Extract PR number (main or release/* branch)
+      if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') }}
+      shell: bash --noprofile --norc -xeuo pipefail {0}
+      run: |
+        trap 'echo "Error at line $LINENO"; exit 1' ERR
+        PR_NUMBER="${{ fromJSON(steps.get-pr-data.outputs.result).number }}"
+        if [[ -z "$PR_NUMBER" ]]; then
+          echo "No associated PR found for the commit in 'main' or 'release/*'."
+          exit 1
+        fi
+        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        echo "BUILD_LATEST=1" >> $GITHUB_ENV

--- a/.github/actions/get_pr_number/action.yml
+++ b/.github/actions/get_pr_number/action.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -35,6 +35,7 @@ defaults:
 permissions:
   actions: read
   contents: write  # required for JamesIves/github-pages-deploy-action to push to gh-pages
+  pull-requests: write  # required for sticky PR comment (doc preview link)
 
 jobs:
   build:
@@ -125,12 +126,31 @@ jobs:
           ls -l build/html
           popd
 
+      # This step sets the PR_NUMBER/BUILD_LATEST/BUILD_PREVIEW env vars.
+      - name: Get PR number
+        if: ${{ !inputs.is-release }}
+        uses: ./.github/actions/get_pr_number
+
+      - name: Set up artifact directories
+        run: |
+          # create an empty folder for removal use (on merge, the preview folder is
+          # replaced with an empty one to effectively delete it)
+          mkdir -p empty_docs
+
       - name: Upload built docs artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: numba-cuda-mlir-docs
           path: docs/build/html/
           retention-days: 7
+
+      - name: Deploy or clean up doc preview
+        if: ${{ !inputs.is-release }}
+        uses: ./.github/actions/doc_preview
+        with:
+          source-folder: ${{ (github.ref_name != 'main' && 'docs/build/html') ||
+                              'empty_docs' }}
+          pr-number: ${{ env.PR_NUMBER }}
 
       - name: Deploy docs
         if: ${{ github.ref_name == 'main' || inputs.is-release }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      pull-requests: write  # required for sticky PR comment (doc preview link)
     uses: ./.github/workflows/build-docs.yml
     with:
       host-platform: linux-64

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Cleanup: PR Preview Documentation"
+
+on:
+  schedule:
+    # Run every night at 11pm EST (4am UTC during EST, 3am UTC during EDT)
+    # Using 4am UTC to be safe during EST (Nov-Mar)
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run in dry-run mode (preview only, no changes)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write  # Required to push changes to gh-pages branch
+
+jobs:
+  cleanup:
+    name: Clean up stale PR preview folders
+    runs-on: ubuntu-latest
+    # Only run for NVIDIA org to prevent forks from running this
+    if: github.repository_owner == 'NVIDIA'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Fetch all history and branches for worktree operations
+          fetch-depth: 0
+
+      - name: Run PR preview cleanup script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Determine if we should run in dry-run mode
+          if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+            echo "Running in dry-run mode (preview only)"
+            ./ci/cleanup-pr-previews --dry-run
+          else
+            echo "Running cleanup with push to gh-pages"
+            ./ci/cleanup-pr-previews --push
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### PR Preview Cleanup Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+            echo "Dry-run completed successfully" >> $GITHUB_STEP_SUMMARY
+            echo "No changes were made to the gh-pages branch" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Cleanup completed and changes pushed to gh-pages" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY

--- a/ci/cleanup-pr-previews
+++ b/ci/cleanup-pr-previews
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# A utility script to clean up PR preview documentation folders for closed/merged PRs.
+# This script checks all pr-XXXXX folders in the gh-pages branch pr-preview/ directory,
+# verifies if the corresponding PR XXXXX is still open, and removes preview folders
+# for PRs that have been closed or merged.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Usage information
+usage() {
+    cat << EOF
+PR Preview Cleanup Script - Clean up stale PR preview documentation folders
+
+This script fetches all pr-XXXXX folders from pr-preview/ in the gh-pages branch,
+checks PR status via GitHub API, and removes folders for closed/merged/deleted PRs.
+
+USAGE: $0 [OPTIONS]
+
+OPTIONS:
+    -n, --dry-run    Preview what would be deleted without actually deleting
+    --push           Commit and push changes to gh-pages (default: false, requires manual push)
+    -h, --help       Show this help message
+
+EXAMPLES:
+    $0 -n                     # Preview what would be cleaned up (RECOMMENDED FIRST)
+    $0                        # Clean up folders locally (no push)
+    $0 --push                 # Clean up folders and push to gh-pages branch
+    $0 --dry-run --push       # Invalid combination (dry-run takes precedence)
+
+REQUIREMENTS:
+    - GH_TOKEN environment variable must be set with appropriate permissions
+    - 'gh' (GitHub CLI) must be installed and authenticated
+    - 'jq' must be installed for JSON parsing
+
+SAFETY:
+Always run with --dry-run first to verify expected behavior before actual cleanup.
+The script will show a summary of what would be removed. Use --push to automatically
+commit and push changes, otherwise manual git operations are required.
+EOF
+    exit 1
+}
+
+# Configuration
+REPOSITORY="NVIDIA/numba-cuda-mlir"
+DRY_RUN="false"
+PUSH_CHANGES="false"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--dry-run)
+            DRY_RUN="true"
+            shift
+            ;;
+        --push)
+            PUSH_CHANGES="true"
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo -e "${RED}[ERROR]${NC} Unknown option: $1" >&2
+            echo "Use --help for usage information" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required tools and environment
+echo -e "${YELLOW}[INFO]${NC} Checking prerequisites..."
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo -e "${RED}[ERROR]${NC} GH_TOKEN environment variable is required" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo -e "${RED}[ERROR]${NC} jq is required but not installed" >&2
+    exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo -e "${RED}[ERROR]${NC} GitHub CLI (gh) is required but not installed" >&2
+    exit 1
+fi
+
+echo -e "${GREEN}[INFO]${NC} All prerequisites satisfied"
+
+# Fetch PR preview folders from gh-pages branch
+echo -e "${YELLOW}[INFO]${NC} Fetching PR preview folders from gh-pages branch..."
+
+# Get the list of pr-XXXXX folders from gh-pages branch
+PR_FOLDERS=$(gh api repos/"${REPOSITORY}"/contents/pr-preview?ref=gh-pages \
+    --header "Accept: application/vnd.github+json" \
+    --jq '.[] | select(.type == "dir" and (.name | test("^pr-[0-9]+$"))) | .name' \
+    2>/dev/null || true)
+
+if [[ -z "$PR_FOLDERS" ]]; then
+    echo -e "${YELLOW}[INFO]${NC} No PR preview folders found in gh-pages branch"
+    exit 0
+fi
+
+echo -e "${GREEN}[INFO]${NC} Found $(echo "$PR_FOLDERS" | wc -l) PR preview folders"
+
+# Check each PR folder
+FOLDERS_TO_REMOVE=()
+TOTAL_FOLDERS=0
+OPEN_PRS=0
+
+while IFS= read -r folder; do
+    if [[ -z "$folder" ]]; then
+        continue
+    fi
+
+    TOTAL_FOLDERS=$((TOTAL_FOLDERS + 1))
+
+    # Extract PR number from folder name (pr-XXXXX -> XXXXX)
+    PR_NUMBER="${folder#pr-}"
+
+    echo -e "${YELLOW}[CHECK]${NC} Checking PR #${PR_NUMBER}..."
+
+    # Check PR status using GitHub API
+    PR_STATUS=$(gh api repos/"${REPOSITORY}"/pulls/"${PR_NUMBER}" \
+        --header "Accept: application/vnd.github+json" \
+        --jq '.state' 2>/dev/null || echo "not_found")
+
+    case "$PR_STATUS" in
+        "open")
+            echo -e "${GREEN}[KEEP]${NC} PR #${PR_NUMBER} is still open"
+            OPEN_PRS=$((OPEN_PRS + 1))
+            ;;
+        "closed")
+            echo -e "${RED}[REMOVE]${NC} PR #${PR_NUMBER} is closed"
+            FOLDERS_TO_REMOVE+=("$folder")
+            ;;
+        "not_found")
+            echo -e "${RED}[REMOVE]${NC} PR #${PR_NUMBER} not found (may have been deleted)"
+            FOLDERS_TO_REMOVE+=("$folder")
+            ;;
+        *)
+            echo -e "${YELLOW}[UNKNOWN]${NC} PR #${PR_NUMBER} has unexpected status: ${PR_STATUS}"
+            ;;
+    esac
+done <<< "$PR_FOLDERS"
+
+# Summary
+echo ""
+echo -e "${YELLOW}[SUMMARY]${NC}"
+echo "Total PR preview folders: ${TOTAL_FOLDERS}"
+echo "Open PRs: ${OPEN_PRS}"
+echo "Folders to remove: ${#FOLDERS_TO_REMOVE[@]}"
+
+if [[ ${#FOLDERS_TO_REMOVE[@]} -eq 0 ]]; then
+    echo -e "${GREEN}[INFO]${NC} No cleanup needed - all preview folders correspond to open PRs"
+    exit 0
+fi
+
+# List folders to be removed
+echo ""
+echo -e "${YELLOW}[FOLDERS TO REMOVE]${NC}"
+for folder in "${FOLDERS_TO_REMOVE[@]}"; do
+    pr_num="${folder#pr-}"
+    echo "  - $folder (PR #${pr_num})"
+done
+
+# Perform cleanup or show what would be done
+echo ""
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "${YELLOW}[DRY RUN]${NC} Would remove ${#FOLDERS_TO_REMOVE[@]} folders (run without --dry-run to actually remove)"
+else
+    echo -e "${RED}[CLEANUP]${NC} Proceeding to remove ${#FOLDERS_TO_REMOVE[@]} folders..."
+
+    # Create a git worktree for gh-pages branch
+    TEMP_DIR="./gh-pages-cleanup"
+
+    # Safely remove any existing worktree and directory
+    if [[ -d "$TEMP_DIR" ]]; then
+        echo -e "${YELLOW}[INFO]${NC} Cleaning up existing worktree at $TEMP_DIR..."
+        # Try to remove existing worktree first (if it's registered)
+        git worktree remove "$TEMP_DIR" --force >/dev/null 2>&1 || true
+        # Now remove the directory
+        rm -rf "$TEMP_DIR"
+    fi
+
+    # Cleanup function to properly remove worktree and temp directory
+    cleanup_worktree() {
+        cd - >/dev/null 2>&1 || true  # Go back to original directory
+        # Only cleanup if changes have been pushed or if no changes were made
+        if [[ "${CHANGES_PUSHED:-false}" == "true" ]] || [[ "${REMOVED_COUNT:-0}" -eq 0 ]]; then
+            if [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]]; then
+                git worktree remove "$TEMP_DIR" --force >/dev/null 2>&1 || true
+            fi
+            rm -rf "$TEMP_DIR" >/dev/null 2>&1 || true
+        else
+            echo -e "${YELLOW}[INFO]${NC} Worktree preserved at $TEMP_DIR for manual verification" >&2
+            echo -e "${YELLOW}[INFO]${NC} Remove manually with: git worktree remove $TEMP_DIR && rm -rf $TEMP_DIR" >&2
+        fi
+    }
+    trap cleanup_worktree EXIT
+
+    # Ensure the local gh-pages branch is up-to-date
+    git fetch origin gh-pages:gh-pages
+
+    echo -e "${YELLOW}[INFO]${NC} Creating git worktree for gh-pages branch..."
+    if ! git worktree add "$TEMP_DIR" gh-pages >/dev/null 2>&1; then
+        echo -e "${RED}[ERROR]${NC} Failed to create git worktree for gh-pages branch" >&2
+
+        # Check if the issue might be a leftover worktree registration
+        if git worktree list | grep -q "$TEMP_DIR" 2>/dev/null; then
+            echo -e "${YELLOW}[INFO]${NC} Found existing worktree registration, attempting to clean up..." >&2
+            git worktree remove "$TEMP_DIR" --force >/dev/null 2>&1 || true
+            rm -rf "$TEMP_DIR" >/dev/null 2>&1 || true
+
+            # Try again
+            if ! git worktree add "$TEMP_DIR" gh-pages >/dev/null 2>&1; then
+                echo -e "${RED}[ERROR]${NC} Still unable to create worktree after cleanup" >&2
+                exit 1
+            fi
+        else
+            echo "Make sure the gh-pages branch exists and is accessible" >&2
+            exit 1
+        fi
+    fi
+
+    cd "$TEMP_DIR"
+
+    # Remove each folder
+    REMOVED_COUNT=0
+    for folder in "${FOLDERS_TO_REMOVE[@]}"; do
+        pr_num="${folder#pr-}"
+        folder_path="pr-preview/$folder"
+
+        if [[ -d "$folder_path" ]]; then
+            echo -e "${YELLOW}[REMOVE]${NC} Removing $folder_path"
+            rm -rf "$folder_path"
+            git add "$folder_path"
+            REMOVED_COUNT=$((REMOVED_COUNT + 1))
+        else
+            echo -e "${YELLOW}[SKIP]${NC} Folder $folder_path not found locally"
+        fi
+    done
+
+    if [[ $REMOVED_COUNT -gt 0 ]]; then
+        # Commit and push changes
+        commit_message="Clean up PR preview folders for ${REMOVED_COUNT} closed/merged PRs
+
+Removed preview folders for the following PRs:
+$(printf '%s\n' "${FOLDERS_TO_REMOVE[@]}" | sed 's/^pr-/- PR #/' | head -20)
+$(if [[ ${#FOLDERS_TO_REMOVE[@]} -gt 20 ]]; then echo "... and $((${#FOLDERS_TO_REMOVE[@]} - 20)) more"; fi)"
+
+        echo -e "${YELLOW}[INFO]${NC} Committing changes..."
+        git commit -m "$commit_message"
+
+        if [[ "$PUSH_CHANGES" == "true" ]]; then
+            echo -e "${YELLOW}[INFO]${NC} Pushing to gh-pages branch..."
+            git push origin gh-pages
+            CHANGES_PUSHED="true"
+            echo -e "${GREEN}[SUCCESS]${NC} Cleanup completed! Removed ${REMOVED_COUNT} PR preview folders and pushed changes"
+        else
+            CHANGES_PUSHED="false"
+            echo -e "${GREEN}[SUCCESS]${NC} Cleanup completed! Removed ${REMOVED_COUNT} PR preview folders"
+            echo -e "${YELLOW}[INFO]${NC} Changes have been committed locally but not pushed. Use 'git push origin gh-pages' to push manually."
+            echo -e "${YELLOW}[WARNING]${NC} Worktree will be preserved for manual verification."
+        fi
+    else
+        CHANGES_PUSHED="true"  # No changes made, safe to cleanup
+        echo -e "${YELLOW}[INFO]${NC} No folders were actually removed (they may have been cleaned up already)"
+    fi
+fi

--- a/ci/cleanup-pr-previews
+++ b/ci/cleanup-pr-previews
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
## Summary

- Port the doc preview system from cuda-python to enable documentation previews on pull requests
- On PR branches, built docs are deployed to `pr-preview/pr-N/` on gh-pages and a sticky comment with the preview URL is posted
- On merge to main, the preview folder is cleaned up and the comment is marked outdated
- Add a nightly cleanup workflow to remove stale previews for closed/merged PRs

## New files

- `.github/actions/get_pr_number/action.yml` — resolve PR number from branch refs (via `nv-gha-runners/get-pr-info` for PR branches, commit-to-PR lookup for main/release)
- `.github/actions/doc_preview/action.yml` — deploy preview to gh-pages + sticky comment with preview URL, or clean up on merge
- `.github/workflows/cleanup-pr-previews.yml` — nightly cron (4am UTC) + manual dispatch with dry-run option
- `ci/cleanup-pr-previews` — shell script that checks PR status via GitHub API and removes preview folders for closed/merged PRs

## Modified files

- `.github/workflows/build-docs.yml` — integrate preview deploy/cleanup steps, add `pull-requests: write` permission
- `.github/workflows/ci.yaml` — add `pull-requests: write` permission to build-docs caller

## Test plan

- [ ] Verify CI passes on this PR (doc build + preview deploy)
- [ ] Check that a sticky comment with the preview URL appears on this PR
- [ ] After merge, verify the preview folder is cleaned up and the comment is marked outdated
- [ ] Trigger the cleanup workflow manually with `--dry-run` to verify it lists the correct folders