### PR TITLE
Preserve memref offsets in pointer casts

### DIFF
--- a/src/numba_cuda_mlir/lowering/cuda.py
+++ b/src/numba_cuda_mlir/lowering/cuda.py
@@ -32,6 +32,7 @@ from numba_cuda_mlir.lowering_utilities import (
     memref_to_llvm_ptr,
     storage_itemsize_bytes,
     storage_bitwidth,
+    memref_llvm_address_space,
 )
 from numba_cuda_mlir.lowering_utilities.type_conversions import (
     to_mlir_type,
@@ -1120,21 +1121,9 @@ def cuda_generic_atomic_cg(builder, target, mr, indices, value, body_builder):
     builder.store_var(target, ir.Value(rmw))
 
 
-def _get_llvm_address_space(memref_type: ir.MemRefType) -> int:
-    mspace = memref_type.memory_space
-    if mspace is None:
-        return 1  # Global memory
-    mspace_str = str(mspace)
-    if "workgroup" in mspace_str:
-        return 3  # Shared memory
-    if "private" in mspace_str:
-        return 5  # Local/private memory
-    return 1  # Default to global
-
-
 def _atomic_ptr(mr: ir.Value, indices: list[ir.Value], value_type: ir.Type) -> ir.Value:
     llvm_kDynamic = -2147483648
-    addrspace = _get_llvm_address_space(mr.type)
+    addrspace = memref_llvm_address_space(mr.type)
     ptr_type = llvm.PointerType.get(addrspace)
 
     md = memref.extract_strided_metadata(mr)

--- a/src/numba_cuda_mlir/lowering/math.py
+++ b/src/numba_cuda_mlir/lowering/math.py
@@ -452,8 +452,9 @@ def pointer_array_cg(builder, target, args, kwargs):
         "calling types.ptr() is only supported on arrays, pointers, and integers"
     )
     array = builder.load_var(args[0])
-    result = memref.extract_aligned_pointer_as_index(array)
-    result = convert(result, llvm.PointerType.get())
+    result = lowering_utilities.memref_data_pointer_as_index(array)
+    result = arith.index_cast(T.i64(), result)
+    result = llvm.inttoptr(res=llvm.PointerType.get(), arg=result)
     builder.store_var(target, result)
 
 

--- a/src/numba_cuda_mlir/lowering_utilities/__init__.py
+++ b/src/numba_cuda_mlir/lowering_utilities/__init__.py
@@ -40,11 +40,64 @@ import operator
 GEP_DYNAMIC_INDEX = -2147483648
 
 
+def memref_llvm_address_space(memref_type: ir.MemRefType) -> int:
+    """Return the NVVM LLVM address space for a CUDA memref type.
+
+    Untagged CUDA kernel argument memrefs represent global memory. Tagged memrefs
+    are used for explicit CUDA spaces such as workgroup/shared and private/local.
+    """
+    memory_space = memref_type.memory_space
+    if memory_space is None:
+        return 1
+    if isinstance(memory_space, ir.IntegerAttr):
+        return int(memory_space.value)
+    memory_space_str = str(memory_space)
+    if "workgroup" in memory_space_str:
+        return 3
+    if "private" in memory_space_str:
+        return 5
+    return 1
+
+
+def _memref_llvm_pointer_type(memref_type: ir.MemRefType) -> llvm.PointerType:
+    return llvm.PointerType.get(memref_llvm_address_space(memref_type))
+
+
+def memref_data_pointer_as_index(array: ir.Value, element_type: ir.Type | None = None) -> ir.Value:
+    metadata = memref.extract_strided_metadata(array)
+    base_ptr_idx = memref.extract_aligned_pointer_as_index(metadata[0])
+    offset = index_of(metadata[1])
+    if element_type is None:
+        element_type = ir.MemRefType(array.type).element_type
+    elem_bytes = get_type_size_bytes(element_type)
+    byte_offset = arith.muli(offset, arith.constant(T.index(), elem_bytes))
+    return arith.addi(base_ptr_idx, byte_offset)
+
+
+def _memref_index_offset(array: ir.Value, indices: list[ir.Value]) -> ir.Value:
+    """Return the element offset for indices into a potentially-strided memref."""
+    metadata = memref.extract_strided_metadata(array)
+    rank = array.type.rank
+    ndim = len(indices)
+    if ndim == 1 and rank != 1:
+        return convert(indices[0], T.i64())
+    if ndim != rank:
+        raise ValueError(
+            f"Expected either a scalar linear index or {rank} indices for {array.type}, got {ndim}"
+        )
+    linear_idx = arith.constant(T.i64(), 0)
+    for d, index in enumerate(indices):
+        idx_val = convert(index, T.i64())
+        stride = convert(metadata[2 + rank + d], T.i64())
+        linear_idx = linear_idx + idx_val * stride
+    return linear_idx
+
+
 def memref_to_llvm_ptr(array: ir.Value, indices: list[ir.Value], element_type: ir.Type) -> ir.Value:
     """Convert memref + indices to LLVM pointer.
 
-    Extracts base pointer from potentially strided memref and computes
-    element pointer using getelementptr with linearized indices.
+    Extracts base pointer from a potentially-strided memref and computes the
+    element pointer using the memref metadata offset and strides.
 
     Args:
         array: Memref value (potentially strided)
@@ -54,50 +107,21 @@ def memref_to_llvm_ptr(array: ir.Value, indices: list[ir.Value], element_type: i
     Returns:
         LLVM pointer (!llvm.ptr) to the indexed element
     """
