### PR TITLE
Drop implicit `nvjitlink` dependency derived from `cudatoolkit` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,12 @@ dependencies = [
 [project.optional-dependencies]
 cu12 = [
     "cuda-bindings>=12.9.1,<13.0.0",
-    "cuda-toolkit[cudart,nvcc,nvrtc,nvjitlink,cccl]==12.*",
+    "cuda-toolkit[cudart,nvcc,nvrtc,cccl]==12.*",
     "nvidia-nvjitlink-cu12>=12.3.0,<13.0.0",
 ]
 cu13 = [
     "cuda-bindings==13.*",
-    "cuda-toolkit[cudart,nvcc,nvrtc,nvjitlink,cccl]==13.*",
+    "cuda-toolkit[cudart,nvcc,nvrtc,cccl]==13.*",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,26 @@ dependencies = [
 cu12 = [
     "cuda-bindings>=12.9.1,<13.0.0",
     "cuda-toolkit[cudart,nvcc,nvrtc,cccl]==12.*",
+
+    # The nvJitLink library is compatible across minor versions in a release,
+    # but may not be compatible across major versions. The library version
+    # itself must be >= the maximum version of the inputs, and the shared
+    # library version must be >= the version that was linked with.
+    #
+    # https://docs.nvidia.com/cuda/archive/12.9.1/nvjitlink/index.html#compatibility
     "nvidia-nvjitlink-cu12>=12.3.0,<13.0.0",
 ]
 cu13 = [
     "cuda-bindings==13.*",
     "cuda-toolkit[cudart,nvcc,nvrtc,cccl]==13.*",
+
+    # The nvJitLink library is compatible across minor versions in a release,
+    # but may not be compatible across major versions. The library version
+    # itself must be >= the maximum version of the inputs, and the shared
+    # library version must be >= the version that was linked with.
+    #
+    # https://docs.nvidia.com/cuda/nvjitlink/index.html#compatibility
+    "nvidia-nvjitlink>=13.0.0,<14.0.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Drops `nvjitlink` from the list of extras installed via the `cudatoolkit` pypi metapackages. With the current setup, a downstream library that pins the `cudatoolkit` package implicitly pins `nvjitlink` as well, which is a problem if they need 12.9 for instance to ensure MVC. 

The explicit nvjitlink dependency listed should be sufficient. 