### PR TITLE
Optimize CUDA array interface launch caching

### DIFF
--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -29,6 +29,7 @@ from numba_cuda_mlir.numba_cuda import serialize, typing
 from numba_cuda_mlir.numba_cuda.core.base import BaseContext
 from numba_cuda_mlir.numba_cuda.core.callconv import MinimalCallConv
 from numba_cuda_mlir.numba_cuda.cudadrv.devicearray import DeviceNDArrayBase
+from numba_cuda_mlir.numba_cuda.np import numpy_support
 from numba_cuda_mlir.numba_cuda.core.descriptors import TargetDescriptor
 from numba_cuda_mlir.numba_cuda.core.compiler_lock import global_compiler_lock
 from numba_cuda_mlir.numba_cuda.dispatcher import Dispatcher
@@ -129,6 +130,149 @@ def _flatten_arg(arg, out):
         out.append(arg)
 
 
+def _cuda_array_interface(arg):
+    return getattr(arg, "__cuda_array_interface__", None)
+
+
+def _validate_cuda_array_interface(cai):
+    version = cai.get("version")
+    if version is not None and 1 <= version and cai.get("mask") is not None:
+        raise NotImplementedError("Masked arrays are not supported")
+
+
+def _sync_cuda_array_interface_stream(arg):
+    if isinstance(arg, DeviceNDArrayBase):
+        return
+
+    cai = _cuda_array_interface(arg)
+    if cai is None:
+        return
+
+    _validate_cuda_array_interface(cai)
+    stream_ptr = cai.get("stream")
+    if stream_ptr is None or not cuda_config.CUDA_ARRAY_INTERFACE_SYNC:
+        return
+
+    from numba_cuda_mlir.numba_cuda.cudadrv import devices
+
+    devices.get_context().create_external_stream(stream_ptr).synchronize()
+
+
+def _array_shape(arg):
+    shape = getattr(arg, "shape", None)
+    if shape is not None:
+        return tuple(shape)
+
+    cai = _cuda_array_interface(arg)
+    if cai is not None:
+        return tuple(cai["shape"])
+
+    return None
+
+
+def _array_dtype(arg, ty=None):
+    dtype = getattr(arg, "dtype", None)
+    if dtype is not None:
+        return np.dtype(dtype)
+
+    cai = _cuda_array_interface(arg)
+    if cai is not None:
+        return np.dtype(cai["typestr"])
+
+    if isinstance(ty, types.Array):
+        return numpy_support.as_dtype(ty.dtype)
+
+    raise AttributeError(f"{type(arg).__name__!r} object has no dtype metadata")
+
+
+def _array_strides(arg):
+    strides = getattr(arg, "strides", None)
+    if strides is not None:
+        return tuple(strides)
+
+    cai = _cuda_array_interface(arg)
+    if cai is not None:
+        strides = cai.get("strides")
+        if strides is not None:
+            return tuple(strides)
+
+    return None
+
+
+def _array_layout(arg, ty=None):
+    """Return the Numba array layout key for array-like runtime arguments."""
+    ndim = getattr(arg, "ndim", None)
+    if ndim is None:
+        shape = _array_shape(arg)
+        if shape is None:
+            if isinstance(ty, types.Array):
+                return ty.layout
+            shape = ()
+        ndim = len(shape)
+    if ndim == 0:
+        return "C"
+
+    strides = _array_strides(arg)
+    if strides is None:
+        return "C"
+
+    shape = _array_shape(arg)
+    itemsize = _array_dtype(arg, ty).itemsize
+
+    c_stride = itemsize
+    c_strides = []
+    for extent in reversed(shape):
+        c_strides.append(c_stride)
+        c_stride *= extent
+    c_strides = tuple(reversed(c_strides))
+    if tuple(strides) == c_strides:
+        return "C"
+
+    f_stride = itemsize
+    f_strides = []
+    for extent in shape:
+        f_strides.append(f_stride)
+        f_stride *= extent
+    if tuple(strides) == tuple(f_strides):
+        return "F"
+
+    return "A"
+
+
+def _array_readonly(arg, ty=None):
+    cai = _cuda_array_interface(arg)
+    if cai is not None:
+        _, readonly = cai["data"]
+        return bool(readonly)
+
+    flags = getattr(arg, "flags", None)
+    if flags is not None:
+        writeable = getattr(flags, "writeable", None)
+        if writeable is None:
+            writeable = flags["WRITEABLE"]
+        return not writeable
+
+    if isinstance(ty, types.Array):
+        return not ty.mutable
+
+    return False
+
+
+def _array_cache_key(arg, ty):
+    """Return metadata that determines whether a cached array type is reusable."""
+    dtype = _array_dtype(arg, ty)
+    ndim = getattr(arg, "ndim", None)
+    if ndim is None:
+        shape = _array_shape(arg)
+        if shape is None:
+            ndim = ty.ndim
+        else:
+            ndim = len(shape)
+    layout = _array_layout(arg, ty)
+    readonly = _array_readonly(arg, ty)
+    return (dtype, ndim, layout, readonly)
+
+
 def _raise_as_cuda_error(e):
     """Convert RuntimeError from C++ launcher to cuda.core CUDAError."""
     try:
