### PR TITLE
Permit `NamedTuple` in a kernel + fix `None` start in shmem view

### DIFF
--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -574,7 +574,7 @@ class Slice:
         self.start: ir.Value = (
             lowering_utilities.convert(start, T.index())
             if start is not None
-            else arith.constant(result=T.index(), value=0)
+            else arith.index_cast(arith.constant(result=T.i64(), value=0), to=T.index())
         )
         # Handle None for stop (e.g., x[2:] has stop=None meaning end of array)
         if isinstance(stop, ir.NoneType):
@@ -903,7 +903,7 @@ def lower_array_slice_getitem(builder, target, args, kwargs):
     slice = builder.load_var(args[1])
     start, stop, step = slice.start, slice.stop, slice.step
     if start is None:
-        start = index_of(0)
+        start = arith.index_cast(arith.constant(result=T.i64(), value=0), to=T.index())
     if stop is None:
         stop = memref.dim(mr, index_of(0))
     if step is None:

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -17,7 +17,6 @@ from numba_cuda_mlir.numba_cuda.extending import _Intrinsic
 
 from numba_cuda_mlir.numba_cuda.core.environment import Environment
 from numba_cuda_mlir import types
-from numba_cuda_mlir.numba_cuda import types as numba_types
 from numba_cuda_mlir.numba_cuda.datamodel.models import ArrayModel
 from numba_cuda_mlir.annotations import Builder, AnyCallable, PS
 from numba_cuda_mlir.errors import InternalCompilerError, ensure_verifies
@@ -2527,6 +2526,13 @@ extern "C" __global__ void
                 container=struct_val,
                 position=ir.DenseI64ArrayAttr.get([field_idx]),
             )
+            self.incref(target_type, result)
+            self.store_var(target, result)
+            return
+
+        if isinstance(value_type, types.BaseNamedTuple) and attr in value_type.fields:
+            index = value_type.fields.index(attr)
+            result = self.load_var(value)[index]
             self.incref(target_type, result)
             self.store_var(target, result)
             return

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -9,6 +9,7 @@ import operator
 from typing import Any, Callable, Sequence
 import numpy as np
 from numba_cuda_mlir.numba_cuda import typing, utils
+from numba_cuda_mlir.numba_cuda import types as numba_types
 from numba_cuda_mlir.numba_cuda.core import targetconfig, errors
 from numba_cuda_mlir.numba_cuda.core import ir as numba_ir
 from numba_cuda_mlir.numba_cuda import dispatcher

--- a/src/numba_cuda_mlir/numba_cuda/api.py
+++ b/src/numba_cuda_mlir/numba_cuda/api.py
@@ -12,7 +12,10 @@ import numpy as np
 
 from .cudadrv import devicearray, devices, driver
 from numba_cuda_mlir.numba_cuda.core import config
-from numba_cuda_mlir.numba_cuda.api_util import prepare_shape_strides_dtype
+from numba_cuda_mlir.numba_cuda.api_util import (
+    prepare_shape_strides_dtype,
+    resolve_cuda_array_interface_dtype,
+)
 
 # NDarray device helper
 
@@ -41,7 +44,8 @@ def from_cuda_array_interface(desc, owner=None, sync=True):
     shape = desc["shape"]
     strides = desc.get("strides")
 
-    shape, strides, dtype = prepare_shape_strides_dtype(shape, strides, desc["typestr"], order="C")
+    dtype = resolve_cuda_array_interface_dtype(desc["typestr"], getattr(owner, "dtype", None))
+    shape, strides, dtype = prepare_shape_strides_dtype(shape, strides, dtype, order="C")
     size = driver.memory_size_from_info(shape, strides, dtype.itemsize)
 
     cudevptr_class = driver.binding.CUdeviceptr

--- a/src/numba_cuda_mlir/numba_cuda/api_util.py
+++ b/src/numba_cuda_mlir/numba_cuda/api_util.py
@@ -8,6 +8,21 @@ import numpy as np
 import functools
 
 
+def resolve_cuda_array_interface_dtype(typestr, owner_dtype=None):
+    dtype = np.dtype(typestr)
+    if owner_dtype is None:
+        return dtype
+
+    try:
+        owner_dtype = np.dtype(owner_dtype)
+    except TypeError:
+        return dtype
+
+    if owner_dtype.itemsize == dtype.itemsize:
+        return owner_dtype
+    return dtype
+
+
 def prepare_shape_strides_dtype(shape, strides, dtype, order):
     dtype = np.dtype(dtype)
     if isinstance(shape, (float, np.floating)):

--- a/src/numba_cuda_mlir/numba_cuda/np/numpy_support.py
+++ b/src/numba_cuda_mlir/numba_cuda/np/numpy_support.py
@@ -156,6 +156,13 @@ def _from_dtype_impl(dtype_cached):
     if result is not None:
         return result
 
+    if (
+        ml_dtypes is not None
+        and getattr(dtype, "name", None) == "bfloat16"
+        and getattr(dtype, "itemsize", None) == 2
+    ):
+        return types.bfloat16
+
     if (char := getattr(dtype, "char", None)) is not None:
         if char in "SU":
             return _from_str_dtype(dtype)

--- a/src/numba_cuda_mlir/numba_cuda/typing/typeof.py
+++ b/src/numba_cuda_mlir/numba_cuda/typing/typeof.py
@@ -14,6 +14,7 @@ from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir.numba_cuda.core import errors
 from numba_cuda_mlir.numba_cuda import utils
 from numba_cuda_mlir.numba_cuda.np import numpy_support
