### PR TITLE
[codex] Add Numbast MLIR CI integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,52 @@ jobs:
       build-type: pull-request
       host-platform: ${{ matrix.host-platform }}
 
+  test-numbast-mlir-linux-64:
+    name: Numbast MLIR Test linux-64
+    if: ${{ github.repository_owner == 'nvidia' }}
+    permissions:
+      contents: read  # This is required for actions/checkout
+    needs:
+      - build-linux-64
+    uses: ./.github/workflows/test-wheel-linux.yml
+    with:
+      build-type: pull-request
+      host-platform: linux-64
+      test-script: run-numbast-mlir-tests
+      matrix_filter: >-
+        map(select(
+          .PY_VER == "3.12" and
+          .CUDA_VER == "13.2.1" and
+          .GPU == "l4" and
+          .GPU_COUNT == "1" and
+          (.FLAVOR | not)
+        ))
+        | map(.LOCAL_CTK = "1")
+        | .[0:1]
+
+  test-numbast-mlir-linux-aarch64:
+    name: Numbast MLIR Test linux-aarch64
+    if: ${{ github.repository_owner == 'nvidia' }}
+    permissions:
+      contents: read  # This is required for actions/checkout
+    needs:
+      - build-linux-aarch64
+    uses: ./.github/workflows/test-wheel-linux.yml
+    with:
+      build-type: pull-request
+      host-platform: linux-aarch64
+      test-script: run-numbast-mlir-tests
+      matrix_filter: >-
+        map(select(
+          .PY_VER == "3.12" and
+          .CUDA_VER == "13.2.1" and
+          .GPU == "a100" and
+          .GPU_COUNT == "1" and
+          (.FLAVOR | not)
+        ))
+        | map(.LOCAL_CTK = "1")
+        | .[0:1]
+
   test-expensive-linux-64:
     name: Expensive Test linux-64
     if: ${{ github.repository_owner == 'nvidia' }}
@@ -209,6 +255,8 @@ jobs:
     needs:
       - test-linux-64
       - test-linux-aarch64
+      - test-numbast-mlir-linux-64
+      - test-numbast-mlir-linux-aarch64
       - test-expensive-linux-64
       - test-expensive-linux-aarch64
       - build-docs
@@ -237,6 +285,10 @@ jobs:
                  needs.test-linux-64.result == 'failure' ||
                  needs.test-linux-aarch64.result == 'cancelled' ||
                  needs.test-linux-aarch64.result == 'failure' ||
+                 needs.test-numbast-mlir-linux-64.result == 'cancelled' ||
+                 needs.test-numbast-mlir-linux-64.result == 'failure' ||
+                 needs.test-numbast-mlir-linux-aarch64.result == 'cancelled' ||
+                 needs.test-numbast-mlir-linux-aarch64.result == 'failure' ||
                  needs.test-expensive-linux-64.result == 'cancelled' ||
                  needs.test-expensive-linux-64.result == 'failure' ||
                  needs.test-expensive-linux-aarch64.result == 'cancelled' ||

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -89,6 +89,16 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      - name: Checkout Numbast
+        if: ${{ inputs.test-script == 'run-numbast-mlir-tests' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: NVIDIA/numbast
+          ref: fb743408b07e52beb4980f858ceb648b4e15f619
+          path: numbast-checkout
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
@@ -182,6 +192,7 @@ jobs:
         env:
           CUDA_VER: ${{ matrix.CUDA_VER }}
           LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+          NUMBAST_CHECKOUT: ${{ github.workspace }}/numbast-checkout
           TEST_SCRIPT: ${{ inputs.test-script }}
         run: |
           if [[ "${LOCAL_CTK}" != 1 ]]; then
@@ -190,7 +201,7 @@ jobs:
             export NUMBA_CUDA_TEST_WHEEL_ONLY=1
           fi
           case "${TEST_SCRIPT}" in
-            run-tests|run-coverage-tests) ;;
+            run-tests|run-coverage-tests|run-numbast-mlir-tests) ;;
             *) echo "Unsupported test script: ${TEST_SCRIPT}"; exit 1 ;;
           esac
           "${TEST_SCRIPT}"