@@ -161,7 +305,7 @@ class _ArgMarshaller:
         self._extensions = extensions or []
         self._dispatcher = dispatcher
         self._sig_cache = {}  # {type_key: (argtypes, fast_ok)}
-        self._array_sig_cache = {}  # {type_key: (argtypes, ((idx, dtype_num, ndim), ...))}
+        self._array_sig_cache = {}  # {type_key: [(argtypes, ((idx, array_key), ...))]}
 
     def _maybe_copy_to_device_item(self, arg):
         if isinstance(arg, DeviceNDArrayBase):
@@ -212,11 +356,11 @@ class _ArgMarshaller:
                     self._callbacks.append(copy_back)
                 return device_arg
             case _ if hasattr(arg, "__cuda_array_interface__") and not isinstance(arg, np.ndarray):
-                # Third-party objects implementing __cuda_array_interface__.
-                # Convert to DeviceNDArray so typeof() works.
-                from numba_cuda_mlir.numba_cuda.api import from_cuda_array_interface
-
-                return from_cuda_array_interface(arg.__cuda_array_interface__, owner=arg)
+                # The C++ launcher can consume CUDA Array Interface objects
+                # directly. Keep the original object so repeated CuPy/foreign
+                # array launches do not rebuild DeviceNDArray wrappers.
+                _sync_cuda_array_interface_stream(arg)
+                return arg
             case np.ndarray() if hasattr(arg, "__cuda_array_interface__"):
                 return arg
             case np.ndarray():
@@ -314,17 +458,19 @@ class _ArgMarshaller:
 
                 # Array values keep the same Python class across many dtypes.
                 # Reuse cached argtypes only when the Numba array type is stable.
-                array_entry = self._array_sig_cache.get(type_key)
-                if array_entry is not None:
-                    cached_argtypes, array_checks = array_entry
-                    ok = True
-                    for idx, dtype, ndim in array_checks:
-                        a = args[idx]
-                        if a.dtype != dtype or a.ndim != ndim:
-                            ok = False
-                            break
-                    if ok:
-                        return self._launch(cached_argtypes, args)
+                array_entries = self._array_sig_cache.get(type_key)
+                if array_entries is not None:
+                    for cached_argtypes, array_checks in array_entries:
+                        ok = True
+                        for idx, array_key in array_checks:
+                            a = args[idx]
+                            if _array_cache_key(a, cached_argtypes[idx]) != array_key:
+                                ok = False
+                                break
+                        if ok:
+                            for idx, _ in array_checks:
+                                _sync_cuda_array_interface_stream(args[idx])
+                            return self._launch(cached_argtypes, args)
 
         reversed_ext = self._extensions[::-1] if has_ext else None
         copy_item = self._maybe_copy_to_device_item
@@ -389,12 +535,16 @@ class _ArgMarshaller:
 
                 # Only cache already-device array launches. Host arrays and
                 # wrappers need per-launch copy/copyback setup.
-                if has_arrays and all_pass_through and type_key not in self._array_sig_cache:
+                if has_arrays and all_pass_through:
                     array_checks = []
                     for i, ct in enumerate(coerced_types):
                         if isinstance(ct, types.Array):
-                            array_checks.append((i, args[i].dtype, args[i].ndim))
-                    self._array_sig_cache[type_key] = (list(coerced_types), tuple(array_checks))
+                            array_checks.append((i, _array_cache_key(args[i], ct)))
+                    array_checks = tuple(array_checks)
+                    entries = self._array_sig_cache.setdefault(type_key, [])
+                    if not any(checks == array_checks for _, checks in entries):
+                        entries.append((list(coerced_types), array_checks))
+                        del entries[:-8]
 
         return result
 

--- a/tests/test_cuda_array_interface_launch_cache.py
+++ b/tests/test_cuda_array_interface_launch_cache.py
@@ -54,9 +54,7 @@ def test_cupy_launch_does_not_reconstruct_device_arrays(monkeypatch):
         calls.append((args, kwargs))
         raise AssertionError("launch path should pass CUDA Array Interface objects through")
 
-    monkeypatch.setattr(
-        cuda_api, "from_cuda_array_interface", forbidden_from_cuda_array_interface
-    )
+    monkeypatch.setattr(cuda_api, "from_cuda_array_interface", forbidden_from_cuda_array_interface)
 
     @cuda.jit
     def add(a, b, out):