-    # Extract base pointer from memref and convert to LLVM pointer
-    base_ptr_idx = memref.extract_aligned_pointer_as_index(array)
-    base_ptr = convert(base_ptr_idx, llvm.PointerType.get())
+    # Extract base pointer from memref and convert to an address-space-preserving
+    # LLVM pointer.
+    ptr_type = _memref_llvm_pointer_type(ir.MemRefType(array.type))
+    base_ptr_idx = memref_data_pointer_as_index(array)
+    base_ptr = llvm.inttoptr(res=ptr_type, arg=convert(base_ptr_idx, T.i64()))
 
-    # Compute linear offset and use getelementptr
-    if len(indices) == 1:
-        # 1D case: simple offset
-        idx = convert(indices[0], T.i64())
-        element_ptr = llvm.getelementptr(
-            llvm.PointerType.get(),
-            base_ptr,
-            [idx],
-            [GEP_DYNAMIC_INDEX],
-            element_type,
-            None,
-        )
-    else:
-        # N-D case: linearize indices using row-major strides
-        ndim = len(indices)
-
-        # Compute strides for row-major layout (C order)
-        strides = [None] * ndim
-        strides[-1] = arith.constant(T.i64(), 1)
-        for d in range(ndim - 2, -1, -1):
-            dim_size = memref.dim(array, index_of(d + 1))
-            dim_size = convert(dim_size, T.i64())
-            strides[d] = dim_size * strides[d + 1]
-
-        # Compute linear index: sum(index[d] * stride[d])
-        linear_idx = arith.constant(T.i64(), 0)
-        for d in range(ndim):
-            idx_val = convert(indices[d], T.i64())
-            linear_idx = linear_idx + idx_val * strides[d]
-
-        element_ptr = llvm.getelementptr(
-            llvm.PointerType.get(),
-            base_ptr,
-            [linear_idx],
-            [GEP_DYNAMIC_INDEX],
-            element_type,
-            None,
-        )
-
-    return element_ptr
+    linear_idx = _memref_index_offset(array, indices)
+    return llvm.getelementptr(
+        ptr_type,
+        base_ptr,
+        [linear_idx],
+        [GEP_DYNAMIC_INDEX],
+        element_type,
+        None,
+    )
 
 
 def memref_to_tensor(memref):
@@ -209,6 +233,14 @@ def llvm_struct_to_complex(value, complex_type):
         position=ir.DenseI64ArrayAttr.get([1]),
     )
     return complex_dialect.create_(complex=complex_type, real=real, imaginary=imag)
