### PR TITLE
BUG: Remove packaging dependency from numba_cuda._compat

### DIFF
--- a/src/numba_cuda_mlir/numba_cuda/_compat.py
+++ b/src/numba_cuda_mlir/numba_cuda/_compat.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 from cuda import core
 
-# Utilize core._version attributes
-#    __version__ => '1.0.2.dev46+g16df11dab'
-#    __version_tuple__ => (1, 0, 2, 'dev46', 'g16df11dab')
-CUDA_CORE_VERSION = core._version.__version_tuple__
+# core.__version__ returns str like '1.0.1',
+# '1.0.2.dev46+g16df11dab', etc.
+CUDA_CORE_VERSION = tuple(int(i) for i in core.__version__.split(".") if i.isdigit())
 CUDA_CORE_GT_0_6 = CUDA_CORE_VERSION >= (0, 6, 0)
 CUDA_CORE_GE_1_0 = CUDA_CORE_VERSION >= (1, 0, 0)

--- a/src/numba_cuda_mlir/numba_cuda/_compat.py
+++ b/src/numba_cuda_mlir/numba_cuda/_compat.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-from packaging import version
 from cuda import core
 
-
-CUDA_CORE_VERSION = version.parse(core.__version__)
-CUDA_CORE_GT_0_6 = CUDA_CORE_VERSION >= version.parse("0.6.0")
-CUDA_CORE_GE_1_0 = CUDA_CORE_VERSION >= version.parse("1.0.0")
+# Utilize core._version attributes
+#    __version__ => '1.0.2.dev46+g16df11dab'
+#    __version_tuple__ => (1, 0, 2, 'dev46', 'g16df11dab')
+CUDA_CORE_VERSION = core._version.__version_tuple__
+CUDA_CORE_GT_0_6 = CUDA_CORE_VERSION >= (0, 6, 0)
+CUDA_CORE_GE_1_0 = CUDA_CORE_VERSION >= (1, 0, 0)


### PR DESCRIPTION
Fixes #106 

Rather than add another runtime dependency to numba-cuda-mlir to fix the import issue, we can utilize the `cuda.core._version.__version__tuple` attribute and Python's already powerful tuple comparison functionality to mimic the previous version-comparing behavior.

It also appears that `CUDA_CORE_VERSION` isn't used anywhere else in the codebase, so there aren't any places where the interpreter would expect a `Version` object. Since it's only used to ensure `CUDA_CORE_GT_0_6` and `CUDA_CORE_GE_1_0` are correctly configured before being imported in files like `./src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py`, this PR should be enough to address the issue at hand.

This PR also assumes that any string after the patch number is seen as a dev build:
```python
(1, 0, 0, 'dev', 'g16df11dab') >= (1, 0, 0)   # True
(1, 0, 0, 'alpha', 'g16df11dab') >= (1, 0, 0) # Still true
```

Of course, this corner-case could be covered, but then the work to cover the corner cases might warrant shipping a new `cuda-versions` package (or just relying on packaging after all) 😜 