### PR TITLE
Fix to_numba_type for np dtypes

### DIFF
--- a/src/numba_cuda_mlir/lowering_utilities/type_conversions.py
+++ b/src/numba_cuda_mlir/lowering_utilities/type_conversions.py
@@ -456,6 +456,14 @@ def np_dtype_to_numba_dtype(dtype: np.dtype) -> types.Type:
             return types.int32
         case np.int64:
             return types.int64
+        case np.uint8:
+            return types.uint8
+        case np.uint16:
+            return types.uint16
+        case np.uint32:
+            return types.uint32
+        case np.uint64:
+            return types.uint64
         case np.complex64:
             return types.complex64
         case np.complex128:

--- a/src/numba_cuda_mlir/lowering_utilities/type_conversions.py
+++ b/src/numba_cuda_mlir/lowering_utilities/type_conversions.py
@@ -163,21 +163,21 @@ def ctypes_type_to_numba_type(obj: ctypes._SimpleCData) -> types.Type:
             return types.ptr
         case ctypes.c_bool:
             return types.bool
-        case ctypes.c_byte:
+        case ctypes.c_int8:
             return types.int8
-        case ctypes.c_ubyte:
+        case ctypes.c_uint8:
             return types.uint8
-        case ctypes.c_short:
+        case ctypes.c_int16:
             return types.int16
-        case ctypes.c_ushort:
+        case ctypes.c_uint16:
             return types.uint16
-        case ctypes.c_int:
+        case ctypes.c_int32:
             return types.int32
-        case ctypes.c_uint:
+        case ctypes.c_uint32:
             return types.uint32
-        case ctypes.c_long:
+        case ctypes.c_int64:
             return types.int64
-        case ctypes.c_ulong:
+        case ctypes.c_uint64:
             return types.uint64
         case ctypes.c_float:
             return types.float32
@@ -221,22 +221,26 @@ def ctypes_type_to_mlir_type(obj: ctypes._SimpleCData) -> ir.Type:
             return llvm.PointerType.get()
         case ctypes.c_bool:
             return T.bool()
-        case ctypes.c_byte:
+        case ctypes.c_int8:
             return T.i8()
-        case ctypes.c_ubyte:
+        case ctypes.c_uint8:
             return T.ui8()
-        case ctypes.c_short | ctypes.c_int16 | ctypes.c_short:
+        case ctypes.c_int16:
             return T.i16()
-        case ctypes.c_int | ctypes.c_int32 | ctypes.c_int:
-            return T.i32()
         case ctypes.c_uint16:
             return T.i16()
-        case ctypes.c_uint32 | ctypes.c_uint:
+        case ctypes.c_int32:
             return T.i32()
-        case ctypes.c_uint64 | ctypes.c_ulong:
+        case ctypes.c_uint32:
+            return T.i32()
+        case ctypes.c_int64:
             return T.i64()
-        case ctypes.c_long | ctypes.c_int64 | ctypes.c_long:
+        case ctypes.c_uint64:
             return T.i64()
+        case ctypes.c_float:
+            return T.f32()
+        case ctypes.c_double:
+            return T.f64()
         case ctypes.POINTER():
             raise NotImplementedError(f"Not implemented for type {type(obj)}")
         case _:

--- a/src/numba_cuda_mlir/lowering_utilities/type_conversions.py
+++ b/src/numba_cuda_mlir/lowering_utilities/type_conversions.py
@@ -152,6 +152,8 @@ def _(ty: ir.Type | ir.FunctionType) -> types.Type | typing.Signature:
 def _(obj: type) -> types.Type:
     if ctypes._SimpleCData in obj.mro():
         return ctypes_type_to_numba_type(obj)
+    if issubclass(obj, np.generic):
+        return np_dtype_to_numba_dtype(np.dtype(obj))
     raise NotImplementedError(f"Not implemented for type {obj}")
 
 
@@ -177,8 +179,6 @@ def ctypes_type_to_numba_type(obj: ctypes._SimpleCData) -> types.Type:
             return types.int64
         case ctypes.c_ulong:
             return types.uint64
-        case ctypes.c_float16:
-            return types.float16
         case ctypes.c_float:
             return types.float32
         case ctypes.c_double:
