### PR TITLE
Reordered includes to enable compiling on newer libc++ versions

### DIFF
--- a/cext/launcher/cuda_helper.cpp
+++ b/cext/launcher/cuda_helper.cpp
@@ -2,9 +2,10 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <array>
 #include "cuda_helper.h"
 #include "cuda_loader.h"
+
+#include <array>
 
 
 const char* get_cuda_error(CUresult res) {

--- a/cext/launcher/py.h
+++ b/cext/launcher/py.h
@@ -4,8 +4,9 @@
  */
 #pragma once
 
-#include "ref_ptr.h"
 #include <Python.h>
+
+#include "ref_ptr.h"
 #include <optional>
 
 #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 13


### PR DESCRIPTION
## Summary
- Reorder includes in `cext/launcher/cuda_helper.cpp` so `Python.h` (via `py.h`) precedes libstdc++ headers.
- Fixes build under GCC 16 where lib headers sets `_POSIX_C_SOURCE=202405L` / `_XOPEN_SOURCE=800` before `pyconfig.h` redefines them, tripping `-Werror`.

pyconfig.h:1874:9: error: '_POSIX_C_SOURCE' redefined [-Werror]
pyconfig.h:1895:9: error: '_XOPEN_SOURCE' redefined [-Werror]

## Failure:

```
       make -C /home/jlisowski/repos/numba-cuda-mlir-fork/build -j 1
        make: Entering directory '/home/jlisowski/repos/numba-cuda-mlir-fork/build'
        [  3%] Building CXX object cext/launcher/CMakeFiles/_cext.dir/cuda_helper.cpp.o
        In file included from /usr/include/python3.12/Python.h:12,
                         from /home/jlisowski/repos/numba-cuda-mlir-fork/cext/launcher/py.h:8,
                         from /home/jlisowski/repos/numba-cuda-mlir-fork/cext/launcher/cuda_helper.h:7,
                         from /home/jlisowski/repos/numba-cuda-mlir-fork/cext/launcher/cuda_helper.cpp:6:
        /usr/include/python3.12/pyconfig.h:1874:9: error: ‘_POSIX_C_SOURCE’ redefined [-Werror]
         1874 | #define _POSIX_C_SOURCE 200809L
              |         ^~~~~~~~~~~~~~~
        In file included from /usr/include/c++/16.1.1/x86_64-pc-linux-gnu/bits/os_defines.h:39,
                         from /usr/include/c++/16.1.1/x86_64-pc-linux-gnu/bits/c++config.h:733,
                         from /usr/include/c++/16.1.1/bits/version.h:51,
                         from /usr/include/c++/16.1.1/compare:40,
                         from /usr/include/c++/16.1.1/array:40,
                         from /home/jlisowski/repos/numba-cuda-mlir-fork/cext/launcher/cuda_helper.cpp:5:
        /usr/include/features.h:319:10: note: this is the location of the previous definition
          319 | # define _POSIX_C_SOURCE        202405L
              |          ^~~~~~~~~~~~~~~
        /usr/include/python3.12/pyconfig.h:1895:9: error: ‘_XOPEN_SOURCE’ redefined [-Werror]
         1895 | #define _XOPEN_SOURCE 700
              |         ^~~~~~~~~~~~~
        /usr/include/features.h:234:10: note: this is the location of the previous definition
          234 | # define _XOPEN_SOURCE  800
              |          ^~~~~~~~~~~~~
        cc1plus: all warnings being treated as errors
        make[2]: *** [cext/launcher/CMakeFiles/_cext.dir/build.make:107: cext/launcher/CMakeFiles/_cext.dir/cuda_helper.cpp.o] Error 1
        make[1]: *** [CMakeFiles/Makefile2:351: cext/launcher/CMakeFiles/_cext.dir/all] Error 2
        make: *** [Makefile:136: all] Error 2
        make: Leaving directory '/home/jlisowski/repos/numba-cuda-mlir-fork/build'
        error: command '/usr/sbin/make' failed with exit code 2
        [end of output]
    ```