### PR TITLE
Add Numbast MLIR source CI tests

### DIFF
--- a/.github/actions/fetch_ctk/action.yml
+++ b/.github/actions/fetch_ctk/action.yml
@@ -54,8 +54,8 @@ runs:
       uses: ./.github/actions/install_unix_deps
       continue-on-error: false
       with:
-        dependencies: "zstd curl xz-utils"
-        dependent_exes: "zstd curl xz"
+        dependencies: "zstd curl xz-utils jq"
+        dependent_exes: "zstd curl xz jq"
 
     - name: Download CTK cache
       id: ctk-get-cache
@@ -96,8 +96,9 @@ runs:
             curl -LSs $1 -o $2
           }
           CTK_COMPONENT=$1
-          CTK_COMPONENT_REL_PATH="$(curl -s $CTK_JSON_URL |
-              python -c "import sys, json; print(json.load(sys.stdin)['${CTK_COMPONENT}']['${CTK_SUBDIR}']['relative_path'])")"
+          CTK_COMPONENT_REL_PATH="$(curl -fsSL "$CTK_JSON_URL" |
+              jq -er --arg component "$CTK_COMPONENT" --arg subdir "$CTK_SUBDIR" \
+                '.[$component][$subdir].relative_path')"
           CTK_COMPONENT_URL="${CTK_BASE_URL}/${CTK_COMPONENT_REL_PATH}"
           CTK_COMPONENT_COMPONENT_FILENAME="$(basename $CTK_COMPONENT_REL_PATH)"
           download $CTK_COMPONENT_URL $CTK_COMPONENT_COMPONENT_FILENAME

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,6 +193,28 @@ jobs:
     with:
       host-platform: linux-aarch64
 
+  test-numbast-mlir-linux-64:
+    name: Numbast MLIR Test linux-64
+    if: ${{ github.repository_owner == 'nvidia' }}
+    permissions:
+      contents: read
+    needs:
+      - build-linux-64
+    uses: ./.github/workflows/test-numbast-mlir-linux.yml
+    with:
+      host-platform: linux-64
+
+  test-numbast-mlir-linux-aarch64:
+    name: Numbast MLIR Test linux-aarch64
+    if: ${{ github.repository_owner == 'nvidia' }}
+    permissions:
+      contents: read
+    needs:
+      - build-linux-aarch64
+    uses: ./.github/workflows/test-numbast-mlir-linux.yml
+    with:
+      host-platform: linux-aarch64
+
   # ============== old CI jobs (ci.yaml & pr.yaml) ==============
 
   build-docs:
@@ -235,6 +257,8 @@ jobs:
       - test-expensive-linux-aarch64
       - test-cudf-source-linux-64
       - test-cudf-source-linux-aarch64
+      - test-numbast-mlir-linux-64
+      - test-numbast-mlir-linux-aarch64
       - build-docs
       # - coverage-report
       # - test-simulator
@@ -269,6 +293,10 @@ jobs:
                  needs.test-cudf-source-linux-64.result == 'failure' ||
                  needs.test-cudf-source-linux-aarch64.result == 'cancelled' ||
                  needs.test-cudf-source-linux-aarch64.result == 'failure' ||
+                 needs.test-numbast-mlir-linux-64.result == 'cancelled' ||
+                 needs.test-numbast-mlir-linux-64.result == 'failure' ||
+                 needs.test-numbast-mlir-linux-aarch64.result == 'cancelled' ||
+                 needs.test-numbast-mlir-linux-aarch64.result == 'failure' ||
                  needs.build-docs.result == 'cancelled' ||
                  needs.build-docs.result == 'failure' }}; then
           #        needs.coverage-report.result == 'cancelled' ||

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -67,8 +67,8 @@ jobs:
         uses: ./.github/actions/install_unix_deps
         continue-on-error: false
         with:
-          dependencies: "git jq wget libgl1 libegl1"
-          dependent_exes: "git jq wget"
+          dependencies: "clang git jq wget libgl1 libegl1"
+          dependent_exes: "clang++ git jq wget"
 
       - name: Checkout Numbast
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -139,7 +139,7 @@ jobs:
         with:
           host-platform: ${{ inputs.host-platform }}
           cuda-version: ${{ matrix.CUDA_VER }}
