### PR TITLE
Expose normalized launch metadata during kernel dispatch

### DIFF
--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 import collections
 from contextlib import contextmanager
+from dataclasses import dataclass
 import sys
 import os
-from functools import cached_property, lru_cache
+import threading
+from functools import cached_property
 
 from numba_cuda_mlir.typing import unicode
 
@@ -50,7 +52,6 @@ import numpy as np
 from numba_cuda_mlir.errors import ExtensionError
 from numba_cuda_mlir import _cext
 from numba_cuda_mlir._cext import LaunchConfiguration
-import threading
 import cProfile
 import pstats
 
@@ -293,6 +294,127 @@ def _ensure_numba_cuda_context():
     return devices.get_context()
 
 
+_MISSING = object()
+_CONFIGURE_CACHE_SIZE = 128
+_CONFIGURE_CACHE_STALE_RETRY_LIMIT = 8
+# Keep this larger than configure()'s cache so any marshaller retained by
+# configure() also has room to keep its native dispatcher entry live.
+_LAUNCH_CONFIG_CACHE_SIZE = _CONFIGURE_CACHE_SIZE * 2
+
+
+def _env_int(name, default):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        warnings.warn(
+            f"Ignoring invalid {name}={value!r}; expected an integer.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return default
+
+
+_OLD_DISPATCHER_RETAIN_LIMIT = _env_int("NUMBA_CUDA_MLIR_OLD_DISPATCHER_RETAIN_LIMIT", 1024)
+
+
+@dataclass(frozen=True)
+class LaunchConfigInspectableKey:
+    argtypes: tuple
+    launch_config_key: tuple
+
+
+def _is_launch_config_key_tuple(value):
+    return (
+        isinstance(value, tuple)
+        and len(value) == 4
+        and all(isinstance(item, tuple) and len(item) == 2 for item in value)
+        and value[0][0] == "grid"
+        and value[1][0] == "block"
+        and value[2][0] == "sharedmem"
+        and value[3][0] == "cluster"
+    )
+
+
+def _is_launch_config_dict(value):
+    return isinstance(value, dict) and "grid" in value and "block" in value
+
+
+def _launch_config_key(launch_config):
+    """Return the specialization key for a configure-produced launch config."""
+    if launch_config is None:
+        return None
+    block = launch_config.get("block")
+    if block is None:
+        raise ValueError("launch_config must contain a 'block' entry")
+    if not isinstance(block, tuple):
+        raise TypeError("launch_config 'block' must be a normalized tuple")
+    grid = launch_config.get("grid")
+    if grid is None:
+        raise ValueError("launch_config must contain a 'grid' entry")
+    if not isinstance(grid, tuple):
+        raise TypeError("launch_config 'grid' must be a normalized tuple")
+    cluster = launch_config.get("cluster")
+    if cluster is not None and not isinstance(cluster, tuple):
+        raise TypeError("launch_config 'cluster' must be a normalized tuple or None")
+    sharedmem = launch_config.get("sharedmem", 0)
+    if sharedmem is None:
+        sharedmem = 0
+    try:
+        sharedmem = int(sharedmem)
+    except (TypeError, ValueError):
+        raise TypeError("launch_config 'sharedmem' must be integer-convertible") from None
+    return (
+        ("grid", grid),
+        ("block", block),
+        ("sharedmem", sharedmem),
+        ("cluster", cluster),
+    )
+
+
+def _launch_config_dict_from_key(launch_config_key):
+    if not _is_launch_config_key_tuple(launch_config_key):
+        raise TypeError("launch_config_key must be a normalized launch-config key")
+    return {name: value for name, value in launch_config_key}
+
+
+def _normalize_launch_sharedmem(sharedmem):
+    if sharedmem is None:
+        return 0
+    try:
+        return int(sharedmem)
+    except (TypeError, ValueError):
+        raise TypeError("launch_config 'sharedmem' must be integer-convertible") from None
+
+
+def _validate_configure_cache_key(cache_key):
+    try:
+        hash(cache_key)
+    except TypeError:
+        raise TypeError("kernel launch configuration values must be hashable") from None
+
+
+def _extensions_use_launch_config(extensions):
+    return any(getattr(ext, "uses_launch_config", False) for ext in extensions)
+
+
+class _ObjectIdentityKey:
+    __slots__ = ("obj",)
+
+    def __init__(self, obj):
+        # Keep a strong reference so cached identity keys cannot collide with a
+        # newly allocated extension after the original extension is removed.
+        self.obj = obj
+
+    def __hash__(self):
+        return id(self.obj)
+
+    def __eq__(self, other):
+        return isinstance(other, _ObjectIdentityKey) and self.obj is other.obj
+
+
 class _ArgMarshaller:
     """
     Handles copying numpy arrays to the device and back to the host
@@ -301,11 +423,30 @@ class _ArgMarshaller:
     But numba-cuda supports it, so we must, for now.
     """
 
-    def __init__(self, launcher, extensions=None, dispatcher=None):
+    def __init__(
+        self,
+        launcher,
+        extensions=None,
+        dispatcher=None,
+        launch_config=None,
+        kernel_dispatcher=None,
+        launch_config_generation=None,
+        stream_ref=None,
+    ):
         self._launcher = launcher
         self._callbacks = []
-        self._extensions = extensions or []
+        # Snapshot extensions for this configured launcher; configure() cache keys
+        # include extension identities so replacing the extension list builds a
+        # distinct marshaller.
+        self._has_extension_snapshot = extensions is not None
+        self._extensions = list(extensions) if extensions is not None else []
         self._dispatcher = dispatcher
+        self._launch_config = launch_config
+        self._kernel_dispatcher = kernel_dispatcher
+        self._launch_config_generation = launch_config_generation
+        self._stream_ref = stream_ref
+        self._kernel_dispatcher_registered = False
+        self._kernel_dispatcher_registration_lock = threading.Lock()
         self._sig_cache = {}  # {type_key: (argtypes, fast_ok)}
         self._array_sig_cache = {}  # {type_key: [(argtypes, ((idx, array_key), ...))]}
 
@@ -392,16 +533,41 @@ class _ArgMarshaller:
     def _coerce_to_overload(self, device_args, argtypes):
         """Coerce scalar arguments to match a pre-compiled overload signature."""
         disp = self._dispatcher
-        if disp is None or disp._can_compile or not disp.overloads:
+        if disp is None or disp._can_compile:
             return device_args, argtypes
 
-        for sig_args in disp.overloads:
-            if len(sig_args) == len(argtypes) and all(
-                disp._can_reuse_overload(s, r) for s, r in zip(sig_args, argtypes)
-            ):
+        extensions = (
+            self._extensions if self._has_extension_snapshot else getattr(disp, "extensions", ())
+        )
+        active_launch_config = (
+            self._launch_config if _extensions_use_launch_config(extensions) else None
+        )
+        active_launch_config_key = _launch_config_key(active_launch_config)
+        if active_launch_config_key is None:
+            overload_argtypes = tuple(disp.overloads)
+            if not overload_argtypes:
                 return device_args, argtypes
+            for sig_args in overload_argtypes:
+                if len(sig_args) == len(argtypes) and all(
+                    disp._can_reuse_overload(s, r) for s, r in zip(sig_args, argtypes)
+                ):
+                    return device_args, argtypes
+            best, has_match = disp._resolve_overload(argtypes, allow_unsafe=True)
+        else:
+            overload_argtypes = disp._launch_config_overload_argtypes(active_launch_config_key)
+            if not overload_argtypes:
+                return device_args, argtypes
+            for sig_args in overload_argtypes:
+                if len(sig_args) == len(argtypes) and all(
+                    disp._can_reuse_overload(s, r) for s, r in zip(sig_args, argtypes)
+                ):
+                    return device_args, argtypes
+            best, has_match = disp._resolve_overload(
+                argtypes,
+                allow_unsafe=True,
+                candidate_sig_args=overload_argtypes,
+            )
 
-        best, has_match = disp._resolve_overload(argtypes, allow_unsafe=True)
         if not has_match or len(best) != 1:
             return device_args, argtypes
 
@@ -431,8 +597,48 @@ class _ArgMarshaller:
 
     def _launch(self, argtypes, launch_args):
         """Set compile arg types and invoke the C++ launcher with error handling."""
-        _compile_arg_types.types = argtypes
+        # Preserve existing thread-local state for nested launches triggered by
+        # compile-time helpers.
+        previous_types = getattr(_compile_arg_types, "types", _MISSING)
+        previous_launch_config = getattr(_compile_arg_types, "launch_config", _MISSING)
+        previous_extensions = getattr(_compile_arg_types, "extensions", _MISSING)
         try:
+            _compile_arg_types.types = argtypes
+            if self._launch_config is not None:
+                _compile_arg_types.launch_config = self._launch_config
+            elif hasattr(_compile_arg_types, "launch_config"):
+                delattr(_compile_arg_types, "launch_config")
+            if self._has_extension_snapshot:
+                _compile_arg_types.extensions = self._extensions
+            elif self._dispatcher is not None and hasattr(self._dispatcher, "extensions"):
+                _compile_arg_types.extensions = self._dispatcher.extensions
+            elif hasattr(_compile_arg_types, "extensions"):
+                delattr(_compile_arg_types, "extensions")
+            if (
+                self._dispatcher is not None
+                and self._launch_config is not None
+                and self._kernel_dispatcher is not None
+            ):
+                with self._kernel_dispatcher_registration_lock:
+                    if self._kernel_dispatcher_registered and hasattr(
+                        self._dispatcher, "_is_kernel_dispatcher_registered"
+                    ):
+                        self._kernel_dispatcher_registered = (
+                            self._dispatcher._is_kernel_dispatcher_registered(
+                                self._launch_config,
+                                self._kernel_dispatcher,
+                                self._launch_config_generation,
+                            )
+                        )
+                    if not self._kernel_dispatcher_registered:
+                        self._kernel_dispatcher_registered = (
+                            self._dispatcher._remember_kernel_dispatcher(
+                                self._launch_config,
+                                self._kernel_dispatcher,
+                                self._launch_config_generation,
+                                replace_existing=False,
+                            )
+                        )
             return self._launcher(*launch_args)
         except UserFacingInternalCompilerError as e:
             if os.environ.get("NUMBA_CUDA_MLIR_ICE_FULL_TB", "0").strip() == "1":
@@ -441,7 +647,21 @@ class _ArgMarshaller:
         except RuntimeError as e:
             _raise_as_cuda_error(e)
         finally:
-            _compile_arg_types.types = None
+            if previous_types is _MISSING:
+                if hasattr(_compile_arg_types, "types"):
+                    delattr(_compile_arg_types, "types")
+            else:
+                _compile_arg_types.types = previous_types
+            if previous_launch_config is _MISSING:
+                if hasattr(_compile_arg_types, "launch_config"):
+                    delattr(_compile_arg_types, "launch_config")
+            else:
+                _compile_arg_types.launch_config = previous_launch_config
+            if previous_extensions is _MISSING:
+                if hasattr(_compile_arg_types, "extensions"):
+                    delattr(_compile_arg_types, "extensions")
+            else:
+                _compile_arg_types.extensions = previous_extensions
 
     def __call__(self, *args):
         nargs = len(args)
@@ -551,6 +771,19 @@ class _ArgMarshaller:
         return result
 
 
+class _ConfigureProxy:
+    __slots__ = ("_dispatcher",)
+
+    def __init__(self, dispatcher):
+        self._dispatcher = dispatcher
+
+    def __call__(self, *args, **kwargs):
+        return type(self._dispatcher).configure(self._dispatcher, *args, **kwargs)
+
+    def cache_clear(self):
+        self._dispatcher._clear_configure_cache()
+
+
 class _ForAll:
     """Deferred forall launcher to compute optimal block size at call time."""
 
@@ -575,7 +808,10 @@ class _ForAll:
         try:
             from cuda.bindings import driver
 
-            cres = next(iter(self.dispatcher.overloads.values()))
+            compile_results = list(self.dispatcher.overloads.values())
+            if not compile_results and hasattr(self.dispatcher, "_launch_config_compile_results"):
+                compile_results = self.dispatcher._launch_config_compile_results()
+            cres = compile_results[0]
             cufunc = cres._codelibrary.get_cufunc()
             grid_size, block_size = driver.cuOccupancyMaxPotentialBlockSize(
                 cufunc._handle, None, self.sharedmem, 1024
@@ -1192,7 +1428,19 @@ class MLIR(_get_cuda_base()):
 
 
 _CompileStats = collections.namedtuple(
-    "_CompileStats", ("cache_path", "cache_hits", "cache_misses")
+    "_CompileStats",
+    (
+        "cache_path",
+        "cache_hits",
+        "cache_misses",
+    ),
+)
+_LaunchConfigCompileStats = collections.namedtuple(
+    "_LaunchConfigCompileStats",
+    (
+        "cache_hits",
+        "cache_misses",
+    ),
 )
 
 
@@ -1230,16 +1478,24 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         # created with inline="always".
         self._compiler.pipeline_class = get_compiler_class(targetoptions)
 
-        self._c = _cext.KernelDispatcher(
-            self._compile,
-            get_constant_args(py_func),
-            _ensure_numba_cuda_context,
-        )
+        self._launch_config_lock = threading.RLock()
+        # Launch-specialized overloads are retained until either recompile() or
+        # cache eviction, whichever happens first. Retained marshallers can
+        # reinstall their native dispatcher after dispatcher cache eviction, but
+        # recompile() invalidates old launch-config generations.
+        self._launch_config_overloads = {}
+        self._launch_config_dispatchers = collections.OrderedDict()
+        self._launch_config_generation = 0
+        self._c = self._new_kernel_dispatcher()
         self.extensions = targetoptions.get("extensions") or []
         self._specialized = False
         self.specializations = {}
         self._module_setup_callbacks = []
         self._module_teardown_callbacks = []
+        self._old_dispatchers = []
+        self._configure_cache = collections.OrderedDict()
+        self._configure_cache_inflight = {}
+        self.configure = _ConfigureProxy(self)
         for link_item in targetoptions.get("link", []):
             if hasattr(link_item, "setup_callback") and link_item.setup_callback:
                 self._module_setup_callbacks.append(link_item.setup_callback)
@@ -1250,6 +1506,9 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self._cache = NullCache()
         self._cache_hits = collections.Counter()
         self._cache_misses = collections.Counter()
+        self._launch_config_cache_hits = collections.Counter()
+        self._launch_config_cache_misses = collections.Counter()
+        self._launch_config_cache_notice_emitted = False
 
         # Checked by type inferer (numba-cuda's typeinfer.py) to detect self-recursive calls
         self._is_compiling = False
@@ -1262,12 +1521,247 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
     def _numba_type_(self):
         return MLIRDispatcherType(self)
 
-    @lru_cache(maxsize=128)
+    def _new_kernel_dispatcher(self):
+        return _cext.KernelDispatcher(
+            self._compile,
+            get_constant_args(self.py_func),
+            _ensure_numba_cuda_context,
+        )
+
+    @property
+    def _launch_config_enabled(self):
+        return _extensions_use_launch_config(self.extensions)
+
+    def _get_kernel_dispatcher(self, launch_config):
+        dispatcher, _ = self._get_kernel_dispatcher_and_generation(launch_config)
+        return dispatcher
+
+    def _get_kernel_dispatcher_and_generation(self, launch_config):
+        self._ensure_dispatcher_state()
+        if not self._launch_config_enabled:
+            return self._c, None
+        launch_config_key = _launch_config_key(launch_config)
+        if launch_config_key is None:
+            return self._c, None
+
+        while True:
+            with self._launch_config_lock:
+                dispatcher = self._launch_config_dispatchers.get(launch_config_key)
+                generation = self._launch_config_generation
+                if dispatcher is not None:
+                    self._launch_config_dispatchers.move_to_end(launch_config_key)
+                    return dispatcher, generation
+
+            # Construct outside the lock. If another thread wins the insertion
+            # race or recompile() advances the generation, this passive native
+            # dispatcher is discarded without ever launching.
+            dispatcher = self._new_kernel_dispatcher()
+            with self._launch_config_lock:
+                if generation != self._launch_config_generation:
+                    continue
+                existing = self._launch_config_dispatchers.get(launch_config_key)
+                if existing is not None:
+                    self._launch_config_dispatchers.move_to_end(launch_config_key)
+                    return existing, generation
+                self._remember_kernel_dispatcher_locked(launch_config_key, dispatcher)
+                return dispatcher, generation
+
+    def _remember_kernel_dispatcher(
+        self,
+        launch_config,
+        kernel_dispatcher,
+        launch_config_generation=None,
+        replace_existing=True,
+    ):
+        self._ensure_dispatcher_state()
+        launch_config_key = _launch_config_key(launch_config)
+        if launch_config_key is None:
+            return False
+        with self._launch_config_lock:
+            if (
+                launch_config_generation is not None
+                and launch_config_generation != self._launch_config_generation
+            ):
+                return False
+            return self._remember_kernel_dispatcher_locked(
+                launch_config_key,
+                kernel_dispatcher,
+                replace_existing=replace_existing,
+            )
+
+    def _is_kernel_dispatcher_registered(
+        self, launch_config, kernel_dispatcher, launch_config_generation=None
+    ):
+        self._ensure_dispatcher_state()
+        launch_config_key = _launch_config_key(launch_config)
+        if launch_config_key is None:
+            return False
+        with self._launch_config_lock:
+            if (
+                launch_config_generation is not None
+                and launch_config_generation != self._launch_config_generation
+            ):
+                return False
+            return self._launch_config_dispatchers.get(launch_config_key) is kernel_dispatcher
+
+    def _ensure_dispatcher_state(self):
+        # ReduceMixin restore paths may bypass __init__, so recreate the new
+        # mutable caches lazily before paths that append or clear them.
+        if not hasattr(self, "_launch_config_lock"):
+            self._launch_config_lock = threading.RLock()
+        if not hasattr(self, "_launch_config_overloads"):
+            self._launch_config_overloads = {}
+        if not hasattr(self, "_launch_config_dispatchers"):
+            self._launch_config_dispatchers = collections.OrderedDict()
+        if not hasattr(self, "_launch_config_generation"):
+            self._launch_config_generation = 0
+        if not hasattr(self, "_launch_config_cache_misses"):
+            self._launch_config_cache_misses = collections.Counter()
+        if not hasattr(self, "_launch_config_cache_hits"):
+            self._launch_config_cache_hits = collections.Counter()
+        if not hasattr(self, "_launch_config_cache_notice_emitted"):
+            self._launch_config_cache_notice_emitted = False
+        if not hasattr(self, "_old_dispatchers"):
+            self._old_dispatchers = []
+        if not hasattr(self, "_configure_cache"):
+            self._configure_cache = collections.OrderedDict()
+        if not hasattr(self, "_configure_cache_inflight"):
+            self._configure_cache_inflight = {}
+        if "configure" not in self.__dict__:
+            self.configure = _ConfigureProxy(self)
+
+    def _clear_configure_cache(self):
+        self._ensure_dispatcher_state()
+        with self._launch_config_lock:
+            self._configure_cache.clear()
+            inflight = tuple(self._configure_cache_inflight.values())
+            self._configure_cache_inflight.clear()
+            for event in inflight:
+                event.set()
+
+    def _retain_old_dispatcher(self, kernel_dispatcher):
+        self._ensure_dispatcher_state()
+        self._old_dispatchers.append(kernel_dispatcher)
+        overflow = len(self._old_dispatchers) - _OLD_DISPATCHER_RETAIN_LIMIT
+        if overflow > 0:
+            # The cap trades crash-avoidance retention against unbounded growth;
+            # users with very long-lived dispatchers can raise it via the env var.
+            del self._old_dispatchers[:overflow]
+
+    def _remember_kernel_dispatcher_locked(
+        self, launch_config_key, kernel_dispatcher, replace_existing=True
+    ):
+        existing = self._launch_config_dispatchers.get(launch_config_key)
+        if existing is not None:
+            if existing is not kernel_dispatcher:
+                if not replace_existing:
+                    return False
+                self._retain_old_dispatcher(existing)
+                self._launch_config_dispatchers[launch_config_key] = kernel_dispatcher
+            self._launch_config_dispatchers.move_to_end(launch_config_key)
+            return True
+        self._launch_config_dispatchers[launch_config_key] = kernel_dispatcher
+        self._launch_config_dispatchers.move_to_end(launch_config_key)
+        while len(self._launch_config_dispatchers) > _LAUNCH_CONFIG_CACHE_SIZE:
+            evicted_key, evicted_dispatcher = self._launch_config_dispatchers.popitem(last=False)
+            self._retain_old_dispatcher(evicted_dispatcher)
+            for key in list(self._launch_config_overloads):
+                if key[1] == evicted_key:
+                    del self._launch_config_overloads[key]
+        return True
+
     def configure(self, griddim, blockdim, stream=None, sharedmem=None, cluster=None):
         griddim, blockdim = normalize_kernel_dimensions(griddim, blockdim)
         if cluster is not None:
             cluster = normalize_kernel_dimensions(cluster, (1, 1, 1))[0]
+        launch_config_enabled = self._launch_config_enabled
+        extension_key = tuple(_ObjectIdentityKey(ext) for ext in self.extensions)
+        configured_sharedmem = sharedmem
+        if launch_config_enabled:
+            configured_sharedmem = _normalize_launch_sharedmem(sharedmem)
+        cache_key = (
+            launch_config_enabled,
+            extension_key,
+            griddim,
+            blockdim,
+            stream,
+            configured_sharedmem,
+            cluster,
+        )
+        _validate_configure_cache_key(cache_key)
+        self._ensure_dispatcher_state()
 
+        stale_retries = 0
+        while True:
+            with self._launch_config_lock:
+                cached = self._configure_cache.get(cache_key)
+                if cached is not None:
+                    self._configure_cache.move_to_end(cache_key)
+                    return cached
+                inflight = self._configure_cache_inflight.get(cache_key)
+                if inflight is None:
+                    inflight = threading.Event()
+                    self._configure_cache_inflight[cache_key] = inflight
+                    owns_inflight = True
+                else:
+                    owns_inflight = False
+
+            if not owns_inflight:
+                inflight.wait()
+                continue
+
+            try:
+                marshaller = self._configure_cached(*cache_key)
+            except BaseException:
+                with self._launch_config_lock:
+                    if self._configure_cache_inflight.get(cache_key) is inflight:
+                        del self._configure_cache_inflight[cache_key]
+                    inflight.set()
+                raise
+
+            retry_stale_marshaller = False
+            with self._launch_config_lock:
+                try:
+                    cached = self._configure_cache.get(cache_key)
+                    if cached is not None:
+                        self._configure_cache.move_to_end(cache_key)
+                        return cached
+                    if self._configure_marshaller_stale_locked(launch_config_enabled, marshaller):
+                        stale_retries += 1
+                        if stale_retries >= _CONFIGURE_CACHE_STALE_RETRY_LIMIT:
+                            raise RuntimeError(
+                                "Kernel launch configuration was invalidated repeatedly "
+                                "during configure(); retry after concurrent recompile() calls finish."
+                            )
+                        retry_stale_marshaller = True
+                    else:
+                        self._configure_cache[cache_key] = marshaller
+                        self._configure_cache.move_to_end(cache_key)
+                        while len(self._configure_cache) > _CONFIGURE_CACHE_SIZE:
+                            self._configure_cache.popitem(last=False)
+                        return marshaller
+                finally:
+                    if self._configure_cache_inflight.get(cache_key) is inflight:
+                        del self._configure_cache_inflight[cache_key]
+                    inflight.set()
+            if retry_stale_marshaller:
+                continue
+
+    def _configure_marshaller_stale_locked(self, launch_config_enabled, marshaller):
+        if launch_config_enabled:
+            return marshaller._launch_config_generation != self._launch_config_generation
+        return marshaller._kernel_dispatcher is not self._c
+
+    def _configure_cached(
+        self,
+        launch_config_enabled,
+        extension_key,
+        griddim,
+        blockdim,
+        stream,
+        configured_sharedmem,
+        cluster,
+    ):
         # Warn when the grid has fewer than 128 blocks (low occupancy)
         if cuda_config.CUDA_LOW_OCCUPANCY_WARNINGS and not cuda_config.DISABLE_PERFORMANCE_WARNINGS:
             min_grid_size = 128
@@ -1279,17 +1773,149 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 )
                 warnings.warn(NumbaPerformanceWarning(msg))
 
-        # Numba-CUDA now holds a reference to a cuda-bindings CUstream instead
-        # of a ctypes object. The easiest way to pass it to cext is as an
-        # integer.
+        launch_config = None
+        kernel_dispatcher = self._c
+        launch_config_generation = None
+        stream_ref = None
+        launch_stream = stream
         if isinstance(stream, numba_cuda_driver.Stream):
-            stream = int(stream.handle)
+            stream_ref = stream
+            launch_stream = int(stream.handle)
+        if launch_config_enabled:
+            launch_config = {
+                "grid": griddim,
+                "block": blockdim,
+                "sharedmem": configured_sharedmem,
+                "cluster": cluster,
+            }
+            (
+                kernel_dispatcher,
+                launch_config_generation,
+            ) = self._get_kernel_dispatcher_and_generation(launch_config)
+        extensions = [key.obj for key in extension_key]
 
         return _ArgMarshaller(
-            LaunchConfiguration(self._c, griddim, blockdim, stream, sharedmem, cluster),
-            extensions=self.extensions,
+            LaunchConfiguration(
+                kernel_dispatcher, griddim, blockdim, launch_stream, configured_sharedmem, cluster
+            ),
+            extensions=extensions,
             dispatcher=self,
+            launch_config=launch_config,
+            kernel_dispatcher=kernel_dispatcher,
+            launch_config_generation=launch_config_generation,
+            stream_ref=stream_ref,
         )
+
+    def _reduce_states(self):
+        """Serialize compiled signatures, including launch-qualified entries."""
+        self._ensure_dispatcher_state()
+        if self._can_compile:
+            sigs = []
+            launch_config_sigs = []
+        else:
+            sigs = [cr.signature for cr in self.overloads.values()]
+            launch_config_sigs = []
+            if self._launch_config_enabled:
+                seen = set()
+                with self._launch_config_lock:
+                    launch_items = list(self._launch_config_overloads.items())
+                for (_sig_args, launch_config_key), cres in launch_items:
+                    cres_id = id(cres)
+                    if cres_id in seen:
+                        continue
+                    seen.add(cres_id)
+                    launch_config_sigs.append((cres.signature, launch_config_key))
+
+        return dict(
+            uuid=str(self._uuid),
+            py_func=self.py_func,
+            locals=self.locals,
+            targetoptions=self.targetoptions,
+            can_compile=self._can_compile,
+            sigs=sigs,
+            launch_config_sigs=launch_config_sigs,
+        )
+
+    @classmethod
+    def _rebuild(
+        cls, uuid, py_func, locals, targetoptions, can_compile, sigs, launch_config_sigs=()
+    ):
+        """Rebuild an MLIRDispatcher after serialization."""
+        try:
+            return cls._memo[uuid]
+        except KeyError:
+            pass
+        self = cls(py_func, targetoptions=targetoptions)
+        self.locals = locals
+        self._set_uuid(uuid)
+        for sig in sigs:
+            self.compile(sig)
+        for sig, launch_config_key in launch_config_sigs:
+            self._compile_launch_config_signature(sig, launch_config_key)
+        self._can_compile = can_compile
+        return self
+
+    def _compile_launch_config_signature(self, sig, launch_config_key):
+        """Rebuild a serialized launch-specialized signature via the dispatch path.
+
+        Reduce state stores signatures, not runtime argument values, so override_argtypes
+        drives compilation while placeholder values satisfy the dispatch entry point.
+        """
+        argtypes, _return_type = sigutils.normalize_signature(sig)
+        launch_config = _launch_config_dict_from_key(launch_config_key)
+        launch_config_key = _launch_config_key(launch_config)
+
+        with self._launch_config_lock:
+            existing = self._launch_config_overloads.get((argtypes, launch_config_key))
+            if existing is not None:
+                return existing
+
+        previous_types = getattr(_compile_arg_types, "types", _MISSING)
+        previous_launch_config = getattr(_compile_arg_types, "launch_config", _MISSING)
+        previous_extensions = getattr(_compile_arg_types, "extensions", _MISSING)
+        previous_force_launch_config = getattr(_compile_arg_types, "force_launch_config", _MISSING)
+        try:
+            _compile_arg_types.types = argtypes
+            _compile_arg_types.launch_config = launch_config
+            _compile_arg_types.extensions = self.extensions
+            _compile_arg_types.force_launch_config = True
+            self._compile_impl([None] * len(argtypes))
+        finally:
+            if previous_types is _MISSING:
+                if hasattr(_compile_arg_types, "types"):
+                    delattr(_compile_arg_types, "types")
+            else:
+                _compile_arg_types.types = previous_types
+            if previous_launch_config is _MISSING:
+                if hasattr(_compile_arg_types, "launch_config"):
+                    delattr(_compile_arg_types, "launch_config")
+            else:
+                _compile_arg_types.launch_config = previous_launch_config
+            if previous_extensions is _MISSING:
+                if hasattr(_compile_arg_types, "extensions"):
+                    delattr(_compile_arg_types, "extensions")
+            else:
+                _compile_arg_types.extensions = previous_extensions
+            if previous_force_launch_config is _MISSING:
+                if hasattr(_compile_arg_types, "force_launch_config"):
+                    delattr(_compile_arg_types, "force_launch_config")
+            else:
+                _compile_arg_types.force_launch_config = previous_force_launch_config
+
+        with self._launch_config_lock:
+            rebuilt = self._find_launch_config_overload_locked(argtypes, launch_config_key)
+        if rebuilt is None:
+            raise RuntimeError(f"Failed to rebuild launch-config specialization for {argtypes}")
+        return rebuilt
+
+    def _apply_shared_memory_carveout(self, wrapped):
+        carveout = self.targetoptions.get("shared_memory_carveout")
+        if carveout is None:
+            return
+        if isinstance(carveout, str):
+            carveout_map = {"default": -1, "maxl1": 0, "maxshared": 100}
+            carveout = carveout_map[carveout.lower()]
+        wrapped._codelibrary.get_cufunc().set_shared_memory_carveout(carveout)
 
     def __getitem__(self, args):
         assert isinstance(args, tuple)
@@ -1314,6 +1940,81 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             cache_misses=self._cache_misses,
         )
 
