### PR TITLE
[Lowering] Fix lowering for defaults, tuples, and dtype tokens

### DIFF
--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -738,7 +738,18 @@ class MLIRTargetContext(BaseContext):
                 if cache_value is None or len(cache_key) != 4:
                     continue
                 _, args, _, _ = cache_key
-                if args == match_args:
+                cache_args = tuple(args)
+                non_omitted_cache_args = tuple(
+                    arg
+                    for arg in cache_args
+                    if not isinstance(arg, (types.Omitted, types.NoneType))
+                )
+                non_omitted_match_args = tuple(
+                    arg
+                    for arg in match_args
+                    if not isinstance(arg, (types.Omitted, types.NoneType))
+                )
+                if cache_args == match_args or non_omitted_cache_args == non_omitted_match_args:
                     disp, _ = cache_value
                     if hasattr(disp, "py_func"):
 

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -64,6 +64,8 @@ from numba_cuda_mlir._mlir.dialects import (
     scf,
     nvvm,
     gpu,
+    complex as complex_dialect,
+    vector as vector_dialect,
 )
 
 from numba_cuda_mlir.logging import trace
@@ -1213,7 +1215,7 @@ extern "C" __global__ void
 
     def lower_literal_if_needed(self, value: ir.Value | np.ndarray, numba_type=None) -> ir.Value:
         match value:
-            case types.Type() if isinstance(numba_type, types.NumberClass):
+            case types.Type() if isinstance(numba_type, types.DTypeSpec):
                 return self._materialize_type_token(numba_type)
             case tuple():
                 return tuple(map(self.lower_literal_if_needed, value))
@@ -1884,6 +1886,10 @@ extern "C" __global__ void
         ty = self.get_numba_type(var.name)
         if isinstance(ty, types.NumberClass):
             return types.NumberClass
+        from numba_cuda_mlir.typing.cuda_vector_types import VectorTypeClass
+
+        if isinstance(ty, VectorTypeClass):
+            return ty.instance_type
         if isinstance(ty, types.Function):
             if self.var_lowered(var):
                 fn = self.load_var(var)
@@ -2369,7 +2375,7 @@ extern "C" __global__ void
         return tuple(result)
 
     def _materialize_type_token(self, target_type):
-        if isinstance(target_type, types.NumberClass):
+        if isinstance(target_type, types.DTypeSpec):
             return self._zero_value_for_type(self.get_mlir_type(target_type.dtype))
         raise InternalCompilerError(f"Cannot materialize type token for {target_type}.")
 
@@ -2379,10 +2385,11 @@ extern "C" __global__ void
         if isinstance(mlir_type, (ir.FloatType, ir.F16Type, ir.BF16Type)):
             return arith.constant(result=mlir_type, value=0.0)
         if isinstance(mlir_type, ir.ComplexType):
-            from numba_cuda_mlir._mlir.dialects import complex as complex_dialect
-
             zero = self._zero_value_for_type(mlir_type.element_type)
             return complex_dialect.create_(complex=mlir_type, real=zero, imaginary=zero)
+        if isinstance(mlir_type, ir.VectorType):
+            zero = self._zero_value_for_type(mlir_type.element_type)
+            return vector_dialect.broadcast(mlir_type, zero)
         if str(mlir_type).startswith("!llvm."):
             return llvm.mlir_undef(res=mlir_type)
         raise InternalCompilerError(f"Cannot materialize zero value for {mlir_type}.")
@@ -2915,7 +2922,7 @@ extern "C" __global__ void
             return_ctor([])
         else:
             value = self.load_var(value)
-            if isinstance(value_type, types.NumberClass) and isinstance(value, types.Type):
+            if isinstance(value_type, types.DTypeSpec) and isinstance(value, types.Type):
                 value = self._materialize_type_token(value_type)
             if isinstance(value, tuple):
                 return_ctor(list(value))

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1156,6 +1156,8 @@ extern "C" __global__ void
             )
         elif hasattr(glob.value, "__cuda_array_interface__"):
             self.lower_captured_array_to_memref(target, glob.value)