+from numba_cuda_mlir.numba_cuda.api_util import resolve_cuda_array_interface_dtype
 
 from cuda.core import Buffer
 from cuda.core.utils import StridedMemoryView
@@ -67,7 +68,7 @@ def typeof_impl(val, c):
     # Numba's own DeviceNDArray is handled above via _numba_type_.
     cai = getattr(val, "__cuda_array_interface__", None)
     if cai is not None:
-        tp = _typeof_cuda_array_interface(cai, c)
+        tp = _typeof_cuda_array_interface(cai, c, getattr(val, "dtype", None))
         if tp is not None:
             return tp
 
@@ -366,11 +367,12 @@ def _typeof_dlpack(val, c):
 
 
 @functools.lru_cache
-def _numba_dtype_from_str(typestr):
-    return numpy_support.from_dtype(np.dtype(typestr))
+def _numba_dtype_from_str(typestr, owner_dtype=None):
+    dtype = resolve_cuda_array_interface_dtype(typestr, owner_dtype)
+    return numpy_support.from_dtype(dtype)
 
 
-def _typeof_cuda_array_interface(val, c):
+def _typeof_cuda_array_interface(val, c, owner_dtype=None):
     """
     Determine the type of a __cuda_array_interface__ object.
 
@@ -378,7 +380,7 @@ def _typeof_cuda_array_interface(val, c):
     Array Interface. These are typed as regular Array types, with lowering
     handled in numba.cuda.np.arrayobj.
     """
-    dtype = _numba_dtype_from_str(val["typestr"])
+    dtype = _numba_dtype_from_str(val["typestr"], owner_dtype)
     shape = val["shape"]
     strides = val.get("strides")
     _, readonly = val["data"]

--- a/src/numba_cuda_mlir/types.py
+++ b/src/numba_cuda_mlir/types.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from numba_cuda_mlir.numba_cuda.types import (
     BaseTuple,
+    BaseNamedTuple,
     BoundFunction,
     Optional,
     Poison,

--- a/tests/numba_cuda_tests/cudapy/test_analysis.py
+++ b/tests/numba_cuda_tests/cudapy/test_analysis.py
@@ -1091,7 +1091,6 @@ class TestBranchPrunePostSemanticConstRewrites(TestBranchPruneBase):
 
         self.assertIn("Unknown attribute 'as_integer_ratio'", str(e.exception))
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_ndim_not_on_array(self):
         FakeArray = collections.namedtuple("FakeArray", ["ndim"])
         fa = FakeArray(ndim=2)

--- a/tests/numba_cuda_tests/cudapy/test_array_args.py
+++ b/tests/numba_cuda_tests/cudapy/test_array_args.py
@@ -61,7 +61,6 @@ class TestCudaArrayArg(NumbaCUDATestCase):
         for i in range(len(r2)):
             self.assertEqual(r2[i], x[i + len(r1)])
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_namedunituple(self):
         @numba_cuda_mlir.cuda.jit
         def f(r, x):
@@ -76,7 +75,6 @@ class TestCudaArrayArg(NumbaCUDATestCase):
         self.assertEqual(r[0], x.x)
         self.assertEqual(r[1], x.y)
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_namedtuple(self):
         @numba_cuda_mlir.cuda.jit
         def f(r1, r2, x):

--- a/tests/numba_cuda_tests/cudapy/test_sm.py
+++ b/tests/numba_cuda_tests/cudapy/test_sm.py
@@ -190,6 +190,21 @@ class TestSharedMemory(NumbaCUDATestCase):
         expected = np.array([1, 2], dtype=np.int32)
         self._test_dynshared_slice(slice_read, arr, expected)
 
+    def test_dynshared_slice_implicit_start(self):
+        @numba_cuda_mlir.cuda.jit
+        def slice_implicit_start(x):
+            dynsmem = cuda.shared.array(0, dtype=np.float32)
+            sm = dynsmem[:4]
+            i = cuda.threadIdx.x
+            sm[i] = np.float32(1.0)
+            x[i] = sm[i]
+
+        arr = np.zeros(4, dtype=np.float32)
+        expected = np.ones(4, dtype=np.float32)
+        nshared = arr.size * arr.dtype.itemsize
+        slice_implicit_start[1, 4, 0, nshared](arr)
+        np.testing.assert_array_equal(expected, arr)
+
     def test_dynshared_slice_diff_sizes(self):
         # Test reading values from disjoint slices of dynamic shared memory
         # with different sizes

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -95,7 +95,21 @@ def test_hetero_tuple_arg():
     np.testing.assert_array_equal(r2, x[3:])
 
 
-@pytest.mark.xfail(reason="namedtuple NYI")
+def test_captured_namedtuple_getattr():
+    Prec = namedtuple("Prec", ["a", "b"])
+    prec = Prec(np.float32, np.float64)
+    r = np.zeros(1, dtype=np.float32)
+
+    @cuda.jit
+    def f(r):
+        tmp = cuda.local.array(1, prec.a)
+        tmp[0] = 1
+        r[0] = tmp[0]
+
+    f[1, 1](r)
+    assert r[0] == np.float32(1)
+
+
 @pytest.mark.parametrize(
     "Point, vals, dtypes",
     [


### PR DESCRIPTION
This removes 4 xfails as well as fixes two bugs needed for nvmath support.