+    @property
+    def launch_config_stats(self):
+        """Return cache counters for launch-config-specialized compiles."""
+        self._ensure_dispatcher_state()
+        return _LaunchConfigCompileStats(
+            cache_hits=self._launch_config_cache_hits,
+            cache_misses=self._launch_config_cache_misses,
+        )
+
+    def _launch_config_compile_results(self):
+        self._ensure_dispatcher_state()
+        results = []
+        seen = set()
+        with self._launch_config_lock:
+            for cres in self._launch_config_overloads.values():
+                cres_id = id(cres)
+                if cres_id in seen:
+                    continue
+                seen.add(cres_id)
+                results.append(cres)
+        return results
+
+    def _launch_config_overload_argtypes(self, launch_config_key):
+        self._ensure_dispatcher_state()
+        # The launch overload table is bounded by the dispatcher cache and is
+        # small in normal use; keep a flat table instead of a secondary index.
+        signatures = []
+        seen = set()
+        with self._launch_config_lock:
+            for sig_args, key in self._launch_config_overloads:
+                if key != launch_config_key or sig_args in seen:
+                    continue
+                seen.add(sig_args)
+                signatures.append(sig_args)
+        return tuple(signatures)
+
+    @property
+    def signatures(self):
+        """Return compiled overload keys.
+
+        Generic entries use Numba-compatible argtypes tuples. Launch entries use
+        LaunchConfigInspectableKey so same-argtype launch specializations remain
+        distinguishable.
+        """
+        self._ensure_dispatcher_state()
+        signatures = list(self.overloads)
+        seen = set(signatures)
+        seen_cres = set()
+        with self._launch_config_lock:
+            launch_items = list(self._launch_config_overloads.items())
+        for (sig_args, launch_config_key), cres in launch_items:
+            cres_id = id(cres)
+            if cres_id in seen_cres:
+                continue
+            seen_cres.add(cres_id)
+            key = LaunchConfigInspectableKey(sig_args, launch_config_key)
+            if key not in seen:
+                seen.add(key)
+                signatures.append(key)
+        return signatures
+
+    @property
+    def nopython_signatures(self):
+        """Return unique nopython signatures across generic and launch-specific overloads."""
+        signatures = [cres.signature for cres in self.overloads.values() if not cres.objectmode]
+        seen = {tuple(sig.args) for sig in signatures}
+        for cres in self._launch_config_compile_results():
+            if cres.objectmode:
+                continue
+            sig_args = tuple(cres.signature.args)
+            if sig_args not in seen:
+                seen.add(sig_args)
+                signatures.append(cres.signature)
+        return signatures
+
     def __call__(self, *args, **kwargs):
         """
         Compile if necessary and invoke this kernel with *args*.
@@ -1327,12 +2028,35 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         - A tuple of argument types (e.g., from inspect_asm(signature=...))
         - A typing.Signature object
         - Already in self.overloads
+        - A raw (argtypes, launch_config_key) key from launch_config_overloads
+        - A LaunchConfigInspectableKey from no-argument inspect_*() results
 
         Returns the compile result if found, or compiles and returns it.
         """
