### PR TITLE
ci: disable sccache preprocessor cache mode

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -56,7 +56,6 @@ jobs:
             | sudo tar -C /usr/local/bin -xz --strip-components=1 --wildcards '*/sccache'
           sccache --version
           echo "SCCACHE_PATH=/usr/local/bin/sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_GHA_USE_PREPROCESSOR_CACHE_MODE=true" >> "$GITHUB_ENV"
 
       # xref: https://github.com/orgs/community/discussions/42856#discussioncomment-7678867
       - name: Adding addtional GHA cache-related env vars
@@ -134,7 +133,6 @@ jobs:
             ACTIONS_RESULTS_URL=${{ env.ACTIONS_RESULTS_URL }}
             ACTIONS_CACHE_URL=${{ env.ACTIONS_CACHE_URL }}
             ACTIONS_CACHE_SERVICE_V2=${{ env.ACTIONS_CACHE_SERVICE_V2 }}
-            SCCACHE_GHA_USE_PREPROCESSOR_CACHE_MODE=${{ env.SCCACHE_GHA_USE_PREPROCESSOR_CACHE_MODE }}
           CIBW_ENVIRONMENT_WINDOWS: >
             MLIR_DIR="$(cygpath -w ${{ env.LLVM_MODERN_INSTALL_DIR }}/lib/cmake/mlir)"
             LIBLLVM7="$(cygpath -w ${{ env.LLVM7_INSTALL_DIR }}/bin/LLVM-C.dll)"


### PR DESCRIPTION
Mirrors NVIDIA/cuda-python#2221 — see NVIDIA/cuda-python#2220 for the full investigation.

Same root cause applies here: pip's per-run `/tmp/pip-build-env-<RANDOM>/...` overlay path leaks into `-I` flags during the cibuildwheel build, so sccache's preprocessor cache key is randomized every run. In cuSIMT the symptom is milder than in cuda-python (CMake doesn't propagate every overlay path through to gcc — last main run had 9 hits / 25 misses) but it's still net overhead.

LLVM 7 / modern LLVM builds (`.github/workflows/build-llvm.yml` + `ci/setup-sccache.sh`) are unaffected: they use the S3 backend with `[cache.s3.preprocessor_cache_mode]` and don't go through cibuildwheel.
