### PR TITLE
Fix multi-assign tuple, Optional lowering, string constant-folding, and VectorType→complex setitem

### DIFF
--- a/src/numba_cuda_mlir/lowering/builtins.py
+++ b/src/numba_cuda_mlir/lowering/builtins.py
@@ -800,6 +800,21 @@ def operator_is_none_none_lower(builder, target, args, kwargs):
     builder.store_var(target, result)
 
 
+@lower(operator.is_, types.Optional, types.NoneType)
+@lower(operator.is_, types.NoneType, types.Optional)
+def operator_is_optional_none_lower(builder, target, args, kwargs):
+    """Lower 'optional_val is None' - check valid bit is false."""
+    from numba_cuda_mlir.mlir.dialect_exts import llvm
+
+    lhs_type = builder.get_numba_type(args[0].name)
+    opt_arg = args[0] if isinstance(lhs_type, types.Optional) else args[1]
+    opt_val = builder.load_var(opt_arg)
+    i1 = ir.IntegerType.get_signless(1)
+    valid = llvm.extractvalue(i1, opt_val, [1])
+    result = arith.xori(valid, arith.constant(i1, 1))
+    builder.store_var(target, result)
+
+
 @lower(operator.is_, types.Boolean, types.Literal)
 @lower(operator.is_, types.Literal, types.Boolean)
 def operator_is_bool_literal_lower(builder, target, args, kwargs):
@@ -839,6 +854,20 @@ def operator_is_not_none_none_lower(builder, target, args, kwargs):
     """Lower 'None is not None' - always False."""
     result = arith.constant(result=ir.IntegerType.get_signless(1), value=False)
     builder.store_var(target, result)
+
+
+@lower(operator.is_not, types.Optional, types.NoneType)
+@lower(operator.is_not, types.NoneType, types.Optional)
+def operator_is_not_optional_none_lower(builder, target, args, kwargs):
+    """Lower 'optional_val is not None' - check valid bit is true."""
+    from numba_cuda_mlir.mlir.dialect_exts import llvm
+
+    lhs_type = builder.get_numba_type(args[0].name)
+    opt_arg = args[0] if isinstance(lhs_type, types.Optional) else args[1]
+    opt_val = builder.load_var(opt_arg)
+    i1 = ir.IntegerType.get_signless(1)
+    valid = llvm.extractvalue(i1, opt_val, [1])
+    builder.store_var(target, valid)
 
 
 @lower(operator.is_not, types.Boolean, types.Literal)

--- a/src/numba_cuda_mlir/lowering/unicode.py
+++ b/src/numba_cuda_mlir/lowering/unicode.py
@@ -32,19 +32,24 @@ lower = registry.lower
 def _unicode_eq_lower(builder, target, args, kwargs):
     """Lower unicode_type == unicode_type / StringLiteral.
 
-    Compares length first, then byte-by-byte (ASCII/kind=1).
+    Constant-folds when both values are known Python strings at compile time.
+    Otherwise compares length first, then byte-by-byte (ASCII/kind=1).
     Uses select + for loop (no scf.if with results needed).
     """
     from numba_cuda_mlir.lowering_utilities.string import (
         materialize_string_constant_if_needed,
     )
 
-    lhs_val = materialize_string_constant_if_needed(
-        builder.mlir_gpu_module, builder.load_var(args[0])
-    )
-    rhs_val = materialize_string_constant_if_needed(
-        builder.mlir_gpu_module, builder.load_var(args[1])
-    )
+    lhs_raw = builder.load_var(args[0])
+    rhs_raw = builder.load_var(args[1])
+
+    if isinstance(lhs_raw, str) and isinstance(rhs_raw, str):
+        result = arith.constant(result=T.bool(), value=(lhs_raw == rhs_raw))
+        builder.store_var(target, result)
+        return
+
+    lhs_val = materialize_string_constant_if_needed(builder.mlir_gpu_module, lhs_raw)
+    rhs_val = materialize_string_constant_if_needed(builder.mlir_gpu_module, rhs_raw)
 
     # Extract lengths (field 1)
     lhs_len = llvm.extractvalue(T.i64(), lhs_val, [1])

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -704,6 +704,18 @@ extern "C" __global__ void
                 var_type = self.get_numba_type(var_name)
                 if isinstance(var_type, types.NoneType):
                     continue