+        if isinstance(sig, tuple) and len(sig) == 2 and isinstance(sig[1], dict):
+            if _is_launch_config_dict(sig[1]):
+                sig = (sig[0], _launch_config_key(sig[1]))
+            else:
+                raise KeyError(f"No overload found for signature {sig}")
+        launch_key = None
+        if isinstance(sig, LaunchConfigInspectableKey):
+            launch_key = (sig.argtypes, sig.launch_config_key)
+        elif isinstance(sig, tuple) and len(sig) == 2 and _is_launch_config_key_tuple(sig[1]):
+            launch_key = sig
+        if launch_key is not None:
+            argtypes, launch_config_key = launch_key
+            with self._launch_config_lock:
+                found = self._find_launch_config_overload_locked(argtypes, launch_config_key)
+                if found is not None:
+                    return found
+            raise KeyError(f"No launch-config overload found for signature {sig}")
+
         # Direct lookup
         if sig in self.overloads:
             return self.overloads[sig]
+        with self._launch_config_lock:
+            if sig in self._launch_config_overloads:
+                return self._launch_config_overloads[sig]
 
         # Extract args to search for matching overload
         search_args = sig.args if hasattr(sig, "args") else sig if isinstance(sig, tuple) else None
@@ -1343,6 +2067,21 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 )
                 if key_args == search_args:
                     return cres
+            launch_matches = []
+            seen_launch_matches = set()
+            with self._launch_config_lock:
+                for (sig_args, _lc_key), cres in self._launch_config_overloads.items():
+                    cres_id = id(cres)
+                    if sig_args == search_args and cres_id not in seen_launch_matches:
+                        seen_launch_matches.add(cres_id)
+                        launch_matches.append(cres)
+            if len(launch_matches) == 1:
+                return launch_matches[0]
+            if len(launch_matches) > 1:
+                raise KeyError(
+                    f"Multiple launch-config overloads found for signature {sig}; "
+                    "use a launch-config-qualified key from inspect_*()"
+                )
 
         # Not found - compile it
         self.compile(sig)
@@ -1360,6 +2099,34 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
 
         raise KeyError(f"No overload found for signature {sig}")
 
+    @property
+    def launch_config_overloads(self):
+        self._ensure_dispatcher_state()
+        with self._launch_config_lock:
+            return dict(self._launch_config_overloads)
+
+    def get_metadata(self, signature=None):
+        """Return compile metadata for generic and launch-specialized overloads."""
+        if signature is not None:
+            return self._find_overload(signature).metadata
+        return {sig: cres.metadata for sig, cres in self._inspectable_overloads().items()}
+
+    def _inspectable_overloads(self):
+        self._ensure_dispatcher_state()
+        with self._launch_config_lock:
+            generic_overloads = dict(self.overloads)
+            launch_overloads = dict(self._launch_config_overloads)
+        if not launch_overloads:
+            return generic_overloads
+        overloads = generic_overloads
+        seen = {id(cres) for cres in overloads.values()}
+        for (sig_args, launch_config_key), cres in launch_overloads.items():
+            if id(cres) in seen:
+                continue
+            seen.add(id(cres))
+            overloads[LaunchConfigInspectableKey(sig_args, launch_config_key)] = cres
+        return overloads
+
     def inspect_llvm(self, sig=None):
         raise NotImplementedError(
             "inspect_llvm is not supported. "
@@ -1367,9 +2134,13 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         )
 
     def inspect_asm(self, signature=None):
-        """Get the generated PTX assembly code."""
+        """Get generated PTX.
+
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
+        """
         if signature is None:
-            return {sig: self.inspect_asm(sig) for sig in self.overloads}
+            return {sig: self.inspect_asm(sig) for sig in self._inspectable_overloads()}
         cres = self._find_overload(signature)
         ptx = cres.metadata.get("ptx")
         if ptx:
@@ -1384,16 +2155,26 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         return ptx
 
     def inspect_mlir(self, sig=None):
+        """Get generated MLIR.
+
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
+        """
         if sig is None:
-            return {sig: self.inspect_mlir(sig) for sig in self.overloads}
+            return {sig: self.inspect_mlir(sig) for sig in self._inspectable_overloads()}
         from numba_cuda_mlir.mlir_lowering import get_mlir_module_str
 
         cres = self._find_overload(sig)
         return get_mlir_module_str(cres.metadata)
 
     def inspect_mlir_optimized(self, sig=None):