@@ -203,7 +203,7 @@ def _(obj: type) -> ir.Type:
     mro = obj.mro()
     if ctypes._SimpleCData in mro:
         return ctypes_type_to_mlir_type(obj)
-    elif obj.__module__ == "numpy":
+    elif issubclass(obj, np.generic):
         return np_dtype_to_mlir_type(obj)
     raise NotImplementedError(f"Not implemented for type {obj}")
 

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Typing conversion tests.
+"""
+
+import ctypes
+import numpy as np
+import pytest
+
+from numba_cuda_mlir.numba_cuda import types
+from numba_cuda_mlir.lowering_utilities.type_conversions import to_numba_type
+
+def test_numpy_scalar_type_conversion():
+    """Verify that numpy scalar types convert to correct numba types."""
+    assert to_numba_type(np.float32) == types.float32
+    assert to_numba_type(np.float64) == types.float64
+    assert to_numba_type(np.float16) == types.float16
+    assert to_numba_type(np.int32) == types.int32
+    assert to_numba_type(np.int64) == types.int64
+    assert to_numba_type(np.complex64) == types.complex64
+    assert to_numba_type(np.complex128) == types.complex128
+
+def test_numpy_dtype_conversion():
+    """Verify that numpy dtypes convert to correct numba types."""
+    assert to_numba_type(np.dtype(np.float32)) == types.float32
+    assert to_numba_type(np.dtype(np.float64)) == types.float64
+    assert to_numba_type(np.dtype(np.int32)) == types.int32
+
+def test_ctypes_conversion():
+    """Verify that ctypes types convert to correct numba types."""
+    assert to_numba_type(ctypes.c_float) == types.float32
+    assert to_numba_type(ctypes.c_double) == types.float64
+    assert to_numba_type(ctypes.c_int32) == types.int32

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -11,24 +11,65 @@ import pytest
 from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir.lowering_utilities.type_conversions import to_numba_type
 
-def test_numpy_scalar_type_conversion():
+
+@pytest.mark.parametrize(
+    "np_type, numba_type",
+    [
+        (np.float32, types.float32),
+        (np.float64, types.float64),
+        (np.float16, types.float16),
+        (np.int32, types.int32),
+        (np.int64, types.int64),
+        (np.complex64, types.complex64),
+        (np.complex128, types.complex128),
+    ],
+)
+def test_numpy_scalar_type_conversion(np_type, numba_type):
     """Verify that numpy scalar types convert to correct numba types."""
-    assert to_numba_type(np.float32) == types.float32
-    assert to_numba_type(np.float64) == types.float64
-    assert to_numba_type(np.float16) == types.float16
-    assert to_numba_type(np.int32) == types.int32
-    assert to_numba_type(np.int64) == types.int64
-    assert to_numba_type(np.complex64) == types.complex64
-    assert to_numba_type(np.complex128) == types.complex128
+    assert to_numba_type(np_type) == numba_type
 
-def test_numpy_dtype_conversion():
+
+@pytest.mark.parametrize(
+    "np_type, numba_type",
+    [
+        (np.float32, types.float32),
+        (np.float64, types.float64),
+        (np.int32, types.int32),
+    ],
+)
+def test_numpy_dtype_conversion(np_type, numba_type):
     """Verify that numpy dtypes convert to correct numba types."""
-    assert to_numba_type(np.dtype(np.float32)) == types.float32
-    assert to_numba_type(np.dtype(np.float64)) == types.float64
-    assert to_numba_type(np.dtype(np.int32)) == types.int32
+    assert to_numba_type(np.dtype(np_type)) == numba_type
 
-def test_ctypes_conversion():
+
+@pytest.mark.parametrize(
+    "ctype, numba_type",
+    [
+        (ctypes.c_float, types.float32),
+        (ctypes.c_double, types.float64),
+        (ctypes.c_int32, types.int32),
+    ],
+)
+def test_ctypes_conversion(ctype, numba_type):
     """Verify that ctypes types convert to correct numba types."""
-    assert to_numba_type(ctypes.c_float) == types.float32
-    assert to_numba_type(ctypes.c_double) == types.float64
-    assert to_numba_type(ctypes.c_int32) == types.int32
+    assert to_numba_type(ctype) == numba_type
+
+
+def test_custom_type_conversion():
+    """Verify that a custom type registered through the extension api converts correctly."""
+
+    class CustomFrontendType:
+        pass
+
+    class CustomNumbaType(types.Type):
+        def __init__(self):
+            super().__init__(name="CustomNumbaType")
+
+    custom_numba_type_instance = CustomNumbaType()
+
+    @to_numba_type.register(CustomFrontendType)
+    def _(val: CustomFrontendType) -> types.Type:
+        return custom_numba_type_instance
+
+    frontend_val = CustomFrontendType()
+    assert to_numba_type(frontend_val) == custom_numba_type_instance

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -62,6 +62,8 @@ def test_numpy_dtype_conversion(np_type, numba_type):
         (ctypes.c_uint16, types.uint16),
         (ctypes.c_uint32, types.uint32),
         (ctypes.c_uint64, types.uint64),
+        (ctypes.c_longlong, types.int64),
+        (ctypes.c_ulonglong, types.uint64),
         (np.complex64, types.complex64),
         (np.complex128, types.complex128),
     ],

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -15,11 +15,17 @@ from numba_cuda_mlir.lowering_utilities.type_conversions import to_numba_type
 @pytest.mark.parametrize(
     "np_type, numba_type",
     [
+        (np.float16, types.float16),
         (np.float32, types.float32),
         (np.float64, types.float64),
-        (np.float16, types.float16),
+        (np.int8, types.int8),
+        (np.int16, types.int16),
         (np.int32, types.int32),
         (np.int64, types.int64),
+        (np.uint8, types.uint8),
+        (np.uint16, types.uint16),
+        (np.uint32, types.uint32),
+        (np.uint64, types.uint64),
         (np.complex64, types.complex64),
         (np.complex128, types.complex128),
     ],
@@ -35,6 +41,7 @@ def test_numpy_scalar_type_conversion(np_type, numba_type):
         (np.float32, types.float32),
         (np.float64, types.float64),
         (np.int32, types.int32),
+        (np.uint32, types.uint32),
     ],
 )
 def test_numpy_dtype_conversion(np_type, numba_type):
@@ -47,7 +54,16 @@ def test_numpy_dtype_conversion(np_type, numba_type):
     [
         (ctypes.c_float, types.float32),
         (ctypes.c_double, types.float64),
+        (ctypes.c_int8, types.int8),
+        (ctypes.c_int16, types.int16),
         (ctypes.c_int32, types.int32),
+        (ctypes.c_int64, types.int64),
+        (ctypes.c_uint8, types.uint8),
+        (ctypes.c_uint16, types.uint16),
+        (ctypes.c_uint32, types.uint32),
+        (ctypes.c_uint64, types.uint64),
+        (np.complex64, types.complex64),
+        (np.complex128, types.complex128),
     ],
 )
 def test_ctypes_conversion(ctype, numba_type):


### PR DESCRIPTION
## Description

This PR improves the robustness of type conversions in `type_conversions.py` for NumPy and `ctypes` types, and adds comprehensive, parameterized test coverage for these utilities, including extension API support.

### Key Changes
- **Improved NumPy Type Resolution**: Updated `to_numba_type` and `to_mlir_type` to use `issubclass(obj, np.generic)` instead of checking `__module__ == "numpy"`. This properly catches NumPy scalar types (like `np.float32`, `np.complex64`, etc.) passed as types and maps them correctly to their respective Numba/MLIR types.
- **Removed Invalid Ctype**: Removed `ctypes.c_float16` from `ctypes_type_to_numba_type` as it does not exist in standard Python `ctypes` and was causing an `AttributeError`.
- **Parameterized Unit Tests**: Added `tests/test_type_conversions.py` with `pytest.mark.parametrize` to assert that `to_numba_type` correctly round-trips for NumPy scalar types, `np.dtype` wrappers, and `ctypes` scalar equivalents. 
- **Extension API Testing**: Added a test asserting that custom frontend types dynamically registered via the `@to_numba_type.register` extension API are accurately resolved.

## Testing
- [x] Added `test_type_conversions.py` containing:
  - `test_numpy_scalar_type_conversion` (Parameterized)
  - `test_numpy_dtype_conversion` (Parameterized)
  - `test_ctypes_conversion` (Parameterized)
  - `test_custom_type_conversion`
- [x] Verified `pytest -v tests/test_type_conversions.py` passes successfully locally.
- [x] Tested against `nvmath-python`'s `cufftdx` example test suite.