+        elif isinstance(target_type, types.NumberClass) and isinstance(glob.value, types.Type):
+            self.store_var(target, self._materialize_type_token(target_type))
         else:
             self.store_var(target, glob.value)
 
@@ -1175,6 +1177,9 @@ extern "C" __global__ void
                 self.store_var(target, var_value)
             case str() | bytes():
                 self.store_var(target, var_value)
+            case types.Type() if isinstance(self.get_numba_type(target.name), types.NumberClass):
+                target_type = self.get_numba_type(target.name)
+                self.store_var(target, self._materialize_type_token(target_type))
             case None:
                 target_type = self.get_numba_type(target.name)
                 self.store_var(target, self.get_mlir_type(target_type))
@@ -1208,6 +1213,8 @@ extern "C" __global__ void
 
     def lower_literal_if_needed(self, value: ir.Value | np.ndarray, numba_type=None) -> ir.Value:
         match value:
+            case types.Type() if isinstance(numba_type, types.NumberClass):
+                return self._materialize_type_token(numba_type)
             case tuple():
                 return tuple(map(self.lower_literal_if_needed, value))
             case np.ndarray():
@@ -1517,6 +1524,53 @@ extern "C" __global__ void
 
         raise NotImplementedError(f"lowering getitem {target} = {value}[{index}]")
 
+    def _fold_dispatcher_call_args(
+        self,
+        fn: dispatcher._DispatcherBase,
+        args: list[numba_ir.Var],
+        kws: list[tuple[str, numba_ir.Var]] | None = None,
+    ) -> tuple[tuple[types.Type, ...], list[numba_ir.Var], tuple[types.Type, ...]]:
+        """Fold kwargs/defaults for a dispatcher call.
+
+        Numba represents omitted defaults as ``types.Omitted`` in the callee
+        signature.  The MLIR ABI excludes those arguments, so return both the
+        folded compile signature and the concrete operand vars that should be
+        emitted at the call site.
+        """
+        if kws is None:
+            kws = []
+
+        argtypes = tuple(self.get_numba_type(arg.name) for arg in args)
+        kwarg_types = {name: self.get_numba_type(value.name) for name, value in kws}
+        pysig, folded_argtypes = fn._compiler.fold_argument_types(argtypes, kwarg_types)
+
+        kwarg_vars = dict(kws)
+
+        def normal_handler(index, param, value):
+            return value
+
+        def default_handler(index, param, default):
+            return None
+
+        def stararg_handler(index, param, values):
+            return tuple(values)
+
+        folded_vars = typing.fold_arguments(
+            pysig,
+            tuple(args),
+            kwarg_vars,
+            normal_handler,
+            default_handler,
+            stararg_handler,
+        )
+        call_vars = [
+            var
+            for var, argty in zip(folded_vars, folded_argtypes)
+            if var is not None and not _is_omitted_arg(argty)
+        ]
+        call_argtypes = tuple(argty for argty in folded_argtypes if not _is_omitted_arg(argty))
+        return tuple(folded_argtypes), call_vars, call_argtypes
+
     def build_user_defined_function_call(
         self,
         target: numba_ir.Var,
@@ -1526,14 +1580,6 @@ extern "C" __global__ void
     ):
         if kws is None:
             kws = []
-        target_type = self.get_numba_type(target.name)
-
-        # TODO: Here named arguments are simply considered as positional arguments
-        argtypes = tuple(
-            [self.get_numba_type(arg.name) for arg in args]
-            + [self.get_numba_type(value.name) for (name, value) in kws]
-        )
-        func_name = generate_mangled_name(fn.py_func.__qualname__, argtypes)
 
         from numba_cuda_mlir.descriptor import MLIRDispatcher
 
@@ -1554,7 +1600,9 @@ extern "C" __global__ void
                 fn._device_dispatcher = MLIRDispatcher(fn.py_func, targetoptions=opts)
             fn = fn._device_dispatcher
 
