### PR TITLE
Replace unconditional LTOIR linker optimization disabling with a user-controlled + warning.

### DIFF
--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -115,7 +115,12 @@ SCALAR_UDF="${CUDF_DIR}/python/cudf/cudf/tests/dataframe/methods/test_apply.py"
 GROUPBY_UDF="${CUDF_DIR}/python/cudf/cudf/tests/groupby/test_apply.py"
 NRT_STATS="${CUDF_DIR}/python/cudf/cudf/tests/private_objects/test_nrt_stats.py"
 
-COMMON_ARGS=(-W "ignore::UserWarning" -W "ignore::numba_cuda_mlir.numba_cuda.core.errors.NumbaWarning" -v --tb=short)
+COMMON_ARGS=(
+  -W "ignore::UserWarning"
+  -W "ignore::numba_cuda_mlir.numba_cuda.core.errors.NumbaPerformanceWarning"
+  -W "ignore:Linking LTOIR with optimization_level"
+  -v --tb=short
+)
 
 conda run -n "${CONDA_ENV_NAME}" python -m pytest \
   "${SCALAR_UDF}" \

--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -115,7 +115,7 @@ SCALAR_UDF="${CUDF_DIR}/python/cudf/cudf/tests/dataframe/methods/test_apply.py"
 GROUPBY_UDF="${CUDF_DIR}/python/cudf/cudf/tests/groupby/test_apply.py"
 NRT_STATS="${CUDF_DIR}/python/cudf/cudf/tests/private_objects/test_nrt_stats.py"
 
-COMMON_ARGS=(-W "ignore::UserWarning" -v --tb=short)
+COMMON_ARGS=(-W "ignore::UserWarning" -W "ignore::numba_cuda_mlir.numba_cuda.core.errors.NumbaWarning" -v --tb=short)
 
 conda run -n "${CONDA_ENV_NAME}" python -m pytest \
   "${SCALAR_UDF}" \

--- a/src/numba_cuda_mlir/numba_cuda/core/config.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/config.py
@@ -459,6 +459,10 @@ class _EnvReloader:
         # Whether to generate verbose log messages when JIT linking
         CUDA_VERBOSE_JIT_LOG = _readenv("NUMBA_CUDA_VERBOSE_JIT_LOG", int, 1)
 
+        # WAR for an LTO linking bug that erases float16/bfloat16 (and their
+        # vector type) stores: when set, force opt_level=0 on LTO links
+        CUDA_DISABLE_LTO_OPT = _readenv("NUMBA_CUDA_DISABLE_LTO_OPT", int, 0)
+
         # Whether the default stream is the per-thread default stream
         CUDA_PER_THREAD_DEFAULT_STREAM = _readenv("NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM", int, 0)
 

--- a/src/numba_cuda_mlir/numba_cuda/core/config.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/config.py
@@ -461,7 +461,7 @@ class _EnvReloader:
 
         # WAR for an LTO linking bug that erases float16/bfloat16 (and their
         # vector type) stores: when set, force opt_level=0 on LTO links
-        CUDA_DISABLE_LTO_OPT = _readenv("NUMBA_CUDA_DISABLE_LTO_OPT", int, 0)
+        CUDA_DISABLE_LTO_OPT = _readenv("NUMBA_CUDA_MLIR_DISABLE_LTO_OPT", int, 0)
 
         # Whether the default stream is the per-thread default stream
         CUDA_PER_THREAD_DEFAULT_STREAM = _readenv("NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM", int, 0)