+        """Get optimized MLIR.
+
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
+        """
         if sig is None:
-            return {sig: self.inspect_mlir_optimized(sig) for sig in self.overloads}
+            return {sig: self.inspect_mlir_optimized(sig) for sig in self._inspectable_overloads()}
         cres = self._find_overload(sig)
         return cres.metadata["mlir_module_optimized"]
 
@@ -1406,16 +2187,24 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
 
         Returns:
             The transformed source string, or None if no transforms were applied.
-            If sig is None, returns a dict of {signature: transformed_source}.
+            If sig is None, returns a dict of {signature: transformed_source};
+            launch-specialized entries use LaunchConfigInspectableKey keys.
         """
         if sig is None:
-            return {sig: self.inspect_transformed_source(sig) for sig in self.overloads}
+            return {
+                sig: self.inspect_transformed_source(sig) for sig in self._inspectable_overloads()
+            }
         cres = self._find_overload(sig)
         return cres.metadata.get("transformed_source")
 
     def inspect_ptx(self, sig=None):
+        """Get generated PTX.
+
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
+        """
         if sig is None:
-            return {sig: self.inspect_ptx(sig) for sig in self.overloads}
+            return {sig: self.inspect_ptx(sig) for sig in self._inspectable_overloads()}
         return self.inspect_asm(sig)
 
     @staticmethod
@@ -1493,11 +2282,13 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 total[i] += cost[i]
         return tuple(total)
 
-    def _resolve_overload(self, argtypes, allow_unsafe=True):
+    def _resolve_overload(self, argtypes, allow_unsafe=True, candidate_sig_args=None):
         """Find the best-matching overload(s) for argtypes.
         Returns (tied_best_sig_args_list, has_any_match)."""
         candidates = []
-        for sig_args in self.overloads:
+        if candidate_sig_args is None:
+            candidate_sig_args = self.overloads
+        for sig_args in candidate_sig_args:
             rating = self._rate_overload(sig_args, argtypes)
             if rating is None:
                 continue
@@ -1514,6 +2305,35 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
     def _raise_ambiguous(self, argtypes, tied):
         sigs_str = "\n".join(f"{sig_args} -> none" for sig_args in tied)
         raise TypeError(f"Ambiguous overloading for {self.py_func!r} {argtypes}:\n{sigs_str}")
+
+    def _propagate_compile_callbacks(self, metadata):
+        self._ensure_dispatcher_state()
+        # Reuse the dispatcher state lock so callback dedup is atomic with
+        # launch-config compile publication.
+        with self._launch_config_lock:
+            for cb in metadata.get("setup_callbacks", []):
+                if cb not in self._module_setup_callbacks:
+                    self._module_setup_callbacks.append(cb)
+            for cb in metadata.get("teardown_callbacks", []):
+                if cb not in self._module_teardown_callbacks:
+                    self._module_teardown_callbacks.append(cb)
+
+    def _find_launch_config_overload_locked(self, argtypes, launch_config_key):
+        # Exact hits are O(1). Compatible fallback scans the bounded launch
+        # overload table to preserve existing overload-reuse semantics.
+        exact = self._launch_config_overloads.get((argtypes, launch_config_key))
+        if exact is not None:
+            return exact
+        reusable = None
+        for (sig_args, key), cres in self._launch_config_overloads.items():
+            if (
+                key == launch_config_key
+                and len(sig_args) == len(argtypes)
+                and all(self._can_reuse_overload(s, r) for s, r in zip(sig_args, argtypes))
+            ):
+                reusable = cres
+                break
+        return reusable
 
     def _make_post_load_hook(self):
         """Create a callback for C++ to invoke after loading the CUlibrary."""
@@ -1566,9 +2386,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 return (cubin, func_name, cooperative, self._make_post_load_hook())
             return (cubin, func_name, cooperative)
 
-    def _compile_impl(self, args):
+    def _compile_impl(self, args, launch_config_retry_budget=_CONFIGURE_CACHE_STALE_RETRY_LIMIT):
         from numba_cuda_mlir import mlir_compiler
         from numba_cuda_mlir.compiler import CompileResult
+
+        self._ensure_dispatcher_state()
 
         # Get original arg types - either from thread-local storage (for tuple args)
         # or None to let mlir_compiler_entry infer from args
@@ -1581,6 +2403,19 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             argtypes = override_argtypes
         else:
             argtypes = tuple(typeof(arg) for arg in args)
+        active_extensions = getattr(_compile_arg_types, "extensions", _MISSING)
+        has_extension_snapshot = active_extensions is not _MISSING
+        if not has_extension_snapshot:
+            active_extensions = self.extensions
+        force_launch_config = getattr(_compile_arg_types, "force_launch_config", False)
+        active_launch_config = None
+        if force_launch_config or _extensions_use_launch_config(active_extensions):
+            active_launch_config = getattr(_compile_arg_types, "launch_config", None)
+        active_launch_config_key = _launch_config_key(active_launch_config)
+        active_launch_config_generation = None
+        if active_launch_config_key is not None:
+            with self._launch_config_lock:
+                active_launch_config_generation = self._launch_config_generation
 
         def _result(cres):
             return (
@@ -1589,15 +2424,65 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 cres.metadata.get("use_cooperative", False),
             )
 
-        # Try to reuse a pre-compiled overload with ABI-compatible types
-        if self.overloads:
-            for sig_args, cres in self.overloads.items():
+        if active_launch_config_key is not None:
+            # Launch metadata is visible to compilation. Keep those
+            # specializations separate so consteval/rewrite users never observe
+            # stale launch configuration values from a previous same-signature
+            # launch.
+            with self._launch_config_lock:
+                reusable = self._find_launch_config_overload_locked(
+                    argtypes, active_launch_config_key
+                )
+                if reusable is not None:
+                    self._launch_config_cache_hits[(argtypes, active_launch_config_key)] += 1
+                    return _result(reusable)
+        elif self.overloads:
+            for sig_args, cres in tuple(self.overloads.items()):
                 if len(sig_args) == len(argtypes) and all(
                     self._can_reuse_overload(s, r) for s, r in zip(sig_args, argtypes)
                 ):
                     return _result(cres)
 
         if not self._can_compile:
+            if active_launch_config_key is not None:
+                with self._launch_config_lock:
+                    candidate_overloads = {}
+                    for (sig_args, key), cres in self._launch_config_overloads.items():
+                        if key == active_launch_config_key:
+                            candidate_overloads[sig_args] = cres
+                generic_note = (
+                    f"; {len(self.overloads)} generic overload(s) ignored because "
+                    "active extensions use launch metadata"
+                    if self.overloads
+                    else ""
+                )
+                best, has_any = self._resolve_overload(
+                    argtypes,
+                    allow_unsafe=True,
+                    candidate_sig_args=tuple(candidate_overloads),
+                )
+                if not has_any:
+                    # Generic overloads are not a safe fallback here: opt-in
+                    # extensions may lower code from __launch_config__ metadata.
+                    raise TypeError(
+                        "No matching launch-config specialization for argument "
+                        f"type(s) {argtypes} and launch config {active_launch_config}"
+                        f"{generic_note}"
+                    )
+                if len(best) > 1:
+                    # _resolve_overload returns tied best matches; it does not
+                    # raise ambiguity on its own.
+                    best_results = {id(candidate_overloads[sig_args]) for sig_args in best}
+                    if len(best_results) > 1:
+                        self._raise_ambiguous(argtypes, best)
+                cres = candidate_overloads.get(best[0])
+                if cres is None:
+                    raise TypeError(
+                        "No matching launch-config specialization for argument "
+                        f"type(s) {argtypes} and launch config {active_launch_config}"
+                        f"{generic_note}"
+                    )
+                return _result(cres)
             best, has_any = self._resolve_overload(argtypes, allow_unsafe=True)
             if not has_any:
                 raise TypeError(f"No matching definition for argument type(s) {argtypes}")
@@ -1607,42 +2492,95 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             return _result(cres)
 
         self._resolve_target_options()
+        targetoptions = self.targetoptions
+        if active_launch_config is not None or has_extension_snapshot:
+            targetoptions = self.targetoptions.copy()
+            if has_extension_snapshot:
+                targetoptions["extensions"] = active_extensions
+            if active_launch_config is not None:
+                targetoptions["__launch_config__"] = dict(active_launch_config)
 
         # Try to load from disk cache
         mlir_target.ensure_initialized()
         sig = typing.signature(types.none, *argtypes)
-        cres = self._cache.load_overload(sig, mlir_target.target_context)
-        if cres is not None:
-            self._cache_hits[argtypes] += 1
-            wrapped = CompileResult(cres)
-            self.overloads[argtypes] = wrapped
-            return _result(wrapped)
+        # Launch-specialized compiles use an in-memory cache because the
+        # generic in-memory and on-disk cache keys do not include launch metadata.
+        if active_launch_config_key is None:
+            cres = self._cache.load_overload(sig, mlir_target.target_context)
+            if cres is not None:
+                self._cache_hits[argtypes] += 1
+                wrapped = CompileResult(cres)
+                self.overloads[argtypes] = wrapped
+                return _result(wrapped)
 
         # Cache miss - need to compile
-        self._cache_misses[argtypes] += 1
+        if active_launch_config_key is None:
+            self._cache_misses[argtypes] += 1
 
         # Compile using mlir_compiler_entry which handles annotations and AST transforms
         with self._compile_profiler():
             result = mlir_compiler.mlir_compiler_entry(
                 pyfunc=self.py_func,
                 func_args=list(args),
-                targetoptions=self.targetoptions,
+                targetoptions=targetoptions,
                 override_argtypes=override_argtypes,
             )
         wrapped = CompileResult(result)
-        self.overloads[result.signature.args] = wrapped
-
-        # Propagate callbacks discovered during lowering (e.g. from
-        # declare_device(link=[...])) up to the dispatcher level.
-        for cb in result.metadata.get("setup_callbacks", []):
-            if cb not in self._module_setup_callbacks:
-                self._module_setup_callbacks.append(cb)
-        for cb in result.metadata.get("teardown_callbacks", []):
-            if cb not in self._module_teardown_callbacks:
-                self._module_teardown_callbacks.append(cb)
+        emit_launch_config_cache_notice = False
+        retry_launch_config_compile = False
+        if active_launch_config_key is not None:
+            normalized_args = tuple(result.signature.args)
+            with self._launch_config_lock:
+                if active_launch_config_generation != self._launch_config_generation:
+                    retry_launch_config_compile = True
+                else:
+                    existing = self._find_launch_config_overload_locked(
+                        argtypes, active_launch_config_key
+                    )
+                    if existing is None and normalized_args != argtypes:
+                        existing = self._find_launch_config_overload_locked(
+                            normalized_args, active_launch_config_key
+                        )
+                    if existing is not None:
+                        # A duplicate compile can lose a race to another thread that
+                        # published an equivalent overload. Discard this result
+                        # without publishing callbacks from an unused module.
+                        return _result(existing)
+                    self._launch_config_cache_misses[(argtypes, active_launch_config_key)] += 1
+                    emit_launch_config_cache_notice = not self._launch_config_cache_notice_emitted
+                    self._launch_config_cache_notice_emitted = True
+                    self._propagate_compile_callbacks(result.metadata)
+                    self._apply_shared_memory_carveout(wrapped)
+                    # Preserve both the native dispatcher request types and the
+                    # compiler-normalized signature for launch-qualified lookups.
+                    self._launch_config_overloads.setdefault(
+                        (argtypes, active_launch_config_key), wrapped
+                    )
+                    self._launch_config_overloads.setdefault(
+                        (normalized_args, active_launch_config_key), wrapped
+                    )
+            if retry_launch_config_compile:
+                if launch_config_retry_budget <= 0:
+                    raise RuntimeError(
+                        "Kernel launch configuration was invalidated repeatedly during compile(); "
+                        "retry after concurrent recompile() calls finish."
+                    )
+                return self._compile_impl(args, launch_config_retry_budget - 1)
+            if emit_launch_config_cache_notice:
+                message = (
+                    "Persistent disk cache is disabled for launch-config-specialized "
+                    "compiles because the disk cache key does not include launch metadata."
+                )
+                warnings.warn(message, NumbaPerformanceWarning, stacklevel=3)
+                trace(message)
+        else:
+            self._propagate_compile_callbacks(result.metadata)
+            self._apply_shared_memory_carveout(wrapped)
+            self.overloads[result.signature.args] = wrapped
 
         # Save to disk cache
-        self._cache.save_overload(sig, result)
+        if active_launch_config_key is None:
+            self._cache.save_overload(sig, result)
 
         return _result(wrapped)
 
@@ -1692,12 +2630,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             self._is_compiling = False
 
         # Propagate callbacks discovered during lowering/optimization
-        for cb in cres.metadata.get("setup_callbacks", []):
-            if cb not in self._module_setup_callbacks:
-                self._module_setup_callbacks.append(cb)
-        for cb in cres.metadata.get("teardown_callbacks", []):
-            if cb not in self._module_teardown_callbacks:
-                self._module_teardown_callbacks.append(cb)
+        self._propagate_compile_callbacks(cres.metadata)
 
         # Save to cache
         self._cache.save_overload(sig, cres)
@@ -1705,13 +2638,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         # Wrap in CompileResult for compatibility attributes
         wrapped = CompileResult(cres)
 
-        # Apply shared memory carveout if specified
-        carveout = self.targetoptions.get("shared_memory_carveout")
-        if carveout is not None:
-            if isinstance(carveout, str):
-                carveout_map = {"default": -1, "maxl1": 0, "maxshared": 100}
-                carveout = carveout_map[carveout.lower()]
-            wrapped._codelibrary.get_cufunc().set_shared_memory_carveout(carveout)
+        self._apply_shared_memory_carveout(wrapped)
 
         # Store in overloads
         self.overloads[argtypes] = wrapped
@@ -1786,8 +2713,13 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         return cres
 
     def inspect_lto_ptx(self, args=None):
+        """Get generated LTO PTX.
+
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
+        """
         if args is None:
-            return {sig: self.inspect_lto_ptx(sig) for sig in self.overloads}
+            return {sig: self.inspect_lto_ptx(sig) for sig in self._inspectable_overloads()}
         cres = self._find_overload(args)
         ptx = cres.metadata.get("lto_ptx")
         if ptx:
@@ -1833,17 +2765,31 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         """True if the Dispatcher has been specialized."""
         return self._specialized
 
+    def _specialized_compile_result(self):
+        if self.overloads:
+            return next(iter(self.overloads.values()))
+        launch_results = self._launch_config_compile_results()
+        if launch_results:
+            return launch_results[0]
+        return None
+
     def _get_kernel_attr(self, attr, default, sig=None):
-        """Return a kernel attribute, lazily querying the CUDA driver."""
+        """Return a kernel attribute, lazily querying the CUDA driver.
+
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
+        """
         if sig is not None:
             cres = self._find_overload(sig)
             cres._ensure_kernel_attrs()
             return cres.metadata.get(attr, default)
         if self.specialized:
-            cres = next(iter(self.overloads.values()))
-            cres._ensure_kernel_attrs()
-            return cres.metadata.get(attr, default)
-        return {s: self._get_kernel_attr(attr, default, s) for s in self.overloads}
+            cres = self._specialized_compile_result()
+            if cres is not None:
+                cres._ensure_kernel_attrs()
+                return cres.metadata.get(attr, default)
+        inspectable = self._inspectable_overloads()
+        return {s: self._get_kernel_attr(attr, default, s) for s in inspectable}
 
     def get_regs_per_thread(self, sig=None):
         return self._get_kernel_attr("regs_per_thread", 0, sig)
@@ -1864,6 +2810,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         """Return the SASS assembly for the given signature.
 
         Requires nvdisasm to be available on the PATH.
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
         """
         if self.targetoptions.get("device"):
             raise RuntimeError("Cannot inspect SASS of a device function")
@@ -1872,9 +2820,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             cres = self._find_overload(sig)
             return self._disassemble_cubin(cres)
         if self.specialized:
-            cres = next(iter(self.overloads.values()))
-            return self._disassemble_cubin(cres)
-        return {s: self.inspect_sass(s) for s in self.overloads}
+            cres = self._specialized_compile_result()
+            if cres is not None:
+                return self._disassemble_cubin(cres)
+        inspectable = self._inspectable_overloads()
+        return {s: self.inspect_sass(s) for s in inspectable}
 
     @staticmethod
     def _disassemble_cubin(cres):
@@ -1943,29 +2893,37 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         a fresh compile. Useful when global variables captured by the kernel
         have changed and you want the kernel to use the new values.
         """