+                if isinstance(var_type, types.UniTuple):
+                    elem_mlir_type = self.get_mlir_type(var_type.dtype)
+                    memref_type = ir.MemRefType.get(
+                        shape=[var_type.count], element_type=elem_mlir_type
+                    )
+                    self.varmap[var_name] = memref.alloca(
+                        memref=memref_type, dynamic_sizes=[], symbol_operands=[]
+                    )
+                    continue
+                if isinstance(var_type, types.BaseTuple):
+                    self.var_assign_count[var_name] = 1
+                    continue
                 mlir_type = self.get_mlir_type(var_type)
 
                 if not _is_valid_memref_element_type(mlir_type):
@@ -913,7 +925,11 @@ extern "C" __global__ void
         trace("target: %s, free_var: %s", target, free_var)
         if free_var.value is None:
             target_type = self.get_numba_type(target.name)
-            self.store_var(target, self.get_mlir_type(target_type))
+            if isinstance(target_type, types.Optional):
+                none_val = self._cast_to_optional(types.NoneType("none"), target_type, None)
+                self.store_var(target, none_val)
+            else:
+                self.store_var(target, self.get_mlir_type(target_type))
         elif hasattr(free_var.value, "__cuda_array_interface__"):
             self.lower_captured_array_to_memref(target, free_var.value)
         else:
@@ -1022,11 +1038,15 @@ extern "C" __global__ void
         trace()
         target_type = self.get_numba_type(target.name)
         if const.value is None:
-            # for NoneType const, there is no 1-on-1 mapping between
-            # numba instruction and MLIR op. Therefore, we register the
-            # MLIR type in the varmap to unblock lowering of other
-            # numba instruction (i.e, assign this NoneType variable to other variables)
-            self.store_var(target, self.get_mlir_type(target_type))
+            if isinstance(target_type, types.Optional):
+                none_val = self._cast_to_optional(types.NoneType("none"), target_type, None)
+                self.store_var(target, none_val)
+            else:
+                # for NoneType const, there is no 1-on-1 mapping between
+                # numba instruction and MLIR op. Therefore, we register the
+                # MLIR type in the varmap to unblock lowering of other
+                # numba instruction (i.e, assign this NoneType variable to other variables)
+                self.store_var(target, self.get_mlir_type(target_type))
         elif isinstance(const.value, (bool, int, float, np.number)):
             value = const.value
             mlir_type = self.get_mlir_type(target_type)
@@ -1067,22 +1087,34 @@ extern "C" __global__ void
 
             complex_cg(self, target, [const.value.real, const.value.imag], {})
         elif isinstance(const.value, tuple):