--- a/src/numba_cuda_mlir/numba_cuda/core/config.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/config.py
@@ -592,12 +592,3 @@ def reload_config():
     Reload the configuration from environment variables, if necessary.
     """
     _env_reloader.update()
-
-
-# use numba.core.config if available, otherwise use numba.cuda.core.config
-try:
-    import numba.core.config as _config
-
-    sys.modules[__name__] = _config
-except ImportError:
-    pass

--- a/src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py
+++ b/src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py
@@ -52,6 +52,7 @@ from .mappings import FILE_EXTENSION_MAP
 from .linkable_code import LinkableCode, LTOIR, Fatbin, Object
 from numba_cuda_mlir.numba_cuda.utils import cached_file_read
 from numba_cuda_mlir.numba_cuda.cudadrv import nvrtc
+from numba_cuda_mlir.numba_cuda.core.errors import NumbaWarning
 
 from cuda.bindings import driver as binding
 from cuda.core import (
@@ -2176,6 +2177,17 @@ class CudaPythonFunction:
 Function = CudaPythonFunction
 
 
+@functools.cache
+def _warn_lto_opt_risk():
+    warnings.warn(
+        "Linking LTOIR with optimization_level>0 can erase float16/bfloat16 "
+        "(and their vector type) stores due to a known LTO linking bug."
+        "If results look wrong, set NUMBA_CUDA_DISABLE_LTO_OPT=1 to force "
+        "opt_level=0 on the LTO link.",
+        category=NumbaWarning,
+    )
+
+
 class _Linker:
     def __init__(
         self,
@@ -2402,7 +2414,19 @@ class _Linker:
         # (fixed in cuda-python PR #989, released in cuda-core v0.4.0)
         lto_flag = True if self._has_ltoir else None
         ptx_flag = True if (self._has_ltoir and ptx) else None
-        opt_level = self._optimization_level if (not lto_flag or ptx) else 0
+
+        # LTO cubin links at opt_level>0 can hit an linking bug that erases
+        # float16/bfloat16 (and their vector type) stores. Keep opts on by
+        # default but warn. Allow opting out via NUMBA_CUDA_DISABLE_LTO_OPT,
+        # which forces opt_level=0.
+        lto_cubin_link = bool(lto_flag) and not ptx
+        if lto_cubin_link and config.CUDA_DISABLE_LTO_OPT:
+            opt_level = 0
+        else:
+            opt_level = self._optimization_level
+            if lto_cubin_link and opt_level:
+                _warn_lto_opt_risk()
+
         options = LinkerOptions(
             max_register_count=self.max_registers,
             lineinfo=self.lineinfo,

--- a/src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py
+++ b/src/numba_cuda_mlir/numba_cuda/cudadrv/driver.py
@@ -2182,7 +2182,7 @@ def _warn_lto_opt_risk():
     warnings.warn(
         "Linking LTOIR with optimization_level>0 can erase float16/bfloat16 "
         "(and their vector type) stores due to a known LTO linking bug."
-        "If results look wrong, set NUMBA_CUDA_DISABLE_LTO_OPT=1 to force "
+        "If results look wrong, set NUMBA_CUDA_MLIR_DISABLE_LTO_OPT=1 to force "
         "opt_level=0 on the LTO link.",
         category=NumbaWarning,
     )
@@ -2417,7 +2417,7 @@ class _Linker:
 
         # LTO cubin links at opt_level>0 can hit an linking bug that erases
         # float16/bfloat16 (and their vector type) stores. Keep opts on by
-        # default but warn. Allow opting out via NUMBA_CUDA_DISABLE_LTO_OPT,
+        # default but warn. Allow opting out via NUMBA_CUDA_MLIR_DISABLE_LTO_OPT,
         # which forces opt_level=0.
         lto_cubin_link = bool(lto_flag) and not ptx
         if lto_cubin_link and config.CUDA_DISABLE_LTO_OPT:


### PR DESCRIPTION
The fix introduced in #80 disabled all LTOIR optimizations when linking with LTOIR. This made LTOIR libraries practically unusable, since they are primarily intended for performance-critical use cases and the performance benefit was lost.

Example performance difference:

### Opts disabled
```
((.venv) ) [jlisowski@NV-JVQ3W94 mlir_perf]$ NUMBA_CUDA_DISABLE_LTO_OPT=1 python gemm_perf_mlir.py
GFlop/s        avg 1.21  min 1.21  max 1.21
```

### Opts enbaled
```
((.venv) ) [jlisowski@NV-JVQ3W94 mlir_perf]$ NUMBA_CUDA_DISABLE_LTO_OPT=0 python gemm_perf_mlir.py
GFlop/s        avg 57.61  min 57.47  max 57.69
```

This is roughly a 50x performance difference.

Most use cases are unaffected by the original correctness issue. The problematic path appears to be limited to float16/bfloat16 vector stores when linking with LTOIR and calling an LTOIR function around those stores. Types such as float32, float64, complex64, and complex128 appear to be unaffected.

Given this, it would be better to expose a user-controlled knob and clearly warn about the potential correctness issue, rather than unconditionally disabling all LTOIR optimizations. LTOIR libraries remain usable, and users can decide how to handle the correctness risk depending on their use case.

It should be noted that this LTOIR bug is only present on non-Blackwell architectures with f16, for which a fix will be incoming soon.