+        self._ensure_dispatcher_state()
+
         # Clear Python-side overloads
         self.overloads.clear()
 
         # Clear cache counters
         self._cache_hits.clear()
         self._cache_misses.clear()
+        self._launch_config_cache_hits.clear()
+        self._launch_config_cache_misses.clear()
 
         # Flush disk cache
         self._cache.flush()
 
-        # Clear the configure LRU cache so old LaunchConfiguration refs are dropped
-        self.configure.cache_clear()
-
-        # Keep old dispatcher alive to prevent CUDA resource cleanup issues,
-        # then create a new one. This is a memory leak but avoids crashes.
-        if not hasattr(self, "_old_dispatchers"):
-            self._old_dispatchers = []
-        self._old_dispatchers.append(self._c)
-        self._c = _cext.KernelDispatcher(
-            self._compile,
-            get_constant_args(self.py_func),
-            _ensure_numba_cuda_context,
-        )
+        # Keep old dispatchers alive up to _OLD_DISPATCHER_RETAIN_LIMIT to reduce
+        # CUDA cleanup crashes without allowing unbounded growth.
+        with self._launch_config_lock:
+            self._retain_old_dispatcher(self._c)
+            self._launch_config_generation += 1
+            self._launch_config_overloads.clear()
+            old_launch_config_dispatchers = list(self._launch_config_dispatchers.values())
+            self._launch_config_dispatchers = collections.OrderedDict()
+            for dispatcher in old_launch_config_dispatchers:
+                self._retain_old_dispatcher(dispatcher)
+            self._configure_cache.clear()
+            inflight = tuple(self._configure_cache_inflight.values())
+            self._configure_cache_inflight.clear()
+            for event in inflight:
+                event.set()
+            self._launch_config_cache_notice_emitted = False
+            self._c = self._new_kernel_dispatcher()
 
 
 target_registry["numba_cuda_mlir"] = MLIR

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -1,0 +1,1725 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for dispatcher launch metadata plumbing."""
+
+import threading
+
+import pytest
+import numpy as np
+
+from numba_cuda_mlir import descriptor as descriptor_mod
+from numba_cuda_mlir import cuda
+from numba_cuda_mlir.cuda.experimental import consteval, current_target_options
+from numba_cuda_mlir.descriptor import _ArgMarshaller
+from numba_cuda_mlir.numba_cuda import types, typing as cuda_typing
+
+
+class _Dispatcher:
+    def __init__(self, targetoptions=None):
+        self.targetoptions = {} if targetoptions is None else dict(targetoptions)
+        self._can_compile = True
+        self.overloads = {}
+        self._launch_config_lock = threading.RLock()
+        self.remembered_dispatchers = []
+
+    def _remember_kernel_dispatcher(
+        self,
+        launch_config,
+        kernel_dispatcher,
+        launch_config_generation=None,
+        replace_existing=True,
+    ):
+        active_launch_config = getattr(descriptor_mod._compile_arg_types, "launch_config", None)
+        self.remembered_dispatchers.append(
+            (
+                launch_config,
+                kernel_dispatcher,
+                active_launch_config,
+                launch_config_generation,
+            )
+        )
+        return True
+
+
+class _LaunchConfigExtension:
+    uses_launch_config = True
+
+    def prepare_args(self, ty, val, stream=None, retr=None):
+        return ty, val
+
+
+class _NonLaunchConfigExtension:
+    uses_launch_config = False
+
+    def prepare_args(self, ty, val, stream=None, retr=None):
+        return ty, val
+
+
+class _UnhashableLaunchConfigExtension(_LaunchConfigExtension):
+    __hash__ = None
+
+
+class _CompileResult:
+    objectmode = False
+
+    def __init__(self, sig_args, ptx="ptx"):
+        self.signature = cuda_typing.signature(types.none, *sig_args)
+        self.metadata = {"ptx": ptx}
+
+
+@pytest.fixture(autouse=True)
+def restore_compile_arg_types():
+    # The launch metadata thread-local is only mutated from the test thread in
+    # this file, so restoring the current thread's local dict is sufficient.
+    state = descriptor_mod._compile_arg_types.__dict__.copy()
+    yield
+    descriptor_mod._compile_arg_types.__dict__.clear()
+    descriptor_mod._compile_arg_types.__dict__.update(state)
+
+
+def test_arg_marshaller_exposes_launch_config_during_launch():
+    dispatcher = _Dispatcher()
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 128,
+        "cluster": None,
+    }
+    observed = []
+
+    def launcher():
+        observed.append(getattr(descriptor_mod._compile_arg_types, "launch_config", None))
+        return "launched"
+
+    marshaller = _ArgMarshaller(
+        launcher,
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+    )
+
+    assert marshaller() == "launched"
+    assert observed == [launch_config]
+    assert "__launch_config__" not in dispatcher.targetoptions
+    assert not hasattr(descriptor_mod._compile_arg_types, "launch_config")
+
+
+def test_arg_marshaller_restores_launch_config_after_error():
+    original_launch_config = {"block": (16, 1, 1)}
+    dispatcher = _Dispatcher()
+    descriptor_mod._compile_arg_types.launch_config = original_launch_config
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (64, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    observed = []
+
+    def launcher():
+        observed.append(getattr(descriptor_mod._compile_arg_types, "launch_config", None))
+        raise ValueError("launch failed")
+
+    marshaller = _ArgMarshaller(
+        launcher,
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+    )
+
+    with pytest.raises(ValueError, match="launch failed"):
+        marshaller()
+
+    assert observed == [launch_config]
+    assert descriptor_mod._compile_arg_types.launch_config == original_launch_config
+
+
+def test_arg_marshaller_clears_launch_config_after_error():
+    dispatcher = _Dispatcher()
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (64, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+
+    def launcher():
+        raise ValueError("launch failed")
+
+    marshaller = _ArgMarshaller(
+        launcher,
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+    )
+
+    with pytest.raises(ValueError, match="launch failed"):
+        marshaller()
+
+    assert not hasattr(descriptor_mod._compile_arg_types, "launch_config")
+
+
+def test_arg_marshaller_without_launch_config_leaves_thread_local_absent():
+    observed = []
+
+    def launcher():
+        observed.append(hasattr(descriptor_mod._compile_arg_types, "launch_config"))
+        return "launched"
+
+    marshaller = _ArgMarshaller(launcher)
+
+    assert marshaller() == "launched"
+    assert observed == [False]
+    assert not hasattr(descriptor_mod._compile_arg_types, "launch_config")
+
+
+def test_arg_marshaller_without_launch_config_clears_outer_thread_local_temporarily():
+    outer_launch_config = {"block": (16, 1, 1)}
+    descriptor_mod._compile_arg_types.launch_config = outer_launch_config
+    observed = []
+
+    def launcher():
+        observed.append(hasattr(descriptor_mod._compile_arg_types, "launch_config"))
+        return "launched"
+
+    marshaller = _ArgMarshaller(launcher)
+
+    assert marshaller() == "launched"
+    assert observed == [False]
+    assert descriptor_mod._compile_arg_types.launch_config is outer_launch_config
+
+
+def test_arg_marshaller_refreshes_launch_config_dispatcher():
+    dispatcher = _Dispatcher()
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    kernel_dispatcher = object()
+
+    marshaller = _ArgMarshaller(
+        lambda: None,
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+        kernel_dispatcher=kernel_dispatcher,
+    )
+
+    marshaller()
+    marshaller()
+
+    assert dispatcher.remembered_dispatchers == [
+        (launch_config, kernel_dispatcher, launch_config, None)
+    ]
+
+
+def test_configure_records_normalized_launch_config(monkeypatch):
+    captured = []
+
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        captured.append(
+            {
+                "griddim": griddim,
+                "blockdim": blockdim,
+                "stream": stream,
+                "sharedmem": sharedmem,
+                "cluster": cluster,
+            }
+        )
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    marshaller = dispatcher.configure(2, 32)
+
+    assert captured == [
+        {
+            "griddim": (2, 1, 1),
+            "blockdim": (32, 1, 1),
+            "stream": None,
+            "sharedmem": 0,
+            "cluster": None,
+        }
+    ]
+    assert marshaller._launch_config == {
+        "grid": (2, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    assert dispatcher.configure(2, 32, None, 0) is marshaller
+
+    explicit = dispatcher.configure(2, 32, None, 4096)
+    assert captured[-1] == {
+        "griddim": (2, 1, 1),
+        "blockdim": (32, 1, 1),
+        "stream": None,
+        "sharedmem": 4096,
+        "cluster": None,
+    }
+    assert explicit._launch_config["sharedmem"] == 4096
+
+
+def test_configure_retains_python_stream_object(monkeypatch):
+    captured_streams = []
+
+    class FakeStream:
+        def __init__(self, handle):
+            self.handle = handle
+
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        captured_streams.append(stream)
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod.numba_cuda_driver, "Stream", FakeStream)
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    stream = FakeStream(123)
+    same_handle_stream = FakeStream(123)
+
+    marshaller = dispatcher.configure(2, 32, stream, 0)
+    same_stream_marshaller = dispatcher.configure(2, 32, stream, 0)
+    same_handle_marshaller = dispatcher.configure(2, 32, same_handle_stream, 0)
+
+    assert captured_streams == [123, 123]
+    assert same_stream_marshaller is marshaller
+    assert same_handle_marshaller is not marshaller
+    assert marshaller._stream_ref is stream
+    assert same_handle_marshaller._stream_ref is same_handle_stream
+
+
+def test_plain_configure_preserves_raw_sharedmem(monkeypatch):
+    captured = []
+
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        captured.append(sharedmem)
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+
+    marshaller = dispatcher.configure(2, 32, None, "dynamic")
+
+    assert captured == ["dynamic"]
+    assert marshaller._launch_config is None
+
+
+def test_configure_cache_tracks_mutated_non_launch_extensions(monkeypatch):
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    generic = dispatcher.configure(1, 32)
+
+    extension = _NonLaunchConfigExtension()
+    dispatcher.extensions.append(extension)
+    updated = dispatcher.configure(1, 32)
+
+    assert generic._extensions == []
+    assert updated is not generic
+    assert updated._extensions == [extension]
+    assert updated._launch_config is None
+
+
+def test_launch_config_configure_reports_invalid_sharedmem():
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+
+    with pytest.raises(TypeError, match="sharedmem.*integer-convertible"):
+        dispatcher.configure(2, 32, None, object())
+
+
+def test_configure_accepts_unhashable_extensions(monkeypatch):
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_UnhashableLaunchConfigExtension()]}
+    )
+
+    marshaller = dispatcher.configure(2, 32)
+
+    assert marshaller._launch_config == {
+        "grid": (2, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+
+
+def test_plain_configure_reports_unhashable_cache_values():
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+
+    with pytest.raises(TypeError, match="hashable"):
+        dispatcher.configure(2, 32, None, [])
+
+
+def test_shared_memory_carveout_helper_normalizes_strings():
+    class Cufunc:
+        def __init__(self):
+            self.carveout = None
+
+        def set_shared_memory_carveout(self, carveout):
+            self.carveout = carveout
+
+    class CodeLibrary:
+        def __init__(self):
+            self.cufunc = Cufunc()
+
+        def get_cufunc(self):
+            return self.cufunc
+
+    class Wrapped:
+        def __init__(self):
+            self._codelibrary = CodeLibrary()
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"shared_memory_carveout": "maxshared"}
+    )
+    wrapped = Wrapped()
+
+    dispatcher._apply_shared_memory_carveout(wrapped)
+
+    assert wrapped._codelibrary.cufunc.carveout == 100
+
+    invalid = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"shared_memory_carveout": "invalid"}
+    )
+    with pytest.raises(KeyError):
+        invalid._apply_shared_memory_carveout(wrapped)
+
+
+def test_compile_impl_generic_applies_shared_memory_carveout(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"shared_memory_carveout": "maxshared"}
+    )
+    applied = []
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"generic", "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        return CompilerResult()
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    monkeypatch.setattr(
+        dispatcher,
+        "_apply_shared_memory_carveout",
+        lambda wrapped: applied.append(wrapped),
+    )
+
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+
+    assert dispatcher._compile_impl([1]) == (b"generic", "kernel", False)
+    assert len(applied) == 1
+    assert dispatcher.overloads[(types.int32,)] is applied[0]
+
+
+def test_launch_config_key_validation():
+    launch_config = {
+        "grid": (2, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": None,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+
+    assert launch_key == (
+        ("grid", (2, 1, 1)),
+        ("block", (32, 1, 1)),
+        ("sharedmem", 0),
+        ("cluster", None),
+    )
+    assert descriptor_mod._launch_config_dict_from_key(launch_key) == {
+        "grid": (2, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    assert descriptor_mod._is_launch_config_dict({"grid": (1, 1, 1), "block": (32, 1, 1)})
+    assert not descriptor_mod._is_launch_config_dict({"block": (32, 1, 1)})
+
+    with pytest.raises(ValueError, match="block"):
+        descriptor_mod._launch_config_key({"sharedmem": 0, "cluster": None})
+    with pytest.raises(TypeError, match="block"):
+        descriptor_mod._launch_config_key(
+            {"grid": (1, 1, 1), "block": 32, "sharedmem": 0, "cluster": None}
+        )
+    with pytest.raises(ValueError, match="grid"):
+        descriptor_mod._launch_config_key({"block": (32, 1, 1), "sharedmem": 0, "cluster": None})
+    with pytest.raises(TypeError, match="grid"):
+        descriptor_mod._launch_config_key(
+            {
+                "grid": 1,
+                "block": (32, 1, 1),
+                "sharedmem": 0,
+                "cluster": None,
+            }
+        )
+    with pytest.raises(TypeError, match="cluster"):
+        descriptor_mod._launch_config_key(
+            {
+                "grid": (1, 1, 1),
+                "block": (32, 1, 1),
+                "sharedmem": 0,
+                "cluster": 1,
+            }
+        )
+    with pytest.raises(TypeError, match="sharedmem"):
+        descriptor_mod._launch_config_key(
+            {
+                "grid": (1, 1, 1),
+                "block": (32, 1, 1),
+                "sharedmem": object(),
+                "cluster": None,
+            }
+        )
+
+
+def test_launch_config_uses_distinct_native_dispatchers():
+    def kernel(out):
+        current_target_options()["__launch_config__"]
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    config_32 = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    config_64 = {
+        "grid": (1, 1, 1),
+        "block": (64, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    config_grid_2 = {
+        "grid": (2, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+
+    dispatcher_32 = dispatcher._get_kernel_dispatcher(config_32)
+
+    assert dispatcher_32 is dispatcher._get_kernel_dispatcher(config_32)
+    assert dispatcher_32 is not dispatcher._get_kernel_dispatcher(config_64)
+    assert dispatcher_32 is not dispatcher._get_kernel_dispatcher(config_grid_2)
+
+
+def test_plain_kernel_uses_default_native_dispatcher():
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+
+    assert dispatcher._get_kernel_dispatcher(config) is dispatcher._c
+
+
+def test_launch_config_dispatcher_cache_is_bounded(monkeypatch):
+    monkeypatch.setattr(descriptor_mod, "_OLD_DISPATCHER_RETAIN_LIMIT", 1024)
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+
+    first_dispatcher = dispatcher._get_kernel_dispatcher(
+        {
+            "grid": (1, 1, 1),
+            "block": (1, 1, 1),
+            "sharedmem": 0,
+            "cluster": None,
+        }
+    )
+    first_launch_key = descriptor_mod._launch_config_key(
+        {
+            "grid": (1, 1, 1),
+            "block": (1, 1, 1),
+            "sharedmem": 0,
+            "cluster": None,
+        }
+    )
+    first_overload_key = ((types.int32,), first_launch_key)
+    dispatcher._launch_config_overloads[first_overload_key] = _CompileResult((types.int32,))
+
+    for block_size in range(2, descriptor_mod._LAUNCH_CONFIG_CACHE_SIZE + 1):
+        dispatcher._get_kernel_dispatcher(
+            {
+                "grid": (1, 1, 1),
+                "block": (block_size, 1, 1),
+                "sharedmem": 0,
+                "cluster": None,
+            }
+        )
+
+    assert len(dispatcher._launch_config_dispatchers) == descriptor_mod._LAUNCH_CONFIG_CACHE_SIZE
+    assert first_dispatcher not in dispatcher._old_dispatchers
+
+    dispatcher._get_kernel_dispatcher(
+        {
+            "grid": (1, 1, 1),
+            "block": (descriptor_mod._LAUNCH_CONFIG_CACHE_SIZE + 1, 1, 1),
+            "sharedmem": 0,
+            "cluster": None,
+        }
+    )
+
+    assert len(dispatcher._launch_config_dispatchers) == descriptor_mod._LAUNCH_CONFIG_CACHE_SIZE
+    assert first_dispatcher in dispatcher._old_dispatchers
+    assert first_overload_key not in dispatcher._launch_config_overloads
+
+
+def test_launch_config_compatible_lookup_reuses_without_alias_growth():
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    compile_result = _CompileResult((types.int32,))
+    dispatcher._launch_config_overloads[((types.int32,), launch_key)] = compile_result
+
+    with dispatcher._launch_config_lock:
+        found = dispatcher._find_launch_config_overload_locked(
+            (types.int64,),
+            launch_key,
+        )
+
+    assert found is compile_result
+    assert ((types.int64,), launch_key) not in dispatcher._launch_config_overloads
+
+
+def test_disabled_compile_rejects_nonmatching_launch_specialization():
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    dispatcher._launch_config_overloads[((types.float32,), launch_key)] = _CompileResult(
+        (types.float32,)
+    )
+    dispatcher.disable_compile()
+    descriptor_mod._compile_arg_types.types = (types.complex64,)
+    descriptor_mod._compile_arg_types.launch_config = launch_config
+
+    with pytest.raises(TypeError, match="No matching launch-config specialization"):
+        dispatcher._compile_impl([1 + 0j])
+
+
+def test_launch_config_enabled_tracks_mutated_extensions():
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    assert (
+        dispatcher._get_kernel_dispatcher(
+            {
+                "grid": (1, 1, 1),
+                "block": (32, 1, 1),
+                "sharedmem": 0,
+                "cluster": None,
+            }
+        )
+        is dispatcher._c
+    )
+
+    dispatcher.extensions.append(_LaunchConfigExtension())
+    configured_dispatcher = dispatcher._get_kernel_dispatcher(
+        {
+            "grid": (1, 1, 1),
+            "block": (32, 1, 1),
+            "sharedmem": 0,
+            "cluster": None,
+        }
+    )
+
+    assert configured_dispatcher is not dispatcher._c
+
+
+def test_configure_cache_tracks_mutated_extensions(monkeypatch):
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    generic = dispatcher.configure(1, 32)
+    assert hasattr(dispatcher.configure, "cache_clear")
+    dispatcher.configure.cache_clear()
+    generic_after_clear = dispatcher.configure(1, 32)
+
+    dispatcher.extensions.append(_LaunchConfigExtension())
+    launch_sensitive = dispatcher.configure(1, 32)
+
+    assert generic._launch_config is None
+    assert generic_after_clear is not generic
+    assert launch_sensitive is not generic
+    assert launch_sensitive._launch_config == {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    assert launch_sensitive._kernel_dispatcher is not dispatcher._c
+
+
+def test_configure_uses_extension_snapshot_if_extensions_mutate_during_miss(monkeypatch):
+    launch_extension = _LaunchConfigExtension()
+    replacement_extension = _NonLaunchConfigExtension()
+
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        dispatcher.extensions[:] = [replacement_extension]
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [launch_extension]}
+    )
+
+    marshaller = dispatcher.configure(1, 32)
+
+    assert dispatcher.extensions == [replacement_extension]
+    assert marshaller._extensions == [launch_extension]
+    assert marshaller._launch_config == {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+
+
+def test_launch_config_dispatcher_cache_retains_boundary_before_eviction():
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+
+    for block_size in range(1, descriptor_mod._LAUNCH_CONFIG_CACHE_SIZE + 1):
+        dispatcher._get_kernel_dispatcher(
+            {
+                "grid": (1, 1, 1),
+                "block": (block_size, 1, 1),
+                "sharedmem": 0,
+                "cluster": None,
+            }
+        )
+
+    assert len(dispatcher._launch_config_dispatchers) == descriptor_mod._LAUNCH_CONFIG_CACHE_SIZE
+    assert not dispatcher._old_dispatchers
+
+
+def test_retained_marshaller_reregisters_after_cache_eviction(monkeypatch):
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    marshaller = dispatcher.configure(1, 1)
+    launch_key = descriptor_mod._launch_config_key(marshaller._launch_config)
+    retained_kernel_dispatcher = marshaller._kernel_dispatcher
+
+    marshaller()
+    assert dispatcher._launch_config_dispatchers[launch_key] is retained_kernel_dispatcher
+
+    for block_size in range(2, descriptor_mod._LAUNCH_CONFIG_CACHE_SIZE + 2):
+        dispatcher._get_kernel_dispatcher(
+            {
+                "grid": (1, 1, 1),
+                "block": (block_size, 1, 1),
+                "sharedmem": 0,
+                "cluster": None,
+            }
+        )
+
+    assert launch_key not in dispatcher._launch_config_dispatchers
+
+    marshaller()
+
+    assert dispatcher._launch_config_dispatchers[launch_key] is retained_kernel_dispatcher
+
+
+def test_retained_marshaller_does_not_reregister_after_recompile(monkeypatch):
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    marshaller = dispatcher.configure(1, 32)
+    old_kernel_dispatcher = marshaller._kernel_dispatcher
+
+    dispatcher.recompile()
+    marshaller()
+    fresh_marshaller = dispatcher.configure(1, 32)
+
+    assert old_kernel_dispatcher not in dispatcher._launch_config_dispatchers.values()
+    assert fresh_marshaller._kernel_dispatcher is not old_kernel_dispatcher
+    assert fresh_marshaller._kernel_dispatcher in dispatcher._launch_config_dispatchers.values()
+
+
+def test_configure_discards_marshaller_if_recompile_advances_generation(monkeypatch):
+    captured_dispatchers = []
+
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        captured_dispatchers.append(kernel_dispatcher)
+        if len(captured_dispatchers) == 1:
+            dispatcher.recompile()
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+
+    marshaller = dispatcher.configure(1, 32)
+
+    assert len(captured_dispatchers) == 2
+    assert captured_dispatchers[0] not in dispatcher._launch_config_dispatchers.values()
+    assert marshaller._launch_config_generation == dispatcher._launch_config_generation
+    assert marshaller._kernel_dispatcher in dispatcher._launch_config_dispatchers.values()
+
+
+def test_concurrent_configure_same_key_builds_single_marshaller(monkeypatch):
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    original_configure_cached = dispatcher._configure_cached
+    calls = []
+    first_miss_started = threading.Event()
+    release_first_miss = threading.Event()
+    second_wait_started = threading.Event()
+    thread_timeout = 10
+
+    def configure_cached(*args):
+        calls.append(args)
+        first_miss_started.set()
+        release_first_miss.wait(timeout=thread_timeout)
+        return original_configure_cached(*args)
+
+    monkeypatch.setattr(dispatcher, "_configure_cached", configure_cached)
+    results = []
+
+    def configure_kernel():
+        results.append(dispatcher.configure(1, 32))
+
+    first_thread = threading.Thread(target=configure_kernel)
+    first_thread.start()
+    assert first_miss_started.wait(timeout=thread_timeout)
+    with dispatcher._launch_config_lock:
+        [inflight] = dispatcher._configure_cache_inflight.values()
+    original_wait = inflight.wait
+    wait_timeouts = []
+
+    def observe_wait(timeout=None):
+        wait_timeouts.append(timeout)
+        second_wait_started.set()
+        return original_wait(timeout=timeout)
+
+    monkeypatch.setattr(inflight, "wait", observe_wait)
+
+    second_thread = threading.Thread(target=configure_kernel)
+    second_thread.start()
+    assert second_wait_started.wait(timeout=thread_timeout)
+    release_first_miss.set()
+
+    first_thread.join(timeout=thread_timeout)
+    second_thread.join(timeout=thread_timeout)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert wait_timeouts == [None]
+    assert len(calls) == 1
+    assert len(results) == 2
+    assert results[0] is results[1]
+
+
+def test_stale_launch_generation_does_not_reregister_dispatcher():
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    stale_dispatcher, stale_generation = dispatcher._get_kernel_dispatcher_and_generation(
+        launch_config
+    )
+
+    dispatcher.recompile()
+    dispatcher._remember_kernel_dispatcher(
+        launch_config,
+        stale_dispatcher,
+        stale_generation,
+    )
+
+    assert stale_dispatcher not in dispatcher._launch_config_dispatchers.values()
+
+
+def test_dispatcher_creation_retries_if_generation_advances(monkeypatch):
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    created_dispatchers = []
+
+    def new_kernel_dispatcher():
+        kernel_dispatcher = object()
+        created_dispatchers.append(kernel_dispatcher)
+        if len(created_dispatchers) == 1:
+            with dispatcher._launch_config_lock:
+                dispatcher._launch_config_generation += 1
+        return kernel_dispatcher
+
+    monkeypatch.setattr(dispatcher, "_new_kernel_dispatcher", new_kernel_dispatcher)
+
+    kernel_dispatcher, generation = dispatcher._get_kernel_dispatcher_and_generation(launch_config)
+
+    assert len(created_dispatchers) == 2
+    assert created_dispatchers[1] is kernel_dispatcher
+    assert generation == dispatcher._launch_config_generation
+    assert dispatcher._launch_config_dispatchers[launch_key] is kernel_dispatcher
+    assert created_dispatchers[0] not in dispatcher._launch_config_dispatchers.values()
+
+
+def test_retained_launch_dispatcher_replaces_duplicate_entry(monkeypatch):
+    monkeypatch.setattr(descriptor_mod, "_OLD_DISPATCHER_RETAIN_LIMIT", 1024)
+
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    retained = dispatcher._get_kernel_dispatcher(launch_config)
+    duplicate = object()
+    dispatcher._launch_config_dispatchers[launch_key] = duplicate
+
+    dispatcher._remember_kernel_dispatcher(
+        launch_config,
+        retained,
+        dispatcher._launch_config_generation,
+    )
+
+    assert dispatcher._launch_config_dispatchers[launch_key] is retained
+    assert duplicate in dispatcher._old_dispatchers
+
+
+def test_retained_marshaller_reregister_does_not_replace_newer_dispatcher():
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    newer_dispatcher = object()
+    retained_dispatcher = object()
+    dispatcher._launch_config_dispatchers[launch_key] = newer_dispatcher
+
+    registered = dispatcher._remember_kernel_dispatcher(
+        launch_config,
+        retained_dispatcher,
+        dispatcher._launch_config_generation,
+        replace_existing=False,
+    )
+
+    assert registered is False
+    assert dispatcher._launch_config_dispatchers[launch_key] is newer_dispatcher
+    assert retained_dispatcher not in dispatcher._old_dispatchers
+
+
+def test_inspection_keys_keep_generic_overload_shape():
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    generic_sig = (types.float32,)
+    launch_sig = (types.int32,)
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    dispatcher.overloads[generic_sig] = _CompileResult(generic_sig, ptx="generic")
+    launch_result = _CompileResult(launch_sig, ptx="launch")
+    dispatcher._launch_config_overloads[(launch_sig, launch_key)] = launch_result
+
+    asm = dispatcher.inspect_asm()
+    launch_keys = [key for key in asm if isinstance(key, descriptor_mod.LaunchConfigInspectableKey)]
+
+    assert asm[generic_sig] == "generic"
+    assert len(launch_keys) == 1
+    assert launch_keys[0].argtypes == launch_sig
+    assert launch_keys[0].launch_config_key == launch_key
+    assert asm[launch_keys[0]] == "launch"
+    assert (generic_sig, None) not in asm
+    assert launch_keys[0] in dispatcher.signatures
+
+    compatible_key = descriptor_mod.LaunchConfigInspectableKey((types.int64,), launch_key)
+    assert dispatcher.inspect_asm(compatible_key) == "launch"
+    assert ((types.int64,), launch_key) not in dispatcher._launch_config_overloads
+    assert dispatcher.inspect_asm((launch_sig, launch_config)) == "launch"
+    assert (
+        dispatcher.inspect_asm((launch_sig, {"grid": (1, 1, 1), "block": (32, 1, 1)})) == "launch"
+    )
+    assert dispatcher.get_metadata(generic_sig) == {"ptx": "generic"}
+    assert dispatcher.get_metadata(launch_keys[0]) == {"ptx": "launch"}
+    assert dispatcher.get_metadata()[launch_keys[0]] == {"ptx": "launch"}
+
+    missing_key = descriptor_mod.LaunchConfigInspectableKey(
+        launch_sig,
+        descriptor_mod._launch_config_key(
+            {
+                "grid": (1, 1, 1),
+                "block": (64, 1, 1),
+                "sharedmem": 0,
+                "cluster": None,
+            }
+        ),
+    )
+    with pytest.raises(KeyError, match="No launch-config overload"):
+        dispatcher.inspect_asm(missing_key)
+    with pytest.raises(KeyError, match="No launch-config overload"):
+        dispatcher.inspect_asm((launch_sig, missing_key.launch_config_key))
+    with pytest.raises(KeyError, match="No launch-config overload"):
+        dispatcher.inspect_asm(
+            (
+                launch_sig,
+                {
+                    "grid": (1, 1, 1),
+                    "block": (64, 1, 1),
+                    "sharedmem": 0,
+                    "cluster": None,
+                },
+            )
+        )
+    with pytest.raises(KeyError, match="No overload found"):
+        dispatcher.inspect_asm((launch_sig, {"block": (32, 1, 1)}))
+
+
+def test_disabled_launch_config_overload_coerces_to_active_specialization():
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    dispatcher._launch_config_overloads[((types.float32,), launch_key)] = _CompileResult(
+        (types.float32,)
+    )
+    dispatcher.disable_compile()
+    marshaller = _ArgMarshaller(
+        lambda: None,
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+    )
+
+    coerced_args, coerced_types = marshaller._coerce_to_overload([7], [types.int64])
+
+    assert coerced_args == [np.float32(7)]
+    assert coerced_types == [types.float32]
+
+
+def test_compile_ignores_stale_launch_config_after_extension_removed():
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    sig_args = (types.float32,)
+    compile_result = _CompileResult(sig_args)
+    compile_result.metadata.update({"cubin": b"generic", "func_name": "kernel"})
+    dispatcher.overloads[sig_args] = compile_result
+    dispatcher.disable_compile()
+    dispatcher.extensions.clear()
+
+    descriptor_mod._compile_arg_types.types = sig_args
+    descriptor_mod._compile_arg_types.launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+
+    assert dispatcher._compile_impl([np.float32(1)]) == (b"generic", "kernel", False)
+
+
+def test_retained_marshaller_compiles_with_extension_snapshot_after_mutation(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    launch_extension = _LaunchConfigExtension()
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [launch_extension]}
+    )
+    compile_calls = []
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"launch", "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append((tuple(override_argtypes), dict(targetoptions)))
+        return CompilerResult()
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    marshaller = _ArgMarshaller(
+        lambda *args: dispatcher._compile_impl(list(args)),
+        extensions=dispatcher.extensions,
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+    )
+    dispatcher.extensions.clear()
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ):
+        assert marshaller._launch((types.int32,), [1]) == (b"launch", "kernel", False)
+
+    assert len(compile_calls) == 1
+    assert compile_calls[0][0] == (types.int32,)
+    compile_targetoptions = compile_calls[0][1]
+    assert compile_targetoptions["extensions"] is marshaller._extensions
+    assert compile_targetoptions["extensions"] == [launch_extension]
+    assert compile_targetoptions["extensions"] is not dispatcher.extensions
+    assert compile_targetoptions["__launch_config__"] == launch_config
+
+
+def test_disabled_coercion_ignores_stale_launch_config_after_extension_removed():
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    dispatcher.overloads[(types.float32,)] = _CompileResult((types.float32,))
+    dispatcher.disable_compile()
+    dispatcher.extensions.clear()
+
+    marshaller = _ArgMarshaller(
+        lambda: None,
+        dispatcher=dispatcher,
+        launch_config={
+            "grid": (1, 1, 1),
+            "block": (32, 1, 1),
+            "sharedmem": 0,
+            "cluster": None,
+        },
+    )
+
+    coerced_args, coerced_types = marshaller._coerce_to_overload([7], [types.int64])
+
+    assert coerced_args == [np.float32(7)]
+    assert coerced_types == [types.float32]
+
+
+def test_forall_uses_launch_config_overload_for_occupancy(monkeypatch):
+    from cuda.bindings import driver
+
+    def kernel(x):
+        pass
+
+    class Cufunc:
+        _handle = object()
+
+    class CodeLibrary:
+        def __init__(self):
+            self.cufunc = Cufunc()
+
+        def get_cufunc(self):
+            return self.cufunc
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    compile_result = _CompileResult((types.int32,))
+    compile_result._codelibrary = CodeLibrary()
+    dispatcher._launch_config_overloads[((types.int32,), launch_key)] = compile_result
+    occupancy_calls = []
+
+    def occupancy(handle, callback, sharedmem, block_limit):
+        occupancy_calls.append((handle, callback, sharedmem, block_limit))
+        return 1, 256
+
+    monkeypatch.setattr(driver, "cuOccupancyMaxPotentialBlockSize", occupancy)
+
+    launcher = descriptor_mod._ForAll(dispatcher, ntasks=1000, tpb=0, stream=0, sharedmem=48)
+
+    assert launcher._compute_thread_per_block() == 256
+    assert occupancy_calls == [(compile_result._codelibrary.cufunc._handle, None, 48, 1024)]
+
+
+def test_stats_preserves_legacy_shape_and_exposes_launch_config_stats():
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+
+    assert dispatcher.stats._fields == ("cache_path", "cache_hits", "cache_misses")
+    assert dispatcher.launch_config_stats.cache_hits is dispatcher._launch_config_cache_hits
+    assert dispatcher.launch_config_stats.cache_misses is dispatcher._launch_config_cache_misses
+
+
+def test_launch_config_accessors_initialize_restored_dispatcher_state():
+    dispatcher = descriptor_mod.MLIRDispatcher.__new__(descriptor_mod.MLIRDispatcher)
+    dispatcher.overloads = {}
+
+    assert not dispatcher.launch_config_stats.cache_hits
+    assert not dispatcher.launch_config_stats.cache_misses
+    assert dispatcher.signatures == []
+
+
+def test_recompile_resets_launch_config_cache_notice():
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    dispatcher._launch_config_cache_notice_emitted = True
+
+    dispatcher.recompile()
+
+    assert dispatcher._launch_config_cache_notice_emitted is False
+
+
+def test_compile_impl_launch_config_publishes_aliases_and_skips_disk_cache(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    compile_calls = []
+    saved_overloads = []
+    trace_messages = []
+
+    class CompilerResult:
+        def __init__(self, sig_args, cubin):
+            self.signature = cuda_typing.signature(types.none, *sig_args)
+            self.metadata = {"cubin": cubin, "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append((tuple(override_argtypes), dict(targetoptions)))
+        return CompilerResult(tuple(override_argtypes), f"cubin-{len(compile_calls)}".encode())
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    monkeypatch.setattr(
+        dispatcher._cache,
+        "save_overload",
+        lambda *args: saved_overloads.append(args),
+    )
+    monkeypatch.setattr(descriptor_mod, "trace", lambda message: trace_messages.append(message))
+
+    first_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    first_launch_key = descriptor_mod._launch_config_key(first_launch_config)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.launch_config = first_launch_config
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ) as warning_records:
+        assert dispatcher._compile_impl([1]) == (b"cubin-1", "kernel", False)
+
+        second_launch_config = {
+            "grid": (1, 1, 1),
+            "block": (64, 1, 1),
+            "sharedmem": 0,
+            "cluster": None,
+        }
+        second_launch_key = descriptor_mod._launch_config_key(second_launch_config)
+        descriptor_mod._compile_arg_types.types = (types.int64,)
+        descriptor_mod._compile_arg_types.launch_config = second_launch_config
+
+        assert dispatcher._compile_impl([2]) == (b"cubin-2", "kernel", False)
+
+    assert len(warning_records) == 1
+    assert [call[0] for call in compile_calls] == [(types.int32,), (types.int64,)]
+    assert compile_calls[0][1]["extensions"] is dispatcher.extensions
+    assert compile_calls[0][1]["__launch_config__"] == first_launch_config
+    assert compile_calls[1][1]["extensions"] is dispatcher.extensions
+    assert compile_calls[1][1]["__launch_config__"] == second_launch_config
+    assert (
+        dispatcher._launch_config_overloads[((types.int32,), first_launch_key)].metadata["cubin"]
+        == b"cubin-1"
+    )
+    assert (
+        dispatcher._launch_config_overloads[((types.int64,), second_launch_key)].metadata["cubin"]
+        == b"cubin-2"
+    )
+    assert not dispatcher.overloads
+    assert saved_overloads == []
+    assert trace_messages == [
+        "Persistent disk cache is disabled for launch-config-specialized "
+        "compiles because the disk cache key does not include launch metadata."
+    ]
+
+
+def test_compile_impl_launch_config_separates_same_signature_by_grid(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    compile_calls = []
+
+    class CompilerResult:
+        def __init__(self, cubin):
+            self.signature = cuda_typing.signature(types.none, types.int32)
+            self.metadata = {"cubin": cubin, "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append((tuple(override_argtypes), dict(targetoptions)))
+        return CompilerResult(f"cubin-{len(compile_calls)}".encode())
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+
+    first_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    second_launch_config = {
+        "grid": (2, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    first_launch_key = descriptor_mod._launch_config_key(first_launch_config)
+    second_launch_key = descriptor_mod._launch_config_key(second_launch_config)
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ) as warning_records:
+        descriptor_mod._compile_arg_types.types = (types.int32,)
+        descriptor_mod._compile_arg_types.launch_config = first_launch_config
+        assert dispatcher._compile_impl([1]) == (b"cubin-1", "kernel", False)
+
+        descriptor_mod._compile_arg_types.types = (types.int32,)
+        descriptor_mod._compile_arg_types.launch_config = second_launch_config
+        assert dispatcher._compile_impl([1]) == (b"cubin-2", "kernel", False)
+
+    assert len(warning_records) == 1
+    assert first_launch_key != second_launch_key
+    assert [call[0] for call in compile_calls] == [(types.int32,), (types.int32,)]
+    assert compile_calls[0][1]["__launch_config__"] == first_launch_config
+    assert compile_calls[1][1]["__launch_config__"] == second_launch_config
+    assert (
+        dispatcher._launch_config_overloads[((types.int32,), first_launch_key)].metadata["cubin"]
+        == b"cubin-1"
+    )
+    assert (
+        dispatcher._launch_config_overloads[((types.int32,), second_launch_key)].metadata["cubin"]
+        == b"cubin-2"
+    )
+
+
+def test_compile_impl_discards_callbacks_after_generation_retry(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    stale_setup_callback = lambda obj: None
+    accepted_setup_callback = lambda obj: None
+    compile_calls = []
+
+    class CompilerResult:
+        def __init__(self, cubin, setup_callback):
+            self.signature = cuda_typing.signature(types.none, types.int32)
+            self.metadata = {
+                "cubin": cubin,
+                "func_name": "kernel",
+                "setup_callbacks": [setup_callback],
+            }
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append(dict(targetoptions))
+        if len(compile_calls) == 1:
+            with dispatcher._launch_config_lock:
+                dispatcher._launch_config_generation += 1
+            return CompilerResult(b"stale", stale_setup_callback)
+        return CompilerResult(b"accepted", accepted_setup_callback)
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.launch_config = launch_config
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ):
+        assert dispatcher._compile_impl([1]) == (b"accepted", "kernel", False)
+
+    assert len(compile_calls) == 2
+    assert stale_setup_callback not in dispatcher._module_setup_callbacks
+    assert accepted_setup_callback in dispatcher._module_setup_callbacks
+
+
+def test_compile_impl_discards_callbacks_from_duplicate_launch_compile(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    losing_setup_callback = lambda obj: None
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {
+            "cubin": b"loser",
+            "func_name": "kernel",
+            "setup_callbacks": [losing_setup_callback],
+        }
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        winner = _CompileResult((types.int32,))
+        winner.metadata.update({"cubin": b"winner", "func_name": "kernel"})
+        dispatcher._launch_config_overloads[((types.int32,), launch_key)] = winner
+        return CompilerResult()
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.launch_config = launch_config
+
+    assert dispatcher._compile_impl([1]) == (b"winner", "kernel", False)
+    assert losing_setup_callback not in dispatcher._module_setup_callbacks
+
+
+def test_disabled_launch_config_reduce_rebuild_restores_launch_sigs(monkeypatch):
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    sig_args = (types.float32,)
+    compile_result = _CompileResult(sig_args)
+    dispatcher._launch_config_overloads[(sig_args, launch_key)] = compile_result
+    dispatcher.disable_compile()
+
+    compiled = []
+
+    def compile_launch_config_signature(self, sig, launch_config_key):
+        compiled.append((tuple(sig.args), launch_config_key, self._can_compile))
+        self._launch_config_overloads[(tuple(sig.args), launch_config_key)] = _CompileResult(
+            tuple(sig.args)
+        )
+
+    monkeypatch.setattr(
+        descriptor_mod.MLIRDispatcher,
+        "_compile_launch_config_signature",
+        compile_launch_config_signature,
+    )
+
+    states = dispatcher._reduce_states()
+    states["uuid"] = states["uuid"] + "-rebuilt"
+    rebuilt = descriptor_mod.MLIRDispatcher._rebuild(**states)
+
+    assert states["sigs"] == []
+    assert states["launch_config_sigs"] == [(compile_result.signature, launch_key)]
+    assert compiled == [(sig_args, launch_key, True)]
+    assert rebuilt._can_compile is False
+    assert (sig_args, launch_key) in rebuilt.launch_config_overloads
+
+
+def test_compile_launch_config_signature_forces_launch_rebuild_without_extensions(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    compile_calls = []
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"rebuilt", "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append(dict(targetoptions))
+        return CompilerResult()
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ):
+        rebuilt = dispatcher._compile_launch_config_signature(
+            cuda_typing.signature(types.none, types.int32),
+            launch_key,
+        )
+
+    assert rebuilt.metadata["cubin"] == b"rebuilt"
+    assert dispatcher.launch_config_overloads[((types.int32,), launch_key)] is rebuilt
+    assert len(compile_calls) == 1
+    assert compile_calls[0]["extensions"] == []
+    assert compile_calls[0]["__launch_config__"] == launch_config
+    assert not hasattr(descriptor_mod._compile_arg_types, "force_launch_config")
+
+
+def test_disabled_launch_config_reduce_skips_launch_sigs_after_extension_removed(
+    monkeypatch,
+):
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    sig_args = (types.float32,)
+    compile_result = _CompileResult(sig_args)
+    dispatcher._launch_config_overloads[(sig_args, launch_key)] = compile_result
+    dispatcher.disable_compile()
+    dispatcher.extensions.clear()
+
+    def compile_launch_config_signature(*args):
+        raise AssertionError("stale launch-config signatures should not be rebuilt")
+
+    monkeypatch.setattr(
+        descriptor_mod.MLIRDispatcher,
+        "_compile_launch_config_signature",
+        compile_launch_config_signature,
+    )
+
+    states = dispatcher._reduce_states()
+    states["uuid"] = states["uuid"] + "-rebuilt"
+    rebuilt = descriptor_mod.MLIRDispatcher._rebuild(**states)
+
+    assert states["launch_config_sigs"] == []
+    assert rebuilt._can_compile is False
+    assert not rebuilt.launch_config_overloads
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_launch_config_specializes_same_signature_launches():
+    @cuda.jit(extensions=[_LaunchConfigExtension()])
+    def kernel(out):
+        out[0] = consteval(current_target_options()["__launch_config__"]["block"][0])
+
+    out = np.zeros(1, dtype=np.int32)
+
+    kernel[1, 32](out)
+    assert out[0] == 32
+    misses_after_first_launch = sum(kernel._launch_config_cache_misses.values())
+
+    kernel[1, 32](out)
+    assert out[0] == 32
+    assert sum(kernel._launch_config_cache_misses.values()) == misses_after_first_launch
+
+    kernel[2, 32](out)
+    assert out[0] == 32
+    assert sum(kernel._launch_config_cache_misses.values()) == misses_after_first_launch + 1
+
+    kernel[1, 64](out)
+    assert out[0] == 64
+    assert sum(kernel._launch_config_cache_misses.values()) == misses_after_first_launch + 2
+    assert kernel.signatures
+    assert kernel.nopython_signatures
+    assert kernel.launch_config_overloads


### PR DESCRIPTION
Closes #59.

## Summary
- Add extension opt-in for launch-sensitive compilation via `uses_launch_config = True`.
- Thread normalized launch metadata through dispatch: `grid`, `block`, normalized dynamic `sharedmem`, and `cluster`.
- Include launch metadata in per-launch specialization keys and in-memory overload caches so same-signature kernels can specialize on launch metadata without polluting ordinary generic overloads.
- Keep ordinary kernels and the persistent disk cache path unchanged; launch-specialized compiles skip persistent disk cache because the existing disk key does not include launch metadata.
- Preserve launch-qualified overloads across disabled-compile serialization and expose them through inspection APIs with launch-qualified keys.

## Why
Cooperative/CUDA extension lowering needs compile-time launch metadata to specialize primitives and resource use. Without launch-qualified caching, same-signature launches with different grid, block, shared-memory, or cluster settings can reuse stale consteval/lowering results.

## Validation
- `PYTHONPATH=$PWD/src python -m pytest -o addopts='' tests/test_descriptor_launch_config.py -q`
- `PYTHONPATH=$PWD/src python -m pytest -o addopts='' tests/test_forall.py tests/test_cuda_array_interface_launch_cache.py tests/test_cluster_launch.py -q`
- `ruff check src/numba_cuda_mlir/descriptor.py tests/test_descriptor_launch_config.py`
- `ruff format --check src/numba_cuda_mlir/descriptor.py tests/test_descriptor_launch_config.py`
- `git diff --check`
- `roborev review 3428053 --wait`: pass