-          cuda-components: "cuda_nvcc,cuda_cudart,cuda_crt,libnvvm,cuda_nvrtc,cuda_cccl,libnvjitlink,cuda_cuobjdump"
+          cuda-components: "cuda_nvcc,cuda_cudart,cuda_crt,libnvvm,cuda_nvrtc,cuda_cccl,libnvjitlink,libcurand,cuda_cuobjdump"
 
       - name: Run Numbast MLIR tests
         env:

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: NVIDIA/numbast
-          ref: 6e41a63efb299e1944fee3fa3a636b41827a21c4
+          ref: f779d7d7f834a7e8b411b4d0bfe6c2fb36a58859
           path: numbast-checkout
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: NVIDIA/numbast
-          ref: fb743408b07e52beb4980f858ceb648b4e15f619
+          ref: d619c135b5d37b054d739f405d11979ebe914644
           path: numbast-checkout
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: NVIDIA/numbast
-          ref: d619c135b5d37b054d739f405d11979ebe914644
+          ref: 6e41a63efb299e1944fee3fa3a636b41827a21c4
           path: numbast-checkout
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -67,19 +67,8 @@ jobs:
         uses: ./.github/actions/install_unix_deps
         continue-on-error: false
         with:
-          dependencies: "ca-certificates gnupg git jq wget libgl1 libegl1"
-          dependent_exes: "gpg git jq wget"
-
-      - name: Install Clang 18
-        run: |
-          wget -qO /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
-          gpg --dearmor --yes -o /usr/share/keyrings/llvm-snapshot.gpg /tmp/llvm-snapshot.gpg.key
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" > /etc/apt/sources.list.d/llvm-toolchain-jammy-18.list
-          apt update
-          apt install -y clang-18
-          ln -sf /usr/bin/clang-18 /usr/local/bin/clang
-          ln -sf /usr/bin/clang++-18 /usr/local/bin/clang++
-          clang++ --version
+          dependencies: "bzip2 ca-certificates git jq wget libgl1 libegl1"
+          dependent_exes: "bzip2 git jq wget"
 
       - name: Checkout Numbast
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -136,12 +125,21 @@ jobs:
         run: |
           echo "LD_LIBRARY_PATH=$(pwd)/llvm-modern-install/lib:$(pwd)/llvm7-install/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
 