+
+
+def get_type_size_bytes(ty: ir.Type) -> int:
+    if isinstance(ty, ir.BF16Type):
+        return 2
+    # CUDA memrefs handled here are byte-addressable. Numpy bool storage is one
+    # byte even though the MLIR element type is i1.
+    return max(1, (get_type_width(ty) + 7) // 8)
 
 
 def _lookup_datamodel_type(numba_type: types.Type, context: str) -> ir.Type:
@@ -945,7 +977,7 @@ def unverified_basic_mlir_convert(
             imag = convert(imag, target_element_type)
             return complex_dialect.create_(complex=target_type, real=real, imaginary=imag)
         case ir.MemRefType() as mr, ptr_type if str(ptr_type) == "!llvm.ptr":
-            idx = memref.extract_aligned_pointer_as_index(value)
+            idx = memref_data_pointer_as_index(value, mr.element_type)
             return convert(idx, target_type)
         case ptr_type, ir.IntegerType() if str(ptr_type) == "!llvm.ptr":
             ptrtoi = llvm.ptrtoint(res=T.i64(), arg=value)

--- a/tests/test_lowering_utilities.py
+++ b/tests/test_lowering_utilities.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from numba_cuda_mlir._mlir import ir
+from numba_cuda_mlir._mlir.extras import types as T
+from numba_cuda_mlir.lowering_utilities import get_type_size_bytes
+
+
+def test_get_type_size_bytes_bf16_and_i1():
+    with ir.Context():
+        assert get_type_size_bytes(T.bf16()) == 2
+        assert get_type_size_bytes(ir.IntegerType.get_signless(1)) == 1

--- a/tests/test_ptr_ops.py
+++ b/tests/test_ptr_ops.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir import compiler, types
+from numba_cuda_mlir.cuda.experimental import intrin
+from numba_cuda_mlir._mlir.dialects import llvm
+from numba_cuda_mlir._mlir.extras import types as T
 import ctypes
 import numpy as np
 import pytest
@@ -115,6 +118,58 @@ def test_cpointer_complex_getitem_setitem(numba_complex, numpy_complex, float_dt
     np.testing.assert_array_equal(d_arith.copy_to_host(), h_src[[1, 0]])
 
 
+def test_array_slice_ptr_preserves_offset():
+    """ctypes.cast(array_slice, POINTER(...)) points at the slice start."""
+
+    @cuda.jit
+    def copy_from_slice(src, dst, start):
+        i = cuda.threadIdx.x
+        ptr = ctypes.cast(src[start:], ctypes.POINTER(ctypes.c_int32))
+        dst[i] = ptr[i]
+
+    @cuda.jit
+    def copy_bool_from_slice(src, dst, start):
+        i = cuda.threadIdx.x
+        ptr = ctypes.cast(src[start:], ctypes.POINTER(ctypes.c_bool))
+        dst[i] = ptr[i]
+
+    @intrin.define
+    def load_i32(ptr: llvm.PointerType.get, idx: types.int64) -> types.int32:
+        llvm_kDynamic = -2147483648
+        offset_ptr = llvm.getelementptr(
+            llvm.PointerType.get(), ptr, [idx], [llvm_kDynamic], T.i32(), None
+        )
+        return llvm.load(T.i32(), offset_ptr)
+
+    @cuda.jit
+    def copy_from_types_ptr_slice(src, dst, start):
+        dst[0] = load_i32(types.ptr(src[start:]), 0)
+
+    h_src = np.arange(32, dtype=np.int32)
+    h_dst = np.zeros(8, dtype=np.int32)
+
+    copy_from_slice[1, h_dst.size](h_src, h_dst, 11)
+
+    np.testing.assert_array_equal(h_dst, h_src[11 : 11 + h_dst.size])
+
+    h_bool_src = np.array(
+        [False, True, False, True, True, False, True, False],
+        dtype=np.bool_,
+    )
+    h_bool_dst = np.zeros(4, dtype=np.bool_)
+
+    copy_bool_from_slice[1, h_bool_dst.size](h_bool_src, h_bool_dst, 3)
+
+    np.testing.assert_array_equal(h_bool_dst, h_bool_src[3 : 3 + h_bool_dst.size])
+
+    h_types_ptr_dst = np.zeros(1, dtype=np.int32)
+
+    copy_from_types_ptr_slice[1, 1](h_src, h_types_ptr_dst, 11)
+
+    assert h_types_ptr_dst[0] == h_src[11]
+
+
 if __name__ == "__main__":
     test_ptr_arith()
     test_cpointer_getitem()
+    test_array_slice_ptr_preserves_offset()

--- a/tests/test_vector_types.py
+++ b/tests/test_vector_types.py
@@ -95,6 +95,68 @@ def test_vector_load_store_2d_array():
     np.testing.assert_array_equal(arr_in, arr_out)
 
 
+def test_vector_load_aligned_2d_slice_preserves_strides():
+    @cuda.jit
+    def kernel(arr_in, arr_out):
+        row = cuda.threadIdx.x
+        view = arr_in[1:, 2:]
+        vec = cuda.vector.load(view, (row, 0), 2, alignment=8)
+        cuda.vector.store(arr_out, (row, 0), vec, alignment=8)
+
+    arr_in = np.arange(40, dtype=np.float32).reshape(5, 8)
+    arr_out = np.zeros((4, 2), dtype=np.float32)
+    kernel[1, 4](arr_in, arr_out)
+    np.testing.assert_array_equal(arr_out, arr_in[1:, 2:4])
+
+
+def test_vector_store_aligned_2d_slice_preserves_strides():
+    @cuda.jit
+    def kernel(arr_in, arr_out):
+        row = cuda.threadIdx.x
+        view = arr_out[1:, 2:]
+        vec = cuda.vector.load(arr_in, row * 2, 2, alignment=8)
+        cuda.vector.store(view, (row, 0), vec, alignment=8)
+
+    arr_in = np.arange(8, dtype=np.float32)
+    arr_out = np.zeros((5, 8), dtype=np.float32)
+    kernel[1, 4](arr_in, arr_out)
+
+    expected = np.zeros_like(arr_out)
+    expected[1:, 2:4] = arr_in.reshape(4, 2)
+    np.testing.assert_array_equal(arr_out, expected)
+
+
+def test_vector_load_store_aligned_3d_slice_preserves_strides():
+    @cuda.jit
+    def kernel(arr_in, arr_out):
+        plane = cuda.threadIdx.y
+        row = cuda.threadIdx.x
+        src_view = arr_in[1:, 2:, 2:]
+        dst_view = arr_out[1:, 1:, 2:]
+        vec = cuda.vector.load(src_view, (plane, row, 0), 2, alignment=8)
+        cuda.vector.store(dst_view, (plane, row, 0), vec, alignment=8)
+
+    arr_in = np.arange(160, dtype=np.float32).reshape(4, 5, 8)
+    arr_out = np.zeros((4, 4, 6), dtype=np.float32)
+    kernel[1, (3, 3)](arr_in, arr_out)
+
+    expected = np.zeros_like(arr_out)
+    expected[1:, 1:, 2:4] = arr_in[1:, 2:, 2:4]
+    np.testing.assert_array_equal(arr_out, expected)
+
+
+def test_vector_load_aligned_2d_scalar_index_is_linear():
+    @cuda.jit
+    def kernel(arr_in, arr_out):
+        vec = cuda.vector.load(arr_in, 8, 2, alignment=8)
+        cuda.vector.store(arr_out, 0, vec, alignment=8)
+
+    arr_in = np.arange(35, dtype=np.float32).reshape(5, 7)
+    arr_out = np.zeros(2, dtype=np.float32)
+    kernel[1, 1](arr_in, arr_out)
+    np.testing.assert_array_equal(arr_out, arr_in.ravel()[8:10])
+
+
 def test_vector_2d_shape():
     """Test multi-dimensional vector (4x4 = 16 elements)."""
 


### PR DESCRIPTION
Closes #66.

## Summary
- Include memref element offsets when converting arrays or slices to LLVM pointers.
- Scale offsets by rounded-up element byte size so sub-byte element types, including bool, still advance by storage bytes.
- Apply the same offset logic to both generic memref-to-pointer conversion and `types.ptr(array)`.
- Add regression coverage for `ctypes.cast(src[start:], POINTER(...))`, bool slices, and direct `types.ptr(src[start:])`.

## Validation
- `PYTHONPATH=src /home/trentn/miniforge3/envs/cccl313nr/bin/python -m pytest -o addopts='' tests/test_ptr_ops.py::test_array_slice_ptr_preserves_offset -q`
- `/home/trentn/miniforge3/envs/cccl313nr/bin/python -m ruff check src/numba_cuda_mlir/lowering/math.py src/numba_cuda_mlir/lowering_utilities/__init__.py tests/test_ptr_ops.py`
- `/home/trentn/miniforge3/envs/cccl313nr/bin/python -m ruff format --check src/numba_cuda_mlir/lowering/math.py src/numba_cuda_mlir/lowering_utilities/__init__.py tests/test_ptr_ops.py`
- `git diff --check`
- Roborev on `73b37971d081a2528862f845a4410dc8d63f15e8`: codex pass, claude-code pass, gemini pass