### PR TITLE
[CI] Strip LLVM .so files at install time

### DIFF
--- a/ci/build-llvm-modern.sh
+++ b/ci/build-llvm-modern.sh
@@ -80,9 +80,12 @@ cmake_args=(
 
 cmake "${cmake_args[@]}"
 
-# Build & install
+# Build & install. --strip removes the static symbol table (.symtab +
+# .strtab); LLVM is built without -g so there's no DWARF to strip, but
+# the symbol table itself accounts for ~70 MB on libMLIRPythonCAPI.so
+# alone -- ~25 MB compressed in the wheel.
 cmake --build "${LLVM_BUILD}" -j "${PARALLEL}"
-cmake --install "${LLVM_BUILD}"
+cmake --install "${LLVM_BUILD}" --strip
 
 echo "=== Modern LLVM installed to ${LLVM_INSTALL} ==="
 echo "  MLIR_DIR=${LLVM_INSTALL}/lib/cmake/mlir"

--- a/ci/build-llvm7.sh
+++ b/ci/build-llvm7.sh
@@ -39,16 +39,10 @@ command -v sccache &>/dev/null || { echo "ERROR: sccache not found"; exit 1; }
 export CMAKE_C_COMPILER_LAUNCHER="$(which sccache)"
 export CMAKE_CXX_COMPILER_LAUNCHER="$(which sccache)"
 
-# Configure. CMAKE_PLATFORM_NO_VERSIONED_SONAME=ON tells cmake to skip
-# the SOVERSION symlink chain (libLLVM-7.1.so -> libLLVM-7.so ->
-# libLLVM.so) and emit a single un-versioned shared library. Without
-# this, `cmake --install` installs all three and `actions/upload-artifact`
-# (zip format) materializes each symlink as a full byte-identical copy,
-# 3x-bloating the artifact. Matches ci/build-llvm-modern.sh.
+# Configure
 cmake -G Ninja -S "${LLVM7_SRC}/llvm" -B "${LLVM7_BUILD}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-    -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
     -DLLVM_TARGETS_TO_BUILD="NVPTX" \
     -DLLVM_BUILD_LLVM_DYLIB=ON \
     -DLLVM_BUILD_TOOLS=OFF \
@@ -60,23 +54,19 @@ cmake -G Ninja -S "${LLVM7_SRC}/llvm" -B "${LLVM7_BUILD}" \
     -DLLVM_ENABLE_TERMINFO=OFF \
     -DLLVM_ENABLE_ZLIB=ON
 
-# Build only the LLVM shared lib.
+# Build only the LLVM shared lib (not install).
 cmake --build "${LLVM7_BUILD}" -j "${PARALLEL}" --target LLVM
 
-# Install just the LLVM dylib component, with --strip to drop the static
-# symbol table (~5 MB savings; no DWARF present since the build is
-# Release without -g). Component-scoped install avoids dragging in
-# headers / cmake configs / tools we don't need from a full
-# `cmake --install`. Symmetric with ci/build-llvm-modern.sh.
-cmake --install "${LLVM7_BUILD}" --strip --component LLVM --prefix "${LLVM7_INSTALL}"
-
-# Setup.py / build-wheel.yml expects the dylib at the canonical
-# libLLVM-7.so name. With NO_VERSIONED_SONAME above the install should
-# emit exactly one libLLVM*.so; rename it to libLLVM-7.so if needed.
-if [[ ! -f "${LLVM7_INSTALL}/lib/libLLVM-7.so" ]]; then
-    LLVM7_SO="$(ls "${LLVM7_INSTALL}"/lib/libLLVM*.so 2>/dev/null | head -1)"
-    [[ -n "${LLVM7_SO}" ]] && mv "${LLVM7_SO}" "${LLVM7_INSTALL}/lib/libLLVM-7.so"
-fi
+# Asymmetric with ci/build-llvm-modern.sh which uses
+# `cmake --install --strip`: LLVM 7's tools/llvm-shlib creates extra
+# compatibility symlinks (libLLVM-7.so, libLLVM.so -> libLLVM-7.1.so)
+# regardless of CMAKE_PLATFORM_NO_VERSIONED_SONAME, and
+# `actions/upload-artifact`'s zip format materializes each symlink into
+# a full byte-identical copy -- 3x-bloating the artifact. The narrow
+# `cp` + manual `strip` avoids that entirely.
+LLVM7_SO="$(ls "${LLVM7_BUILD}"/lib/libLLVM-7*.so | head -1)"
+cp "${LLVM7_SO}" "${LLVM7_INSTALL}/lib/libLLVM-7.so"
+strip --strip-unneeded "${LLVM7_INSTALL}/lib/libLLVM-7.so"
 
 echo "=== LLVM 7 built ==="
 ls -lh "${LLVM7_INSTALL}/lib/libLLVM-7.so"

--- a/ci/build-llvm7.sh
+++ b/ci/build-llvm7.sh
@@ -54,12 +54,22 @@ cmake -G Ninja -S "${LLVM7_SRC}/llvm" -B "${LLVM7_BUILD}" \
     -DLLVM_ENABLE_TERMINFO=OFF \
     -DLLVM_ENABLE_ZLIB=ON
 
-# Build only the LLVM shared lib (not install)
+# Build only the LLVM shared lib.
 cmake --build "${LLVM7_BUILD}" -j "${PARALLEL}" --target LLVM
 
-# Copy the .so to the install dir with a stable name for artifact passing
-LLVM7_SO="$(ls "${LLVM7_BUILD}"/lib/libLLVM-7*.so | head -1)"
-cp "${LLVM7_SO}" "${LLVM7_INSTALL}/lib/libLLVM-7.so"
+# Install just the LLVM dylib component, with --strip to drop the static
+# symbol table (~5 MB savings; no DWARF present since the build is
+# Release without -g). Component-scoped install avoids dragging in
+# headers / cmake configs / tools we don't need from a full
+# `cmake --install`. Symmetric with ci/build-llvm-modern.sh.
+cmake --install "${LLVM7_BUILD}" --strip --component LLVM --prefix "${LLVM7_INSTALL}"
+
+# LLVM 7 names the dylib libLLVM-7svn.so when built from source. The
+# wheel staging expects the canonical libLLVM-7.so name.
+if [[ ! -f "${LLVM7_INSTALL}/lib/libLLVM-7.so" ]]; then
+    LLVM7_SO="$(ls "${LLVM7_INSTALL}"/lib/libLLVM-7*.so | head -1)"
+    [[ -n "${LLVM7_SO}" ]] && mv "${LLVM7_SO}" "${LLVM7_INSTALL}/lib/libLLVM-7.so"
+fi
 
 echo "=== LLVM 7 built ==="
 ls -lh "${LLVM7_INSTALL}/lib/libLLVM-7.so"

--- a/ci/build-llvm7.sh
+++ b/ci/build-llvm7.sh
@@ -39,10 +39,16 @@ command -v sccache &>/dev/null || { echo "ERROR: sccache not found"; exit 1; }
 export CMAKE_C_COMPILER_LAUNCHER="$(which sccache)"
 export CMAKE_CXX_COMPILER_LAUNCHER="$(which sccache)"
 
-# Configure
+# Configure. CMAKE_PLATFORM_NO_VERSIONED_SONAME=ON tells cmake to skip
+# the SOVERSION symlink chain (libLLVM-7.1.so -> libLLVM-7.so ->
+# libLLVM.so) and emit a single un-versioned shared library. Without
+# this, `cmake --install` installs all three and `actions/upload-artifact`
+# (zip format) materializes each symlink as a full byte-identical copy,
+# 3x-bloating the artifact. Matches ci/build-llvm-modern.sh.
 cmake -G Ninja -S "${LLVM7_SRC}/llvm" -B "${LLVM7_BUILD}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
     -DLLVM_TARGETS_TO_BUILD="NVPTX" \
     -DLLVM_BUILD_LLVM_DYLIB=ON \
     -DLLVM_BUILD_TOOLS=OFF \
@@ -64,10 +70,11 @@ cmake --build "${LLVM7_BUILD}" -j "${PARALLEL}" --target LLVM
 # `cmake --install`. Symmetric with ci/build-llvm-modern.sh.
 cmake --install "${LLVM7_BUILD}" --strip --component LLVM --prefix "${LLVM7_INSTALL}"
 
-# LLVM 7 names the dylib libLLVM-7svn.so when built from source. The
-# wheel staging expects the canonical libLLVM-7.so name.
+# Setup.py / build-wheel.yml expects the dylib at the canonical
+# libLLVM-7.so name. With NO_VERSIONED_SONAME above the install should
+# emit exactly one libLLVM*.so; rename it to libLLVM-7.so if needed.
 if [[ ! -f "${LLVM7_INSTALL}/lib/libLLVM-7.so" ]]; then
-    LLVM7_SO="$(ls "${LLVM7_INSTALL}"/lib/libLLVM-7*.so | head -1)"
+    LLVM7_SO="$(ls "${LLVM7_INSTALL}"/lib/libLLVM*.so 2>/dev/null | head -1)"
     [[ -n "${LLVM7_SO}" ]] && mv "${LLVM7_SO}" "${LLVM7_INSTALL}/lib/libLLVM-7.so"
 fi
 

--- a/ci/build-llvm7.sh
+++ b/ci/build-llvm7.sh
@@ -65,8 +65,8 @@ cmake --build "${LLVM7_BUILD}" -j "${PARALLEL}" --target LLVM
 # a full byte-identical copy -- 3x-bloating the artifact. The narrow
 # `cp` + manual `strip` avoids that entirely.
 LLVM7_SO="$(ls "${LLVM7_BUILD}"/lib/libLLVM-7*.so | head -1)"
+strip --strip-unneeded "${LLVM7_SO}"
 cp "${LLVM7_SO}" "${LLVM7_INSTALL}/lib/libLLVM-7.so"
-strip --strip-unneeded "${LLVM7_INSTALL}/lib/libLLVM-7.so"
 
 echo "=== LLVM 7 built ==="
 ls -lh "${LLVM7_INSTALL}/lib/libLLVM-7.so"


### PR DESCRIPTION
## Summary

Linux wheels currently ship un-stripped `.so` files — `file(1)` reports `not stripped` for `libMLIRPythonCAPI.so` and friends. The build is Release without `-g` (no DWARF debug info), but the static symbol table (`.symtab` + `.strtab`) is preserved by default at install time. Stripping it saves ~76 MB uncompressed across the LLVM `.so` files in the wheel (~20-25 MB compressed).

Breakdown (`strip --strip-unneeded`):

| File | Before | After | Saved |
|---|---|---|---|
| `libMLIRPythonCAPI.so` | 231.7 MB | 162.2 MB | 69.5 MB |
| `libMLIRPythonSupport-numba_cuda_mlir.so` | 2.6 MB | 1.4 MB | 1.2 MB |
| `libLLVM-7.so` | 37.3 MB | 32.3 MB | 5.0 MB |
| `libMLIRToLLVM70.so` / `libnanobind-*.so` | < 0.1 MB savings each | | |
| **Total** | | | **~76 MB** |

## Changes

- `ci/build-llvm-modern.sh`: pass `--strip` to `cmake --install`.
- `ci/build-llvm7.sh`: this script doesn't `cmake --install` (it copies the LLVM dylib directly out of the build tree), so add an explicit `strip --strip-unneeded` on the copied `.so`.

Windows is not affected: MSVC stores debug info out-of-line in `.pdb` files, so `.dll` files don't carry an embedded symbol table to begin with — the Windows wheel is already at the minimum size.

## Test plan

- [ ] CI build succeeds on Linux.
- [ ] Linux Python tests still pass (stripping `--strip-unneeded` keeps dynamic symbols needed at runtime, so functionality should be unchanged).
- [ ] Verify wheel size shrinks by ~20-25 MB.