-      - name: Set up Python ${{ matrix.PY_VER }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: ${{ matrix.PY_VER }}
-        env:
-          AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
+      - name: Set up Miniforge Python ${{ matrix.PY_VER }}
+        run: |
+          MINIFORGE_DIR="/tmp/miniforge"
+          MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh"
+          if [[ ! -x "${MINIFORGE_DIR}/bin/mamba" ]]; then
+            wget -q "${MINIFORGE_URL}" -O /tmp/miniforge.sh
+            bash /tmp/miniforge.sh -b -p "${MINIFORGE_DIR}"
+            rm /tmp/miniforge.sh
+          fi
+          "${MINIFORGE_DIR}/bin/mamba" create -y -n numbast-mlir \
+            -c conda-forge \
+            "python=${{ matrix.PY_VER }}" \
+            "clangdev=18" \
+            pip
+          "${MINIFORGE_DIR}/bin/conda" run -n numbast-mlir clang++ --version
 
       - name: Set up mini CTK
         if: ${{ matrix.LOCAL_CTK == '1' }}
@@ -157,7 +155,7 @@ jobs:
           CUDA_VER: ${{ matrix.CUDA_VER }}
           LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
           NUMBAST_CHECKOUT: ${{ github.workspace }}/numbast-checkout
-        run: run-numbast-mlir-tests
+        run: /tmp/miniforge/bin/conda run -n numbast-mlir ./ci/tools/run-numbast-mlir-tests
 
       - name: Upload Numbast MLIR test results
         if: always()

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "CI: Test Numbast MLIR"
+
+on:
+  workflow_call:
+    inputs:
+      host-platform:
+        type: string
+        required: true
+      matrix_filter:
+        type: string
+        default: "."
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -xeuo pipefail {0}
+
+jobs:
+  compute-matrix:
+    runs-on: ubuntu-latest
+    env:
+      ARCH: ${{ (inputs.host-platform == 'linux-64' && 'amd64') ||
+                (inputs.host-platform == 'linux-aarch64' && 'arm64') }}
+    outputs:
+      MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
+    steps:
+      - name: Checkout ${{ github.event.repository.name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Compute Numbast MLIR test matrix
+        id: compute-matrix
+        run: |
+          TEST_MATRIX=$(yq -o json ".linux.numbast-mlir // [] | map(select(.ARCH == \"${ARCH}\"))" ci/test-matrix.yml)
+          MATRIX=$(echo "$TEST_MATRIX" | jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end')
+          echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
+
+  test:
+    name: numbast-mlir, py${{ matrix.PY_VER }}, ${{ matrix.CUDA_VER }}, ${{ matrix.GPU }}
+    needs: compute-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
+    runs-on: "${{ matrix.FLAVOR || 'linux' }}-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-${{ matrix.GPU_COUNT }}"
+    if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
+    container:
+      options: -u root --security-opt seccomp=unconfined --shm-size 16g
+      image: ubuntu:22.04
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+        PIP_CACHE_DIR: "/tmp/pip-cache"
+    steps:
+      - name: Ensure GPU is working
+        run: nvidia-smi
+
+      - name: Checkout ${{ github.event.repository.name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Checkout Numbast
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: NVIDIA/numbast
+          ref: fb743408b07e52beb4980f858ceb648b4e15f619
+          path: numbast-checkout
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        continue-on-error: true
+        with:
+          enable-apt: true
+
+      - name: Install dependencies
+        uses: ./.github/actions/install_unix_deps
+        continue-on-error: false
+        with:
+          dependencies: "jq wget libgl1 libegl1"
+          dependent_exes: "jq wget"
+
+      - name: Set environment variables
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          HOST_PLATFORM: ${{ inputs.host-platform }}
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+          PY_VER: ${{ matrix.PY_VER }}
+          SHA: ${{ github.sha }}
+        run: ./ci/tools/env-vars test
+
+      - name: Download numba-cuda-mlir build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: ${{ env.NUMBA_CUDA_MLIR_CUDA_ARTIFACT_NAME }}
+          path: ${{ env.NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR }}
+
+      - name: Display structure of downloaded numba-cuda-mlir artifacts
+        run: |
+          pwd
+          ls -lahR $NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR
+
+      - name: Determine LLVM Python tag
+        run: |
+          PY_VER_FMT=$(echo "${{ matrix.PY_VER }}" | tr -d '.')
+          echo "LLVM_PY_TAG=cp${PY_VER_FMT}" >> "$GITHUB_ENV"
+
+      - name: Download LLVM Modern artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: llvm-modern-install-${{ env.LLVM_PY_TAG }}-${{ inputs.host-platform }}
+          path: llvm-modern-install
+
+      - name: Download LLVM 7 artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: llvm7-install-${{ inputs.host-platform }}
+          path: llvm7-install
+
+      - name: Fix LLVM artifact permissions
+        run: |
+          chmod -R +x llvm-modern-install/bin/ llvm7-install/bin/ || true
+          chmod -R +x llvm-modern-install/lib/ llvm7-install/lib/ || true
+
+      - name: Set LLVM library paths
+        run: |
+          echo "LD_LIBRARY_PATH=$(pwd)/llvm-modern-install/lib:$(pwd)/llvm7-install/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+
+      - name: Set up Python ${{ matrix.PY_VER }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ matrix.PY_VER }}
+        env:
+          AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
+
+      - name: Set up mini CTK
+        if: ${{ matrix.LOCAL_CTK == '1' }}
+        uses: ./.github/actions/fetch_ctk
+        continue-on-error: false
+        with:
+          host-platform: ${{ inputs.host-platform }}
+          cuda-version: ${{ matrix.CUDA_VER }}
+          cuda-components: "cuda_nvcc,cuda_cudart,cuda_crt,libnvvm,cuda_nvrtc,cuda_cccl,libnvjitlink,cuda_cuobjdump"
+
+      - name: Run Numbast MLIR tests
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+          NUMBAST_CHECKOUT: ${{ github.workspace }}/numbast-checkout
+        run: run-numbast-mlir-tests
+
+      - name: Upload Numbast MLIR test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: numbast-mlir-test-results-${{ inputs.host-platform }}-py${{ matrix.PY_VER }}-cu${{ env.TEST_CUDA_MAJOR }}
+          path: numbast-mlir-junit-results.xml
+          if-no-files-found: ignore

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -57,15 +57,6 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Checkout Numbast
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: NVIDIA/numbast
-          ref: d619c135b5d37b054d739f405d11979ebe914644
-          path: numbast-checkout
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
@@ -76,8 +67,17 @@ jobs:
         uses: ./.github/actions/install_unix_deps
         continue-on-error: false
         with:
-          dependencies: "jq wget libgl1 libegl1"
-          dependent_exes: "jq wget"
+          dependencies: "git jq wget libgl1 libegl1"
+          dependent_exes: "git jq wget"
+
+      - name: Checkout Numbast
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: NVIDIA/numbast
+          ref: d619c135b5d37b054d739f405d11979ebe914644
+          path: numbast-checkout
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Set environment variables
         env:

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -67,8 +67,19 @@ jobs:
         uses: ./.github/actions/install_unix_deps
         continue-on-error: false
         with:
-          dependencies: "clang git jq wget libgl1 libegl1"
-          dependent_exes: "clang++ git jq wget"
+          dependencies: "ca-certificates gnupg git jq wget libgl1 libegl1"
+          dependent_exes: "gpg git jq wget"
+
+      - name: Install Clang 18
+        run: |
+          wget -qO /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+          gpg --dearmor --yes -o /usr/share/keyrings/llvm-snapshot.gpg /tmp/llvm-snapshot.gpg.key
+          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" > /etc/apt/sources.list.d/llvm-toolchain-jammy-18.list
+          apt update
+          apt install -y clang-18
+          ln -sf /usr/bin/clang-18 /usr/local/bin/clang
+          ln -sf /usr/bin/clang++-18 /usr/local/bin/clang++
+          clang++ --version
 
       - name: Checkout Numbast
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -74,4 +74,7 @@ linux:
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
+  numbast-mlir:
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
+    - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
   nightly: []

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -75,6 +75,8 @@ linux:
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
   numbast-mlir:
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
+    - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.2.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
   nightly: []

--- a/ci/tools/run-numbast-mlir-tests
+++ b/ci/tools/run-numbast-mlir-tests
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Run Numbast's experimental MLIR backend tests against the just-built
+# numba-cuda-mlir wheel.
+
+set -euo pipefail
+
+: "${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR:?NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR must be set by ci/tools/env-vars}"
+: "${NUMBAST_CHECKOUT:?NUMBAST_CHECKOUT must point to a Numbast checkout}"
+: "${LOCAL_CTK:?LOCAL_CTK must be set by the workflow}"
+: "${TEST_CUDA_MAJOR:?TEST_CUDA_MAJOR must be set by ci/tools/env-vars}"
+: "${TEST_CUDA_MINOR:?TEST_CUDA_MINOR must be set by ci/tools/env-vars}"
+
+NUMBAST_MLIR_TEST_DIR="${NUMBAST_CHECKOUT}/numbast/src/numbast/experimental/mlir"
+if [[ ! -d "${NUMBAST_MLIR_TEST_DIR}" ]]; then
+  echo "Expected Numbast MLIR tests at ${NUMBAST_MLIR_TEST_DIR}"
+  exit 1
+fi
+
+echo "Installing numba-cuda-mlir wheel"
+wheels=("${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR}"/*.whl)
+if [[ ${#wheels[@]} -ne 1 || ! -e "${wheels[0]}" ]]; then
+  echo "Expected exactly one numba-cuda-mlir wheel in ${NUMBA_CUDA_MLIR_CUDA_ARTIFACTS_DIR}, found ${#wheels[@]}"
+  printf '%s\n' "${wheels[@]}"
+  exit 1
+fi
+wheel="${wheels[0]}"
+
+CUDA_BINDINGS_SPEC="cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*"
+if [[ "${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}" == "12.2" ]]; then
+  CUDA_BINDINGS_SPEC="cuda-bindings>=12.9.1,<13.0.0"
+fi
+
+python -m pip install --upgrade pip
+if [[ "${LOCAL_CTK}" == 1 ]]; then
+  python -m pip install "${wheel}" --group "test-cu${TEST_CUDA_MAJOR}" \
+    "${CUDA_BINDINGS_SPEC}" "cuda-core[cu${TEST_CUDA_MAJOR}]"
+else
+  python -m pip install "${wheel}[cu${TEST_CUDA_MAJOR}]" --group "test-cu${TEST_CUDA_MAJOR}" \
+    "${CUDA_BINDINGS_SPEC}" "cuda-core[cu${TEST_CUDA_MAJOR}]" \
+    "cuda-toolkit[cccl,cudart]==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*"
+fi
+
+echo "Installing Numbast dependencies"
+python -m pip install \
+  "ast_canopy==0.9.0" \
+  click \
+  jinja2 \
+  pyyaml
+
+echo "Installing Numbast from ${NUMBAST_CHECKOUT}"
+python -m pip install --no-deps "${NUMBAST_CHECKOUT}/numbast"
+
+echo "Checking numba-cuda-mlir and Numbast MLIR imports"
+python - <<'PY'
+import importlib.metadata
+
+import numba_cuda_mlir
+import numbast.experimental.mlir
+
+print(f"numba_cuda_mlir {numba_cuda_mlir.__version__}")
+print(f"numbast {importlib.metadata.version('numbast')}")
+PY
+
+echo "Running Numbast experimental MLIR tests"
+export NUMBA_CUDA_MLIR_ICE_FULL_TB=1
+pytest "${NUMBAST_MLIR_TEST_DIR}" \
+  -v \
+  --tb=short \
+  --junit-xml=numbast-mlir-junit-results.xml \
+  -o addopts= \
+  --import-mode=importlib \
+  "$@"


### PR DESCRIPTION
## Summary
- add a dedicated Numbast MLIR reusable workflow modeled after the cuDF source workflow from #51
- add `numbast-mlir` matrix coverage for Python 3.12 on CUDA 12.9.1 and 13.2.1 for both Linux architectures: `linux-64`/L4 and `linux-aarch64`/A100
- checkout public `NVIDIA/numbast` at pinned commit `f779d7d7f834a7e8b411b4d0bfe6c2fb36a58859` from Numbast PR #365 and run its experimental MLIR test subtree against the just-built `numba-cuda-mlir` wheel
- provision the Numbast MLIR test lane with Miniforge and `clangdev=18`, which matches the supported ast_canopy LLVM range and provides Clang resource headers
- make `fetch_ctk` parse CUDA redistrib metadata with `jq` instead of ambient `python`, so Miniforge-only jobs can fetch CUDA 12.9.1 mini CTK components
- include the Numbast MLIR jobs in the aggregate `checks` job while preserving the cuDF source jobs from #51

## Validation
- `bash -n ci/tools/run-numbast-mlir-tests`
- YAML parse for `.github/actions/fetch_ctk/action.yml`, `.github/workflows/test-numbast-mlir-linux.yml`, and `ci/test-matrix.yml`
- local `jq` selector test for `.[$component][$subdir].relative_path`
- Python matrix assertion confirms four Numbast MLIR rows: amd64/12.9.1, amd64/13.2.1, arm64/12.9.1, arm64/13.2.1
- `git diff --check`
- verified the Numbast pin matches the current PR #365 head `f779d7d7f834a7e8b411b4d0bfe6c2fb36a58859`

Supersedes #67, which was based on a stale local `main` and did not include the cuDF source CI jobs from #51.