### PR TITLE
Remove conda install documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 Numba-CUDA-MLIR can be installed:
 
-- [With the package managers, pip and conda](#option-1-pre-built-packages):
+- [With the package manager pip](#option-1-pre-built-packages):
   - Recommended for most users.
 - [From source, with pre-built LLVM
   binaries](#option-2-editable-install-with-pre-built-llvm):
@@ -18,7 +18,7 @@ Numba-CUDA-MLIR can be installed:
   - The `cuda.core` and `cuda-bindings` packages
   - NumPy >= 1.22
 - CUDA Toolkit components (CUDA Runtime, NVCC, NVRTC, nvJitLink, and CCCL)
-  installed via pip or conda, or a system package manager (Linux).
+  installed via pip or a system package manager (Linux).
 - NVIDIA GPU with Compute Capability 7.0 or greater and a compatible driver:
   - &gt;= r525 for CUDA 12.x
   - &gt;= r580 for CUDA 13.x
@@ -50,15 +50,6 @@ Development and test dependencies are defined as
 pip install --group dev   # pre-commit tools and linters
 pip install --group test  # pytest and required plugins
 ```
-
-Or, install with conda:
-
-```
-conda install numba-cuda-mlir
-```
-
-Appropriate CUDA toolkit dependencies will be installed for the `cuda-version`
-package in the conda environment.
 
 ### Top-of-tree builds
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Install with pip:
 pip install numba-cuda-mlir[cu13]  # or [cu12] if using CUDA 12
 ```
 
-or using conda:
-
-```
-conda install -c conda-forge numba-cuda-mlir
-```
-
 Writing and executing a simple vector add kernel:
 
 ```python
@@ -73,7 +67,7 @@ documentation for further details.
   - The `cuda.core` and `cuda-bindings` packages
   - NumPy >= 1.22
 - CUDA Toolkit components (CUDA Runtime, NVCC, NVRTC, nvJitLink, and CCCL)
-  installed via pip or conda, or a system package manager (Linux).
+  installed via pip or a system package manager (Linux).
 - NVIDIA GPU with Compute Capability 7.0 or greater and a compatible driver:
   - &gt;= r525 for CUDA 12.x
   - &gt;= r580 for CUDA 13.x

--- a/docs/source/user/installation.rst
+++ b/docs/source/user/installation.rst
@@ -30,21 +30,13 @@ For further information about version compatibility between toolkit and driver
 versions, refer to :ref:`minor-version-compatibility`.
 
 
-Installation with a Python package manager
-==========================================
+Installation with pip
+=====================
 
-Conda users can install the CUDA Toolkit into a conda environment::
-
-    $ conda install -c conda-forge numba-cuda-mlir "cuda-version=12"
-
-Or for CUDA 13::
-
-    $ conda install -c conda-forge numba-cuda-mlir "cuda-version=13"
-
-Alternatively, you can install all CUDA 12 dependencies from PyPI via ``pip``::
+Install CUDA 12 dependencies from PyPI via ``pip``::
 
     $ pip install numba-cuda-mlir[cu12]
 
-CUDA 13 dependencies can be installed via ``pip`` with::
+CUDA 13 dependencies can be installed with::
 
     $ pip install numba-cuda-mlir[cu13]


### PR DESCRIPTION
## Summary

- Remove conda package installation instructions from the README quick start.
- Remove conda installation examples from the user installation guide.
- Remove conda install guidance for numba-cuda-mlir from INSTALL.md.

## Validation

- `git diff --check`
- `rg -n "conda|conda-forge|Anaconda|pip or conda|using conda" README.md INSTALL.md docs/source/user/installation.rst` returns no matches.
- `rg -n "conda install.*numba-cuda-mlir|numba-cuda-mlir.*conda|Conda users|using conda|pip or conda" README.md docs INSTALL.md` returns no matches.