--- a/ci/tools/run-numbast-mlir-tests
+++ b/ci/tools/run-numbast-mlir-tests
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+: "${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR:?NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR must be set by ci/tools/env-vars}"
+: "${NUMBAST_CHECKOUT:?NUMBAST_CHECKOUT must point to a Numbast checkout}"
+: "${LOCAL_CTK:?LOCAL_CTK must be set by the workflow}"
+: "${TEST_CUDA_MAJOR:?TEST_CUDA_MAJOR must be set by ci/tools/env-vars}"
+: "${TEST_CUDA_MINOR:?TEST_CUDA_MINOR must be set by ci/tools/env-vars}"
+
+NUMBAST_MLIR_TEST_DIR="${NUMBAST_CHECKOUT}/numbast/src/numbast/experimental/mlir"
+if [[ ! -d "${NUMBAST_MLIR_TEST_DIR}" ]]; then
+  echo "Expected Numbast MLIR tests at ${NUMBAST_MLIR_TEST_DIR}"
+  exit 1
+fi
+
+echo "Installing numba-cuda-mlir wheel"
+wheels=("${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR}"/*.whl)
+if [[ ${#wheels[@]} -ne 1 || ! -e "${wheels[0]}" ]]; then
+  echo "Expected exactly one numba-cuda-mlir wheel in ${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR}, found ${#wheels[@]}"
+  printf '%s\n' "${wheels[@]}"
+  exit 1
+fi
+wheel="${wheels[0]}"
+
+CUDA_BINDINGS_SPEC="cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*"
+if [[ "${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}" == "12.2" ]]; then
+  CUDA_BINDINGS_SPEC="cuda-bindings>=12.9.1,<13.0.0"
+fi
+
+if [[ "${LOCAL_CTK}" == 1 ]]; then
+  python -m pip install "${wheel}" --group "test-cu${TEST_CUDA_MAJOR}" \
+    "${CUDA_BINDINGS_SPEC}" "cuda-core[cu${TEST_CUDA_MAJOR}]"
+else
+  python -m pip install "${wheel}[cu${TEST_CUDA_MAJOR}]" --group "test-cu${TEST_CUDA_MAJOR}" \
+    "${CUDA_BINDINGS_SPEC}" "cuda-core[cu${TEST_CUDA_MAJOR}]" \
+    "cuda-toolkit[cccl,cudart]==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*"
+fi
+
+echo "Installing Numbast dependencies"
+python -m pip install \
+  "numba-cuda>=0.25.0" \
+  "ast_canopy>=0.5.0" \
+  click \
+  jinja2 \
+  pyyaml
+
+echo "Installing Numbast from ${NUMBAST_CHECKOUT}"
+python -m pip install --no-deps "${NUMBAST_CHECKOUT}/numbast"
+
+echo "Checking numba-cuda-mlir and Numbast MLIR imports"
+python - <<'PY'
+import importlib.metadata
+
+import numba_cuda_mlir
+import numbast.experimental.mlir
+
+print(f"numba_cuda_mlir {numba_cuda_mlir.__version__}")
+print(f"numbast {importlib.metadata.version('numbast')}")
+PY
+
+echo "Running Numbast experimental MLIR tests"
+export NUMBA_CUDA_MLIR_ICE_FULL_TB=1
+pytest "${NUMBAST_MLIR_TEST_DIR}" \
+  -v \
+  --tb=short \
+  -o addopts= \
+  --import-mode=importlib


### PR DESCRIPTION
## Summary
- add a CI helper that installs the just-built numba-cuda-mlir wheel and runs Numbast's experimental MLIR tests
- checkout public NVIDIA/numbast at pinned commit fb743408b07e52beb4980f858ceb648b4e15f619 only for the Numbast MLIR lane
- add one linux-64 and one linux-aarch64 CI job, both on Python 3.12 / CUDA 13.2.1 / local CTK, and include them in aggregate checks

## Validation
- bash -n ci/tools/run-numbast-mlir-tests
- parsed changed workflow YAML with Python yaml.safe_load
- simulated both Numbast matrix filters with jq
- git diff --check
- commit hooks: SPDX, YAML, EOF, whitespace, merge-conflict, large-file checks