### PR TITLE
Fix array.real/imag on shared-memory arrays losing address space

### DIFF
--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -101,63 +101,47 @@ def _lower_array_complex_real_imag(builder, target, array_var, attr):
     For a complex array in memory: [real0, imag0, real1, imag1, ...]
     .real returns a float view at offset 0 with stride 2
     .imag returns a float view at offset 1 with stride 2
+    Uses memref.reinterpret_cast to preserve the source memory space
     """
     complex_array = builder.load_var(array_var)
     array_type = complex_array.type
     rank = array_type.rank
+    float_type = array_type.element_type.element_type
 
-    # Get the data pointer from the complex array
-    ptr_as_index = memref_dialect.extract_aligned_pointer_as_index(complex_array)
-    i64 = ir.IntegerType.get_signless(64)
-    ptr_i64 = arith_dialect.index_cast(i64, ptr_as_index)
+    dyn = ir.ShapedType.get_dynamic_size()
+    dyn_s = ir.ShapedType.get_dynamic_stride_or_offset()
 
-    # For imag, offset by sizeof(float_element)
-    if attr == "imag":
-        complex_elem = array_type.element_type
-        float_width = complex_elem.element_type.width  # 32 or 64
-        byte_offset = float_width // 8  # 4 or 8
-        ptr_i64 = arith_dialect.addi(ptr_i64, arith_dialect.constant(i64, byte_offset))
+    target_mr_type = ir.MemRefType.get(
+        shape=[dyn] * rank,
+        element_type=float_type,
+        layout=ir.StridedLayoutAttr.get(dyn_s, [dyn_s] * rank),
+        memory_space=array_type.memory_space,
+    )
 
-    ptr = llvm.inttoptr(llvm.PointerType.get(), ptr_i64)
+    retyped = builtin.unrealized_conversion_cast([target_mr_type], [complex_array])
 
-    # Get original sizes from the complex array
-    sizes_i64 = []
-    for i in range(rank):
-        dim_val = memref_dialect.dim(complex_array, arith_dialect.constant(ir.IndexType.get(), i))
-        sizes_i64.append(convert(dim_val, i64))
-
-    # Strides: each complex element is 2 floats, so multiply strides by 2
     md = memref_dialect.extract_strided_metadata(complex_array)
-    strides_i64 = []
-    two = arith_dialect.constant(i64, 2)
-    for i in range(rank):
-        original_stride = md[2 + rank + i]
-        stride_i64 = convert(original_stride, i64)
-        strides_i64.append(arith_dialect.muli(stride_i64, two))
+    src_offset = md[1]
+    sizes = list(md[2 : 2 + rank])
+    strides = list(md[2 + rank : 2 + 2 * rank])
 
-    # Build the LLVM struct descriptor for the new float memref
-    struct_type = ir.Type.parse(
-        f"!llvm.struct<(ptr, ptr, i64, array<{rank} x i64>, array<{rank} x i64>)>"
+    # Each complex element spans 2 floats in memory.
+    two = index_of(2)
+    new_offset = arith.muli(src_offset, two)
+    if attr == "imag":
+        new_offset = arith.addi(new_offset, index_of(1))
+    new_strides = [arith.muli(s, two) for s in strides]
+
+    result = memref_dialect.reinterpret_cast(
+        target_mr_type,
+        retyped,
+        offsets=[new_offset],
+        sizes=sizes,
+        strides=new_strides,
+        static_offsets=[dyn_s],
+        static_sizes=[dyn] * rank,
+        static_strides=[dyn_s] * rank,
     )
-    i64c = lambda v: arith_dialect.constant(i64, v)
-    ins = lambda d, v, *p: llvm.insertvalue(
-        container=d, value=v, position=ir.DenseI64ArrayAttr.get(list(p))
-    )
-
-    desc = llvm.UndefOp(struct_type).result
-    desc = ins(desc, ptr, 0)  # allocPtr
-    desc = ins(desc, ptr, 1)  # alignedPtr
-    desc = ins(desc, i64c(0), 2)  # offset
-    for i, s in enumerate(sizes_i64):
-        desc = ins(desc, s, 3, i)
-    for i, s in enumerate(strides_i64):
-        desc = ins(desc, s, 4, i)
-
-    # Get the target memref type from the Numba type system
-    target_numba_type = builder.get_numba_type(target.name)
-    memref_type = builder.get_mlir_type(target_numba_type)
-
-    result = builtin.unrealized_conversion_cast([memref_type], [desc])
     builder.store_var(target, result)
 
 

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -60,3 +60,36 @@ class TestAtomicOnComplexComponents(unittest.TestCase):
         arr2 = arr1.copy()
         atomic_add_one_j_2d[(1, 1), (M, N)](arr2)
         np.testing.assert_equal(arr1 + 1j, arr2)
+
+
+N_SHARED = 32
+
+
+@pytest.mark.parametrize(
+    "complex_dtype,float_dtype",
+    [
+        (np.complex64, np.float32),
+        (np.complex128, np.float64),
+    ],
+)
+def test_shared_memory_complex_real_imag(complex_dtype, float_dtype):
+    """Regression: .real/.imag on shared-memory complex arrays must preserve address space."""
+
+    @cuda.jit
+    def kernel(inp, out_real, out_imag):
+        tid = cuda.threadIdx.x
+        sm = cuda.shared.array(N_SHARED, dtype=complex_dtype)
+        sm[tid] = inp[tid]
+        cuda.syncthreads()
+        out_real[tid] = sm.real[tid]
+        out_imag[tid] = sm.imag[tid]
+
+    rng = np.random.default_rng(42)
+    inp = (rng.standard_normal(N_SHARED) + 1j * rng.standard_normal(N_SHARED)).astype(complex_dtype)
+    out_real = np.zeros(N_SHARED, dtype=float_dtype)
+    out_imag = np.zeros(N_SHARED, dtype=float_dtype)
+
+    kernel[1, N_SHARED](inp, out_real, out_imag)
+
+    np.testing.assert_allclose(out_real, inp.real)
+    np.testing.assert_allclose(out_imag, inp.imag)


### PR DESCRIPTION
`array.real` / `array.imag` on shared-memory complex arrays fails at runtime with `CUDA_ERROR_ILLEGAL_ADDRESS`.

Root cause: `_lower_array_complex_real_imag` extracted the data pointer via `extract_aligned_pointer_as_index` then rebuilt it with `llvm.inttoptr(llvm.PointerType.get(), ...)` — creating a generic (addrspace 0) pointer regardless of where the source array lived.

Fix: Replace the manual LLVM struct construction with `memref.reinterpret_cast`, which preserves the source memref's memory space. Follows the same pattern used by `lower_array_view_cg`.