-        cres = fn.compile(argtypes)
+        folded_argtypes, call_vars, call_argtypes = self._fold_dispatcher_call_args(fn, args, kws)
+        func_name = generate_mangled_name(fn.py_func.__qualname__, call_argtypes)
+        cres = fn.compile(folded_argtypes)
 
         if callee_linker := cres.metadata.get("linker"):
             self.linker.merge_ltoirs_from(callee_linker)
@@ -1594,11 +1642,12 @@ extern "C" __global__ void
         assert callee, f"Could not find callee function {func_name} in the module."
 
         callee_function_type = callee.function_type.value.results
+        callee_inputs = callee.function_type.value.inputs
+        operands = [convert(val, ty) for val, ty in zip(self.load_vars(call_vars), callee_inputs)]
         call_results = func.call(
             result=callee_function_type,
             callee=callee.name.value,
-            operands_=[self.load_var(arg) for arg in args]
-            + [self.load_var(value) for (name, value) in kws],
+            operands_=operands,
         )
 
         target_type = self.get_numba_type(target.name)
@@ -1731,16 +1780,14 @@ extern "C" __global__ void
         from numba_cuda_mlir import cuda
         from numba_cuda_mlir.lowering_utilities import link
 
-        argtypes = tuple(
-            [self.get_numba_type(arg.name) for arg in args]
-            + [self.get_numba_type(value.name) for (name, value) in kws]
-        )
-
         py_func = overload_disp.py_func
         cuda_func = cuda.jit(device=True)(py_func)
+        folded_argtypes, call_vars, call_argtypes = self._fold_dispatcher_call_args(
+            cuda_func, args, kws
+        )
         unique_qualname = f"{py_func.__qualname__}_{id(overload_disp)}"
-        func_name = generate_mangled_name(unique_qualname, argtypes)
-        cres = cuda_func.compile(argtypes, abi_info={"abi_name": func_name})
+        func_name = generate_mangled_name(unique_qualname, call_argtypes)
+        cres = cuda_func.compile(folded_argtypes, abi_info={"abi_name": func_name})
 
         if callee_linker := cres.metadata.get("linker"):
             self.linker.merge_ltoirs_from(callee_linker)
@@ -1763,7 +1810,9 @@ extern "C" __global__ void
             )
 
         callee_type = get_func_type(callee)
