### PR TITLE
Add support for custom dtype

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -936,7 +936,11 @@ extern "C" __global__ void
         elif hasattr(free_var.value, "__cuda_array_interface__"):
             self.lower_captured_array_to_memref(target, free_var.value)
         else:
-            self.store_var(target, free_var.value)
+            target_type = self.get_numba_type(target.name)
+            if isinstance(target_type, types.DTypeSpec):
+                self.store_var(target, self._materialize_type_token(target_type))
+            else:
+                self.store_var(target, free_var.value)
 
     def lower_captured_array_to_memref(self, target, pyval):
         """Build an MLIR memref value from __cuda_array_interface__ metadata.
@@ -1159,7 +1163,7 @@ extern "C" __global__ void
             )
         elif hasattr(glob.value, "__cuda_array_interface__"):
             self.lower_captured_array_to_memref(target, glob.value)
-        elif isinstance(target_type, types.NumberClass) and isinstance(glob.value, types.Type):
+        elif isinstance(target_type, types.DTypeSpec):
             self.store_var(target, self._materialize_type_token(target_type))
         else:
             self.store_var(target, glob.value)
@@ -1180,7 +1184,7 @@ extern "C" __global__ void
                 self.store_var(target, var_value)
             case str() | bytes():
                 self.store_var(target, var_value)
-            case types.Type() if isinstance(self.get_numba_type(target.name), types.NumberClass):
+            case _ if isinstance(self.get_numba_type(target.name), types.DTypeSpec):
                 target_type = self.get_numba_type(target.name)
                 self.store_var(target, self._materialize_type_token(target_type))
             case None:

--- a/src/numba_cuda_mlir/models.py
+++ b/src/numba_cuda_mlir/models.py
@@ -133,11 +133,11 @@ class StructModel(DataModel):
         return self._models
 
 
-@register_model(types.NumberClass)
-class NumpyDataTypeModel(PrimitiveModel):
+@register_model(types.DTypeSpec)
+class DTypeSpecModel(PrimitiveModel):
     """
-    Convert from a Numba NumberClass type instance
-    into the MLIR type that this NumberClass instance represents.
+    Convert from a Numba DTypeSpec type instance
+    into the MLIR type that this DTypeSpec instance represents.
     For example, a NumberClass instance
         class(float64)
     is converted into a F64Type in MLIR.

--- a/src/numba_cuda_mlir/typing/cuda.py
+++ b/src/numba_cuda_mlir/typing/cuda.py
@@ -245,14 +245,11 @@ class GenericArrayTemplate(CallableTemplate):
 
                     raise RequireLiteralValue("alignment must be a constant integer")
 
-            # Parse dtype - handle DTypeSpec, TypeRef, StringLiteral, and NumberClass
+            # Parse dtype - handle DTypeSpec, TypeRef, and StringLiteral
             if isinstance(dtype, types.DTypeSpec):
                 nb_dtype = dtype.dtype
             elif isinstance(dtype, types.TypeRef):
                 nb_dtype = dtype.instance_type
-            elif isinstance(dtype, types.NumberClass):
-                # NumberClass wraps a numeric type (e.g., types.float16 -> NumberClass(float16))
-                nb_dtype = dtype.dtype
             elif isinstance(dtype, types.StringLiteral):
                 import numpy as np
                 from numba_cuda_mlir.numba_cuda.core.errors import TypingError

--- a/src/numba_cuda_mlir/typing/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/typing/cuda_vector_types.py
@@ -19,7 +19,6 @@ from numba_cuda_mlir.cuda.vector_types import (
 )
 
 from numba_cuda_mlir.numba_cuda.types import Callable, DTypeSpec
-from numba_cuda_mlir.models import register_model, NumpyDataTypeModel
 from numba_cuda_mlir.numba_cuda.typing import typeof
 
 registry = Registry()
@@ -52,9 +51,6 @@ class VectorTypeClass(Callable, DTypeSpec):
     def get_impl_key(self, sig):
         return self.typing_key
 
-
-# Register the model for VectorTypeClass
-register_model(VectorTypeClass)(NumpyDataTypeModel)
 
 # Attribute index mapping
 ATTR_INDEX = {"x": 0, "y": 1, "z": 2, "w": 3}

--- a/src/numba_cuda_mlir/typing/numpy.py
+++ b/src/numba_cuda_mlir/typing/numpy.py
@@ -60,8 +60,6 @@ class NumpyEmptyTemplate(AbstractTemplate):
         # Handle dtype
         if isinstance(dtype, types.DTypeSpec):
             element_type = dtype.dtype
-        elif isinstance(dtype, types.NumberClass):
-            element_type = dtype.dtype
         else:
             element_type = dtype
 
