### PR TITLE
Skip building `libcudf` from source in third party tests

### DIFF
--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -96,10 +96,13 @@ if [[ ! -e "${ENV_BIN}/nvidia-smi" ]]; then
   fi
 fi
 
-# --- Install libcudf nightly (skip expensive C++ build) ---
-echo "Installing libcudf nightly wheel..."
+# --- Install RAPIDS nightly wheels (skip expensive C++ builds) ---
+echo "Installing libcudf and rmm nightly wheels..."
 RAPIDS_INDEX="https://pypi.nvidia.com"
-conda run -n "${CONDA_ENV_NAME}" pip install --extra-index-url "${RAPIDS_INDEX}" "libcudf-cu${TEST_CUDA_MAJOR}"
+conda run -n "${CONDA_ENV_NAME}" pip install --extra-index-url "${RAPIDS_INDEX}" \
+  "libcudf-cu${TEST_CUDA_MAJOR}" \
+  "librmm-cu${TEST_CUDA_MAJOR}" \
+  "rmm-cu${TEST_CUDA_MAJOR}"
 
 # --- Build pylibcudf and cudf from source ---
 echo "Building pylibcudf and cudf from source..."

--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -96,15 +96,9 @@ if [[ ! -e "${ENV_BIN}/nvidia-smi" ]]; then
   fi
 fi
 
-# --- Install RAPIDS nightly wheels (skip expensive C++ builds) ---
-echo "Installing libcudf and rmm nightly wheels..."
-RAPIDS_INDEX="https://pypi.nvidia.com"
-conda run -n "${CONDA_ENV_NAME}" pip install --extra-index-url "${RAPIDS_INDEX}" \
-  "libcudf-cu${TEST_CUDA_MAJOR}" \
-  "librmm-cu${TEST_CUDA_MAJOR}" \
-  "rmm-cu${TEST_CUDA_MAJOR}"
-
 # --- Build pylibcudf and cudf from source ---
+# The conda env already provides libcudf, librmm, and rmm (with Cython pxd
+# files) from rapidsai-nightly. We only build the Python layers from source.
 echo "Building pylibcudf and cudf from source..."
 conda run -n "${CONDA_ENV_NAME}" bash -c "cd ${CUDF_DIR} && bash build.sh pylibcudf cudf"
 

--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Build cudf from source against a public branch and run UDF tests with
-# numba-cuda-mlir installed.
+# Install libcudf nightly, build pylibcudf/cudf from source against a public
+# branch, and run UDF tests with numba-cuda-mlir installed.
 
 set -euo pipefail
 
@@ -96,9 +96,14 @@ if [[ ! -e "${ENV_BIN}/nvidia-smi" ]]; then
   fi
 fi
 
-# --- Build cudf from source ---
-echo "Building cudf from source..."
-conda run -n "${CONDA_ENV_NAME}" bash -c "cd ${CUDF_DIR} && bash build.sh libcudf pylibcudf cudf"
+# --- Install libcudf nightly (skip expensive C++ build) ---
+echo "Installing libcudf nightly wheel..."
+RAPIDS_INDEX="https://pypi.nvidia.com"
+conda run -n "${CONDA_ENV_NAME}" pip install --extra-index-url "${RAPIDS_INDEX}" "libcudf-cu${TEST_CUDA_MAJOR}"
+
+# --- Build pylibcudf and cudf from source ---
+echo "Building pylibcudf and cudf from source..."
+conda run -n "${CONDA_ENV_NAME}" bash -c "cd ${CUDF_DIR} && bash build.sh pylibcudf cudf"
 
 # --- Install numba-cuda-mlir wheel ---
 echo "Installing numba-cuda-mlir wheel into conda env..."


### PR DESCRIPTION
The target branch we're testing here only contains python changes relative to main, so we should be able to avoid this piece of the CI job by just pulling a package and building/testing the unmerged code on top of that. 