-            memref_allocaOp = memref.alloca(
-                memref=self.get_mlir_type(target_type),
-                dynamic_sizes=[],
-                symbol_operands=[],
-            )
-            for i in range(len(const.value)):
-                memref_index = arith.constant(result=ir.IndexType.get(), value=i)
-                value = arith.constant(
-                    result=self.get_mlir_type(target_type.dtype), value=const.value[i]
+            if isinstance(target_type, types.BaseTuple):
+                elem_types = (
+                    [target_type.dtype] * target_type.count
+                    if isinstance(target_type, types.UniTuple)
+                    else list(target_type.types)
                 )
-                memref.store(
-                    value=value,
-                    memref=memref_allocaOp,
-                    indices=[memref_index],
+                values = tuple(
+                    arith.constant(result=self.get_mlir_type(et), value=v)
+                    for v, et in zip(const.value, elem_types)
                 )
-            self.store_var(target, memref_allocaOp)
+                self.store_var(target, values)
+            else:
+                memref_allocaOp = memref.alloca(
+                    memref=self.get_mlir_type(target_type),
+                    dynamic_sizes=[],
+                    symbol_operands=[],
+                )
+                for i in range(len(const.value)):
+                    memref_index = arith.constant(result=ir.IndexType.get(), value=i)
+                    value = arith.constant(
+                        result=self.get_mlir_type(target_type.dtype), value=const.value[i]
+                    )
+                    memref.store(
+                        value=value,
+                        memref=memref_allocaOp,
+                        indices=[memref_index],
+                    )
+                self.store_var(target, memref_allocaOp)
         elif isinstance(const.value, (str, bytes)):
             self.store_var(target, const.value)
         else:
@@ -1092,7 +1124,11 @@ extern "C" __global__ void
         trace()
         target_type = self.get_numba_type(target.name)
         if glob.value is None:
-            self.store_var(target, self.get_mlir_type(target_type))
+            if isinstance(target_type, types.Optional):
+                none_val = self._cast_to_optional(types.NoneType("none"), target_type, None)
+                self.store_var(target, none_val)
+            else:
+                self.store_var(target, self.get_mlir_type(target_type))
             return
         if isinstance(glob.value, (bool, int, float, np.number)):
             mlir_type = self.get_mlir_type(target_type)
@@ -2241,6 +2277,12 @@ extern "C" __global__ void
         Otherwise, falls back to ``mlir_convert`` for built-in MLIR type
         conversions (e.g. int widening, float promotion).
         """
+        # Optional type casts handled directly with LLVM struct ops.
+        if isinstance(target_type, types.Optional):
+            return self._cast_to_optional(source_type, target_type, value)
+        if isinstance(source_type, types.Optional):
+            return self._cast_from_optional(source_type, target_type, value)
+
         try:
             cast_impl = self.context._casts.find((source_type, target_type))
         except errors.NumbaNotImplementedError:
@@ -2248,6 +2290,42 @@ extern "C" __global__ void
         if cast_impl is not None and self._is_extension_cast(cast_impl):
             return cast_impl(self.context, self, source_type, target_type, value)
         return self.mlir_convert(value, self.get_mlir_type(target_type))
+
+    def _cast_to_optional(self, source_type, target_type, value):
+        """Cast T or NoneType to Optional(T)."""
+        opt_mlir_type = self.get_mlir_type(target_type)
+        i1 = ir.IntegerType.get_signless(1)
+        if isinstance(source_type, types.NoneType):
+            desc = llvm.UndefOp(opt_mlir_type).result
+            desc = llvm.insertvalue(
+                container=desc,
+                value=arith.constant(i1, 0),
+                position=ir.DenseI64ArrayAttr.get([1]),
+            )
+            return desc
+        inner_value = value
+        if source_type != target_type.type:
+            inner_value = self.mlir_convert(value, self.get_mlir_type(target_type.type))
+        desc = llvm.UndefOp(opt_mlir_type).result
+        desc = llvm.insertvalue(
+            container=desc,
+            value=inner_value,
+            position=ir.DenseI64ArrayAttr.get([0]),
+        )
+        desc = llvm.insertvalue(
+            container=desc,
+            value=arith.constant(i1, 1),
+            position=ir.DenseI64ArrayAttr.get([1]),
+        )
+        return desc
+
+    def _cast_from_optional(self, source_type, target_type, value):
+        """Cast Optional(T) to T (unwrap, assuming valid)."""
+        inner_mlir_type = self.get_mlir_type(source_type.type)
+        data = llvm.extractvalue(inner_mlir_type, value, [0])
+        if source_type.type != target_type:
+            data = self.mlir_convert(data, self.get_mlir_type(target_type))
+        return data
 
     def get_getattr_builder(self, target, value, attr):
         target_type = self.get_numba_type(target.name)
@@ -2588,6 +2666,22 @@ extern "C" __global__ void
         if builder := self.get_registered_builder(operator.setitem, signature):
             builder(self, None, [target, index, value], [])
             return
+        # If value is Optional, unwrap it and retry with the inner type.
+        value_type = self.get_numba_type(value.name)
+        if isinstance(value_type, types.Optional):
+            unwrapped_types = list(arg_types)
+            unwrapped_types[-1] = value_type.type
+            sig2 = types.Any(*unwrapped_types)
+            if builder := self.get_registered_builder(operator.setitem, sig2):
+                mlir_val = self.load_var(value)
+                inner = self._cast_from_optional(value_type, value_type.type, mlir_val)
+                tmp_var = numba_ir.Var(
+                    scope=value.scope, name=f"$optional_unwrap_{value.name}", loc=value.loc
+                )
+                self.fndesc.typemap[tmp_var.name] = value_type.type
+                self.store_var(tmp_var, inner)
+                builder(self, None, [target, index, tmp_var], [])
+                return
 
     def lower_branch(self, branch_inst):
         """
@@ -2972,6 +3066,12 @@ extern "C" __global__ void
             var_type = self.get_numba_type(var.name)
             slot = self.varmap[var.name]
 
+            # UniTuple multi-assign: load each element and return as a Python tuple.
+            if isinstance(var_type, types.UniTuple):
+                return tuple(
+                    memref.load(memref=slot, indices=[index_of(i)]) for i in range(var_type.count)
+                )
+
             if isinstance(slot.type, MemRefType):
                 trace("")
                 index = index_of(0)
@@ -3054,6 +3154,19 @@ extern "C" __global__ void
             slot = self.varmap[var.name]
             var_type = self.get_numba_type(var.name)
 
+            # UniTuple multi-assign: store each element into the memref.
+            if isinstance(var_type, types.UniTuple) and isinstance(value, (tuple, list)):
+                for i, elem in enumerate(value):
+                    memref.store(value=elem, memref=slot, indices=[index_of(i)])
+                return
+
+            # Optional multi-assign receiving a NoneType placeholder:
+            # construct the Optional None struct before storing.
+            if isinstance(var_type, types.Optional) and not isinstance(
+                value, (ir.Value, ir.OpView)
+            ):
+                value = self._cast_to_optional(types.NoneType("none"), var_type, None)
+
             # Decref the old value before overwriting
             if self.nrt.type_has_nrt_meminfo(var_type) and isinstance(value, ir.Value):
                 if isinstance(slot.type, MemRefType):
@@ -3070,7 +3183,9 @@ extern "C" __global__ void
         else:
             # the value can be safely stored in register,
             # register the value in varmap
-            assert not self.var_lowered(var), f"Var {var.name} already defined in varmap."
+            assert not self.var_lowered(var) or isinstance(
+                self.get_numba_type(var.name), types.BaseTuple
+            ), f"Var {var.name} already defined in varmap."
             numba_type = self._get_numba_type_for_dbg_var(var.name)
             if (
                 self._debug_full

--- a/src/numba_cuda_mlir/models.py
+++ b/src/numba_cuda_mlir/models.py
@@ -281,6 +281,19 @@ class UniTupleModel(PrimitiveModel):
         super().__init__(dmm, fe_type, be_type)
 
 
+@register_model(types.Optional)
+class OptionalModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        super().__init__(
+            dmm,
+            fe_type,
+            [
+                ("data", fe_type.type),
+                ("valid", types.boolean),
+            ],
+        )
+
+
 @register_model(types.UnionType)
 class UnionType(PrimitiveModel):
     def __init__(self, dmm, fe_type):

--- a/src/numba_cuda_mlir/types.py
+++ b/src/numba_cuda_mlir/types.py
@@ -3,6 +3,7 @@
 from numba_cuda_mlir.numba_cuda.types import (
     BaseTuple,
     BoundFunction,
+    Optional,
     Poison,
     UnicodeType,
     UnionType,

--- a/src/numba_cuda_mlir/typing/builtin.py
+++ b/src/numba_cuda_mlir/typing/builtin.py
@@ -9,6 +9,7 @@ from numba_cuda_mlir.numba_cuda.typing.templates import (
     signature,
 )
 from numba_cuda_mlir import types
+from numba_cuda_mlir.type_defs.vector_types import VectorType
 import operator
 
 registry = Registry()
@@ -35,15 +36,20 @@ class TupleMultiplyTemplate(AbstractTemplate):
 @registry.register_global(operator.setitem)
 class ArraySetitemTemplate(AbstractTemplate):
     def generic(self, args, kws):
-        match args:
-            case (
-                types.Array() as array,
-                types.Integer() as idx,
-                types.Complex() as value,
-            ):
-                return signature(types.none, array, idx, value)
-            case _:
-                return None
+        if len(args) != 3:
+            return None
+        array, idx, value = args
+        if not isinstance(array, types.Array):
+            return None
+        if isinstance(value, types.Complex):
+            return signature(types.none, array, idx, value)
+        if (
+            isinstance(value, VectorType)
+            and value.length == 2
+            and isinstance(array.dtype, types.Complex)
+        ):
+            return signature(types.none, array, idx, value)
+        return None
 
 
 @registry.register_global(operator.contains)

--- a/tests/numba_cuda_tests/cudapy/test_compiler.py
+++ b/tests/numba_cuda_tests/cudapy/test_compiler.py
@@ -679,7 +679,6 @@ class TestCompile(NumbaCUDATestCase):
 
         cuda.compile(wrapper, wrapper_sig.args, output="ltoir")
 
-    @pytest.mark.xfail(True, reason="Issue with Optional type")
     def test_compile_CABI_calling_device_function_returning_optional(self):
         # Exercise a CABI caller invoking a Numba ABI callee that can return
         # None through Optional[int32]

--- a/tests/numba_cuda_tests/cudapy/test_ssa.py
+++ b/tests/numba_cuda_tests/cudapy/test_ssa.py
@@ -167,7 +167,6 @@ class TestSSA(SSABaseTest):
 
         self.check_func(foo, np.array([1, 2]), np.array([1, 2]))
 
-    @pytest.mark.xfail(True, reason="Typing error")
     def test_unhandled_undefined(self):
         @numba_cuda_mlir.cuda.jit
         def function1(arg1, arg2, arg3, arg4, arg5):

--- a/tests/test_jit_compat.py
+++ b/tests/test_jit_compat.py
@@ -203,6 +203,25 @@ def test_none_is_not_none():
     assert arr.copy_to_host()[0] == 0
 
 
+def test_optional_return_from_device_function():
+    @cuda.jit(device=True)
+    def maybe_value(cond):
+        if cond:
+            return 42
+        return None
+
+    @cuda.jit
+    def kernel(out, n):
+        v = maybe_value(n > 0)
+        if v is not None:
+            out[0] = v
+
+    out = cuda.device_array((1,), dtype=np.int64)
+    out.copy_to_device(np.array([0], dtype=np.int64))
+    kernel[1, 1](out, 1)
+    assert out.copy_to_host()[0] == 42
+
+
 @pytest.mark.parametrize(
     "expr,input_val,expected",
     [

--- a/tests/test_string_types.py
+++ b/tests/test_string_types.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 from numba_cuda_mlir import cuda
+from numba_cuda_mlir import testing
 
 
 @pytest.mark.parametrize(
@@ -142,6 +143,36 @@ def test_string_literal_eq_used_in_conditional():
     kernel[1, 1](out)
     assert out[0] == 1
     assert out[1] == 0
+
+
+def test_string_literal_eq_module_global():
+    """Module-level string compared repeatedly should constant-fold without loops."""
+    _ARRANGEMENT = "col_major"
+
+    @cuda.jit
+    def kernel(out):
+        acc = 0
+        if _ARRANGEMENT == "col_major":
+            acc += 1
+        if _ARRANGEMENT == "col_major":
+            acc += 1
+        if _ARRANGEMENT == "col_major":
+            acc += 1
+        if _ARRANGEMENT == "col_major":
+            acc += 1
+        out[0] = acc
+
+    out = np.zeros(1, dtype=np.int64)
+    kernel[1, 1](out)
+    assert out[0] == 4
+
+    (mlir,) = kernel.inspect_mlir().values()
+    testing.filecheck(
+        """
+        CHECK-NOT: scf.for
+        """,
+        mlir,
+    )
 
 
 def test_string_literal_eq_single_char():

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -233,5 +233,25 @@ def test_tuple_of_array_scalar_tuple():
     np.testing.assert_array_equal(r, expected)
 
 
+def test_tuple_multi_assign_from_device_function():
+    @cuda.jit(device=True)
+    def two_tuple_returns(cond):
+        if cond:
+            return (1, 2, 3)
+        return (4, 5, 6)
+
+    @cuda.jit
+    def kernel(out, n):
+        t = two_tuple_returns(n > 0)
+        out[0] = t[0]
+
+    out = cuda.device_array((1,), dtype=np.int64)
+    kernel[1, 1](out, 1)
+    assert out.copy_to_host()[0] == 1
+
+    kernel[1, 1](out, -1)
+    assert out.copy_to_host()[0] == 4
+
+
 if __name__ == "__main__":
     test_tuple_concat((1, 2), (3, 4, 5))

--- a/tests/test_vector_type_complex_cast.py
+++ b/tests/test_vector_type_complex_cast.py
@@ -101,3 +101,17 @@ class TestVectorTypeComplexCast(NumbaCUDATestCase):
         self.assertEqual(res32[1], 2.5)
         self.assertEqual(res64[0], 3.5)
         self.assertEqual(res64[1], 4.5)
+
+    def test_float64x2_setitem_complex128_array(self):
+        from numba_cuda_mlir.cuda.vector_types import float64x2
+
+        @cuda.jit
+        def kernel(matrix, out):
+            smem = cuda.shared.array(shape=(1,), dtype=float64x2)
+            smem[0] = matrix[0]
+            out[0] = smem[0]
+
+        matrix = np.array([1 + 2j], dtype=np.complex128)
+        out = np.zeros(1, dtype=np.complex128)
+        kernel[1, 1](matrix, out)
+        np.testing.assert_equal(out[0], matrix[0])


### PR DESCRIPTION
This PR addresses four MLIR lowering issues:

1. **Multi-assigned tuple-typed locals** — Allocate per-element memref stack slots for `UniTuple` variables assigned from multiple branches, avoiding a `MemRefType.get` TypeError on tuple types.
2. **Device functions returning `Optional` (int | None)** — Register `OptionalModel`, add cast-to/from-optional via `llvm.insertvalue`/`extractvalue`, handle None assignments to Optional-typed variables, and unwrap Optional values in setitem lowering.
3. **String literal equality constant-folding ** — In the UnicodeType equality lowering, Constant-fold `==` when both operands resolve to Python strings at lowering time, emitting a single `arith.constant` instead of an `scf.for` byte-comparison loop.
4. **Missing `setitem` for `float64x2` → `complex128[:]`** — Extend `ArraySetitemTemplate` to accept 2-lane `VectorType` values when the target array has complex dtype.

Also removed `xfail` from 2 tests using `Optional` type that now pass.