@@ -88,8 +86,6 @@ class NumpyZerosTemplate(AbstractTemplate):
             return None
 
         if isinstance(dtype, types.DTypeSpec):
-            element_type = dtype.dtype
-        elif isinstance(dtype, types.NumberClass):
             element_type = dtype.dtype
         else:
             element_type = dtype
@@ -118,8 +114,6 @@ class NumpyOnesTemplate(AbstractTemplate):
 
         if isinstance(dtype, types.DTypeSpec):
             element_type = dtype.dtype
-        elif isinstance(dtype, types.NumberClass):
-            element_type = dtype.dtype
         else:
             element_type = dtype
 
@@ -147,8 +141,6 @@ class NumpyFullTemplate(AbstractTemplate):
             return None
 
         if isinstance(dtype, types.DTypeSpec):
-            element_type = dtype.dtype
-        elif isinstance(dtype, types.NumberClass):
             element_type = dtype.dtype
         else:
             element_type = dtype

--- a/tests/test_array_methods.py
+++ b/tests/test_array_methods.py
@@ -85,10 +85,6 @@ def test_array_view_custom_dtype():
     def _typeof_my(val, c):
         return nb_types.NumberClass(nb_types.int64)
 
-    @to_mlir_type.register(_MyBoxedDtype)
-    def _my_to_mlir(val):
-        return T.i64()
-
     @cuda.jit
     def kernel(arr):
         v = arr.view(my_dtype)

--- a/tests/test_custom_dtype.py
+++ b/tests/test_custom_dtype.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+from numba_cuda_mlir import cuda
+from numba_cuda_mlir.numba_cuda.extending import typeof_impl
+
+from numba_cuda_mlir import types as mlir_types
+
+
+class MyCustomDType:
+    pass
+
+
+my_dtype = MyCustomDType()
+
+
+@typeof_impl.register(MyCustomDType)
+def typeof_my_dtype(val, c):
+    return mlir_types.NumberClass(mlir_types.float32)
+
+
+def test_custom_dtype_local_array():
+    """
+    Test that a custom Python object mimicking a type specification
+    can be properly lowered when passed as `dtype` to `cuda.local.array`.
+    """
+
+    @cuda.jit
+    def kernel(out):
+        arr = cuda.local.array((10,), dtype=my_dtype)
+        arr[0] = 42.0
+        out[0] = arr[0]
+
+    out = np.zeros(1, dtype=np.float32)
+    kernel[1, 1](out)
+    assert out[0] == 42.0
+
+
+def test_custom_dtype_shared_array():
+    """
+    Test that a custom Python object mimicking a type specification
+    can be properly lowered when passed as `dtype` to `cuda.shared.array`.
+    """
+
+    @cuda.jit
+    def kernel(out):
+        arr = cuda.shared.array((10,), dtype=my_dtype)
+        if cuda.threadIdx.x == 0:
+            arr[0] = 42.0
+        cuda.syncthreads()
+        out[0] = arr[0]
+
+    out = np.zeros(1, dtype=np.float32)
+    kernel[1, 1](out)
+    assert out[0] == 42.0


### PR DESCRIPTION
## Summary

Fixes a lowering bug where custom Python objects acting as data types (resolving to `types.DTypeSpec` in Numba's frontend) would crash the MLIR compiler when passed to `cuda.local.array` or `cuda.shared.array`.

## Root Cause

When a custom Python object (e.g. `Complex(np.float32)`) is assigned to a variable and acts as a data type, Numba's frontend correctly infers its type as a `types.NumberClass` (which inherits from `types.DTypeSpec`). 

However, in `mlir_lowering.py`, `lower_global_assign` and `lower_var_assign` previously checked `isinstance(var_value, types.Type)`. Since the custom Python object itself is not a subclass of `types.Type`, the lowering phase fell back to storing the raw Python object in `self.varmap` instead of materializing a proper MLIR type token (like `arith.constant 0`).

When `cuda_local_array` later called `_resolve_dtype(lower, dtype_var)`, it loaded this raw Python object from the varmap and passed it to `to_mlir_type()`, which crashed with `TypeError: No conversion found for type <class '...'>`.

## Fix

1. **`mlir_lowering.py`**: Changed the fallback type token check in `lower_var_assign` and `lower_global_assign` from checking the Python value's inheritance to checking the Numba frontend type:
   ```python
   case _ if isinstance(self.get_numba_type(target.name), types.DTypeSpec):
       target_type = self.get_numba_type(target.name)
       self.store_var(target, self._materialize_type_token(target_type))

Closes https://github.com/NVIDIA/numba-cuda-mlir/issues/83