### PR TITLE
[CI] Add pull-requests write permissions to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -138,6 +138,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      pull-requests: write  # required by build-docs.yml for doc preview comments
     uses: ./.github/workflows/build-docs.yml
     with:
       host-platform: linux-64


### PR DESCRIPTION
This should fix the release workflow permissions issue.