--- a/tests/test_cuda_array_interface_launch_cache.py
+++ b/tests/test_cuda_array_interface_launch_cache.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from numba_cuda_mlir import cuda
+from numba_cuda_mlir.descriptor import _ArgMarshaller
+
+
+class FakeCudaArray:
+    def __init__(self, *, readonly=False, mask=None):
+        data = (0, readonly)
+        self.__cuda_array_interface__ = {
+            "version": 1,
+            "shape": (4,),
+            "typestr": "<f4",
+            "data": data,
+            "strides": None,
+            "stream": None,
+        }
+        if mask is not None:
+            self.__cuda_array_interface__["mask"] = mask
+
+
+def test_cuda_array_interface_launch_rejects_masked_arrays():
+    configured = _ArgMarshaller(lambda *args: None)
+
+    with pytest.raises(NotImplementedError, match="Masked arrays are not supported"):
+        configured(FakeCudaArray(mask=object()))
+
+
+def test_cuda_array_interface_signature_cache_tracks_readonly():
+    configured = _ArgMarshaller(lambda *args: None)
+    mutable = FakeCudaArray(readonly=False)
+    readonly = FakeCudaArray(readonly=True)
+
+    configured(mutable)
+    type_key = (FakeCudaArray,)
+    assert len(configured._array_sig_cache[type_key]) == 1
+
+    configured(readonly)
+    assert len(configured._array_sig_cache[type_key]) == 2
+
+
+def test_cupy_launch_does_not_reconstruct_device_arrays(monkeypatch):
+    cp = pytest.importorskip("cupy")
+    import numba_cuda_mlir.numba_cuda.api as cuda_api
+    import numba_cuda_mlir.type_defs.cupy_types  # noqa: F401
+
+    calls = []
+
+    def forbidden_from_cuda_array_interface(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("launch path should pass CUDA Array Interface objects through")
+
+    monkeypatch.setattr(
+        cuda_api, "from_cuda_array_interface", forbidden_from_cuda_array_interface
+    )
+
+    @cuda.jit
+    def add(a, b, out):
+        i = cuda.grid(1)
+        if i < out.size:
+            out[i] = a[i] + b[i]
+
+    a = cp.arange(32, dtype=cp.float32)
+    b = cp.ones(32, dtype=cp.float32)
+    out = cp.zeros(32, dtype=cp.float32)
+
+    configured = add[1, 32]
+    configured(a, b, out)
+    configured(a, b, out)
+
+    np.testing.assert_allclose(cp.asnumpy(out), cp.asnumpy(a + b))
+    assert calls == []
+
+
+def test_cupy_array_signature_cache_tracks_dtype_and_ndim():
+    cp = pytest.importorskip("cupy")
+    import numba_cuda_mlir.type_defs.cupy_types  # noqa: F401
+
+    @cuda.jit
+    def add(a, b, out):
+        i = cuda.grid(1)
+        if i < out.size:
+            out[i] = a[i] + b[i]
+
+    configured = add[1, 32]
+
+    a32 = cp.arange(32, dtype=cp.float32)
+    b32 = cp.ones(32, dtype=cp.float32)
+    out32 = cp.zeros(32, dtype=cp.float32)
+    configured(a32, b32, out32)
+
+    type_key = (type(a32), type(b32), type(out32))
+    assert len(configured._array_sig_cache[type_key]) == 1
+
+    a32_b = cp.arange(64, dtype=cp.float32)
+    b32_b = cp.ones(64, dtype=cp.float32)
+    out32_b = cp.zeros(64, dtype=cp.float32)
+    configured(a32_b, b32_b, out32_b)
+    assert len(configured._array_sig_cache[type_key]) == 1
+
+    a64 = cp.arange(32, dtype=cp.float64)
+    b64 = cp.ones(32, dtype=cp.float64)
+    out64 = cp.zeros(32, dtype=cp.float64)
+    configured(a64, b64, out64)
+
+    assert len(configured._array_sig_cache[type_key]) == 2
+    np.testing.assert_allclose(cp.asnumpy(out64), cp.asnumpy(a64 + b64))


### PR DESCRIPTION
Summary:
- pass CUDA Array Interface objects directly to the C++ launcher to avoid rebuilding DeviceNDArray wrappers on hot launches
- cache array launch signatures by dtype, ndim, layout, and readonly state so cached argtypes match Numba typing semantics
- reject masked CUDA Array Interface objects before pass-through launch, preserving the previous unsupported-mask behavior
- add regression coverage for pass-through launches, dtype/ndim cache reuse, readonly cache separation, and masked-array rejection