-        call_args = [convert(val, ty) for val, ty in zip(self.load_vars(args), callee_type.inputs)]
+        call_args = [
+            convert(val, ty) for val, ty in zip(self.load_vars(call_vars), callee_type.inputs)
+        ]
         call_result = func.call(
             result=callee_type.results,
             callee=callee.name.value,
@@ -2290,7 +2339,53 @@ extern "C" __global__ void
             cast_impl = None
         if cast_impl is not None and self._is_extension_cast(cast_impl):
             return cast_impl(self.context, self, source_type, target_type, value)
+        if isinstance(source_type, types.BaseTuple) and isinstance(target_type, types.BaseTuple):
+            return self._lower_tuple_cast(source_type, target_type, value)
         return self.mlir_convert(value, self.get_mlir_type(target_type))
+
+    def _tuple_element_types(self, tuple_type):
+        if isinstance(tuple_type, types.UniTuple):
+            return (tuple_type.dtype,) * tuple_type.count
+        return tuple_type.types
+
+    def _lower_tuple_cast(self, source_type, target_type, value):
+        if not isinstance(value, tuple):
+            raise InternalCompilerError(
+                f"Cannot cast tuple value stored as {type(value)} from {source_type} "
+                f"to {target_type}."
+            )
+        source_types = self._tuple_element_types(source_type)
+        target_types = self._tuple_element_types(target_type)
+        if len(source_types) != len(target_types) or len(value) != len(target_types):
+            raise InternalCompilerError(
+                f"Cannot cast tuple with mismatched arity from {source_type} to {target_type}."
+            )
+        result = []
+        for source_elem_type, target_elem_type, elem in zip(source_types, target_types, value):
+            if source_elem_type == target_elem_type:
+                result.append(elem)
+            else:
+                result.append(self.lower_cast(source_elem_type, target_elem_type, elem))
+        return tuple(result)
+
+    def _materialize_type_token(self, target_type):
+        if isinstance(target_type, types.NumberClass):
+            return self._zero_value_for_type(self.get_mlir_type(target_type.dtype))
+        raise InternalCompilerError(f"Cannot materialize type token for {target_type}.")
+
+    def _zero_value_for_type(self, mlir_type):
+        if isinstance(mlir_type, (ir.IntegerType, ir.IndexType)):
+            return arith.constant(result=mlir_type, value=0)
+        if isinstance(mlir_type, (ir.FloatType, ir.F16Type, ir.BF16Type)):
+            return arith.constant(result=mlir_type, value=0.0)
+        if isinstance(mlir_type, ir.ComplexType):
+            from numba_cuda_mlir._mlir.dialects import complex as complex_dialect
+
+            zero = self._zero_value_for_type(mlir_type.element_type)
+            return complex_dialect.create_(complex=mlir_type, real=zero, imaginary=zero)
+        if str(mlir_type).startswith("!llvm."):
+            return llvm.mlir_undef(res=mlir_type)
+        raise InternalCompilerError(f"Cannot materialize zero value for {mlir_type}.")
 
     def _cast_to_optional(self, source_type, target_type, value):
         """Cast T or NoneType to Optional(T)."""
@@ -2820,6 +2915,8 @@ extern "C" __global__ void
             return_ctor([])
         else:
             value = self.load_var(value)
+            if isinstance(value_type, types.NumberClass) and isinstance(value, types.Type):
+                value = self._materialize_type_token(value_type)
             if isinstance(value, tuple):
                 return_ctor(list(value))
             else:

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -16,7 +16,8 @@ from numba_cuda_mlir.numba_cuda.core import analysis
 from numba_cuda_mlir.numba_cuda.extending import _Intrinsic
 
 from numba_cuda_mlir.numba_cuda.core.environment import Environment
-from numba_cuda_mlir.numba_cuda import types
+from numba_cuda_mlir import types
+from numba_cuda_mlir.numba_cuda import types as numba_types
 from numba_cuda_mlir.numba_cuda.datamodel.models import ArrayModel
 from numba_cuda_mlir.annotations import Builder, AnyCallable, PS
 from numba_cuda_mlir.errors import InternalCompilerError, ensure_verifies
@@ -270,7 +271,7 @@ class MLIRLower(object):
                 continue
             # UnionType is used here as a DI/tag container only;
             # the lowered value is stored in a shared canonical slot.
-            poly_types[name] = types.UnionType(type_set)
+            poly_types[name] = numba_types.UnionType(type_set)
         return poly_types
 
     @staticmethod
@@ -1886,9 +1887,8 @@ extern "C" __global__ void
         ty = self.get_numba_type(var.name)
         if isinstance(ty, types.NumberClass):
             return types.NumberClass
-        from numba_cuda_mlir.typing.cuda_vector_types import VectorTypeClass
 
-        if isinstance(ty, VectorTypeClass):
+        if isinstance(ty, types.VectorTypeClass):
             return ty.instance_type
         if isinstance(ty, types.Function):
             if self.var_lowered(var):
@@ -3366,11 +3366,11 @@ extern "C" __global__ void
             case types.CharSeq():
                 return ir.Type.parse(f"!llvm.array<{ty.count} x i8>")
             case types.UnicodeCharSeq():
-                import numpy as np
-
                 char_bits = np.dtype("U1").itemsize * 8
                 return ir.Type.parse(f"!llvm.array<{ty.count} x i{char_bits}>")
             case _:
+                if isinstance(ty, types.DTypeSpec):
+                    return self.get_mlir_type(ty.dtype)
                 try:
                     return self.context.get_value_type(ty)
                 except KeyError as e:

--- a/src/numba_cuda_mlir/models.py
+++ b/src/numba_cuda_mlir/models.py
@@ -133,10 +133,6 @@ class StructModel(DataModel):
         return self._models
 
 
-from numba_cuda_mlir.typing.cuda_vector_types import VectorTypeClass
-
-
-@register_model(VectorTypeClass)
 @register_model(types.NumberClass)
 class NumpyDataTypeModel(PrimitiveModel):
     """

--- a/src/numba_cuda_mlir/models.py
+++ b/src/numba_cuda_mlir/models.py
@@ -133,6 +133,10 @@ class StructModel(DataModel):
         return self._models
 
 
+from numba_cuda_mlir.typing.cuda_vector_types import VectorTypeClass
+
+
+@register_model(VectorTypeClass)
 @register_model(types.NumberClass)
 class NumpyDataTypeModel(PrimitiveModel):
     """

--- a/src/numba_cuda_mlir/types.py
+++ b/src/numba_cuda_mlir/types.py
@@ -8,6 +8,7 @@ from numba_cuda_mlir.numba_cuda.types import (
     UnicodeType,
     UnionType,
     Boolean,
+    PyObject,
     StringLiteral,
     BooleanLiteral,
     IntegerLiteral,
@@ -30,6 +31,7 @@ from numba_cuda_mlir.numba_cuda.types import (
     Module,
     Type,
     NoneType,
+    MemInfoPointer,
     float16,
     float32,
     float64,
@@ -71,6 +73,7 @@ from numba_cuda_mlir.numba_cuda.types import (
     uintp,
     intp,
     voidptr,
+    unicode_type,
     CPointer,
     RawPointer,
     Array,
@@ -81,6 +84,8 @@ from numba_cuda_mlir.numba_cuda.types import (
     # Record/struct types
     Record,
     NestedArray,
+    RecursiveCall,
+    Omitted,
 )
 from numba_cuda_mlir.numba_cuda.typing import Signature, signature
 from numba_cuda_mlir.type_defs.aggregate_types import AggregateType, UnionType
@@ -180,6 +185,10 @@ _FP8_ATTRS = (
 
 
 def __getattr__(name):
+    if name == "VectorTypeClass":
+        from numba_cuda_mlir.typing.cuda_vector_types import VectorTypeClass
+
+        return VectorTypeClass
     if name not in _FP8_ATTRS:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     import sys

--- a/src/numba_cuda_mlir/typing/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/typing/cuda_vector_types.py
@@ -19,9 +19,10 @@ from numba_cuda_mlir.cuda.vector_types import (
 )
 
 from numba_cuda_mlir.numba_cuda.types import Callable, DTypeSpec
-from numba_cuda_mlir.models import register_model
-from numba_cuda_mlir.numba_cuda.datamodel.models import OpaqueModel
+from numba_cuda_mlir.models import register_model, NumpyDataTypeModel
 from numba_cuda_mlir.numba_cuda.typing import typeof
+
+registry = Registry()
 
 
 class VectorTypeClass(Callable, DTypeSpec):
@@ -52,13 +53,11 @@ class VectorTypeClass(Callable, DTypeSpec):
         return self.typing_key
 
 
-registry = Registry()
+# Register the model for VectorTypeClass
+register_model(VectorTypeClass)(NumpyDataTypeModel)
 
 # Attribute index mapping
 ATTR_INDEX = {"x": 0, "y": 1, "z": 2, "w": 3}
-
-
-register_model(VectorTypeClass)(OpaqueModel)
 
 
 _constructor_template_cache = {}

--- a/tests/numba_cuda_tests/cudapy/test_extending.py
+++ b/tests/numba_cuda_tests/cudapy/test_extending.py
@@ -598,7 +598,6 @@ class TestHighLevelExtending(NumbaCUDATestCase):
         self.assertIn("use of VAR_KEYWORD (e.g. **kwargs) is unsupported", msg)
         self.assertIn("offending argument name is '**kws'", msg)
 
-    @pytest.mark.xfail(True, reason="Typing error")
     def test_overload_method_kwargs(self):
         # Issue #3489
         @overload_method(types.Array, "foo")

--- a/tests/test_numba_cuda_mlir_extending.py
+++ b/tests/test_numba_cuda_mlir_extending.py
@@ -375,3 +375,116 @@ def test_aggregate_type_field_model():
         assert model.get_field_position("x") == 0
         assert model.get_field_position("y") == 1
         assert model.get_field_position("z") == 2
+
+
+def test_register_jitable_tuple_return_cast_from_branches():
+    @extending.register_jitable(typing_registry=extending.typing_registry)
+    def select(flag, a, b):
+        if flag:
+            return (a, b)
+        return (b, a)
+
+    @cuda.jit
+    def kernel(out, flag):
+        x, y = select(flag, 1, 2)
+        out[0] = x
+        out[1] = y
+
+    out = np.zeros(2, dtype=np.int64)
+    kernel[1, 1](out, True)
+    assert out.tolist() == [1, 2]
+
+    kernel[1, 1](out, False)
+    assert out.tolist() == [2, 1]
+
+
+def test_overload_method_omitted_trailing_default_arg():
+    from numba_cuda_mlir._mlir.dialects import llvm
+    from numba_cuda_mlir._mlir.extras import types as T
+    from numba_cuda_mlir.lowering_utilities import unverified_convert
+
+    class Widget:
+        pass
+
+    class WidgetType(types.Type):
+        def __init__(self):
+            super().__init__(name="Widget")
+
+    widget_type = WidgetType()
+
+    @typeof_impl.register(Widget)
+    def typeof_widget(val, c):
+        return widget_type
+
+    class WidgetModel(PrimitiveModel):
+        def __init__(self, dmm, fe):
+            super().__init__(dmm, fe, T.i8())
+
+    register_model(WidgetType)(WidgetModel)
+
+    @unverified_convert.register(Widget)
+    def convert_widget(val, tt, signed=False):
+        return llvm.mlir_undef(T.i8())
+
+    @extending.overload_method(
+        WidgetType,
+        "poke",
+        strict=False,
+        typing_registry=extending.typing_registry,
+    )
+    def ol_poke(w, buf, extra=None):
+        if not isinstance(buf, types.Array):
+            return
+
+        def impl(w, buf, extra=None):
+            buf[0] = buf[0] + 1
+
+        return impl
+
+    widget = Widget()
+
+    @cuda.jit
+    def kernel(buf):
+        widget.poke(buf)
+
+    buf = np.zeros(1, dtype=np.int32)
+    kernel[1, 1](buf)
+    assert buf[0] == 1
+
+
+def test_register_jitable_omitted_default_arg():
+    @extending.register_jitable(typing_registry=extending.typing_registry)
+    def fill(out, lda=None):
+        out[0] = 42
+
+    @cuda.jit
+    def kernel(out):
+        fill(out)
+
+    out = np.zeros(1, dtype=np.int64)
+    kernel[1, 1](out)
+    assert out[0] == 42
+
+
+def test_inline_overload_returning_dtype_token_for_local_array():
+    def get_value_type():
+        return np.float32
+
+    @extending.overload(
+        get_value_type,
+        inline="always",
+        typing_registry=extending.typing_registry,
+        lowering_registry=extending.lowering_registry,
+    )
+    def ol_get_value_type():
+        return lambda: types.float32
+
+    @cuda.jit
+    def kernel(buf):
+        arr = cuda.local.array(shape=(1,), dtype=get_value_type())
+        arr[0] = buf[0]
+        buf[0] = arr[0] + 1
+
+    buf = np.zeros(1, dtype=np.float32)
+    kernel[1, 1](buf)
+    assert buf[0] == 1


### PR DESCRIPTION
- Fold dispatcher call arguments during MLIR lowering so omitted defaults compile with the full Numba signature but emit only real MLIR operands.
- Allow overload-method lookup to match cached implementations when trailing omitted/default args are absent from the lowered call.
- Add recursive tuple-to-tuple cast lowering instead of sending tuple casts through generic MLIR conversion. - Materialize dtype/type-token values as valid MLIR zero placeholders, including builtin complex types.
- Add regression tests for jitable tuple returns, omitted defaults, overload-method defaults, and inline overload dtype tokens.