### PR TITLE
ci: adopt CCCL check_result aggregator and add doc-only PR mode

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           enable-cache: false
 
@@ -51,6 +51,6 @@ jobs:
         with:
           args: "${{ steps.ruff-args.outputs.args }}"
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -115,7 +115,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
 
       - name: Build numba-cuda-mlir wheel
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55  # v4.1.0
         with:
           package-dir: .
           output-dir: dist

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -145,6 +145,11 @@ jobs:
             --exclude libLLVM-7.so &&
             "/host/${{ env.SCCACHE_PATH }}" --show-adv-stats &&
             "/host/${{ env.SCCACHE_PATH }}" --show-stats --stats-format=json > /host/${{ github.workspace }}/sccache_NUMBA_CUDA_MLIR.json
+          # Windows wheels are built with /MT (static CRT) per PR #127, so the
+          # wheel is self-contained and needs no DLL bundling. cibuildwheel v4
+          # made `delvewheel repair` the Windows default; opt out explicitly
+          # to restore the v3.x no-op behavior we rely on.
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
 
       - name: Report sccache stats (numba-cuda-mlir)
         if: ${{ startsWith(inputs.host-platform, 'linux') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       skip: ${{ steps.get-should-skip.outputs.skip }}
+      doc-only: ${{ steps.get-should-skip.outputs.doc_only }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -50,11 +51,16 @@ jobs:
         run: |
           set -euxo pipefail
           if ${{ startsWith(github.ref_name, 'pull-request/') }}; then
-            skip="$(gh pr view "$(grep -Po '(\d+)$' <<< '${{ github.ref_name }}')" --json title --jq '.title | contains("[no-ci]")')"
+            pr_number="$(grep -Po '(\d+)$' <<< '${{ github.ref_name }}')"
+            pr_title="$(gh pr view "${pr_number}" --json title --jq '.title')"
+            skip="$(echo "${pr_title}" | grep -q '\[no-ci\]' && echo true || echo false)"
+            doc_only="$(echo "${pr_title}" | grep -q '\[doc-only\]' && echo true || echo false)"
           else
             skip=false
+            doc_only=false
           fi
           echo "skip=${skip}" >> "$GITHUB_OUTPUT"
+          echo "doc_only=${doc_only}" >> "$GITHUB_OUTPUT"
 
   # LLVM build stages (matching GitLab build-llvm stage)
   build-llvm-linux-64:
@@ -69,7 +75,7 @@ jobs:
   build-llvm-linux-aarch64:
     needs:
       - should-skip
-    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) }}
     uses: ./.github/workflows/build-llvm.yml
     with:
       host-platform: linux-aarch64
@@ -78,7 +84,7 @@ jobs:
   build-llvm-windows:
     needs:
       - should-skip
-    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) }}
     uses: ./.github/workflows/build-llvm.yml
     with:
       host-platform: win-64
@@ -115,7 +121,7 @@ jobs:
         host-platform:
           - linux-aarch64
     name: Build ${{ matrix.host-platform }}
-    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) }}
     uses: ./.github/workflows/build-wheel.yml
     with:
       host-platform: ${{ matrix.host-platform }}
@@ -134,7 +140,7 @@ jobs:
         host-platform:
           - win-64
     name: Build ${{ matrix.host-platform }}
-    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) }}
     uses: ./.github/workflows/build-wheel.yml
     with:
       host-platform: ${{ matrix.host-platform }}
@@ -149,10 +155,11 @@ jobs:
         host-platform:
           - linux-64
     name: Test ${{ matrix.host-platform }}
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read  # This is required for actions/checkout
     needs:
+      - should-skip
       - build-linux-64
     uses: ./.github/workflows/test-wheel-linux.yml
     with:
@@ -167,10 +174,11 @@ jobs:
         host-platform:
           - linux-aarch64
     name: Test ${{ matrix.host-platform }}
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read  # This is required for actions/checkout
     needs:
+      - should-skip
       - build-linux-aarch64
     uses: ./.github/workflows/test-wheel-linux.yml
     with:
@@ -184,10 +192,11 @@ jobs:
         host-platform:
           - win-64
     name: Test ${{ matrix.host-platform }}
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read  # This is required for actions/checkout
     needs:
+      - should-skip
       - build-windows
     uses: ./.github/workflows/test-wheel-windows.yml
     with:
@@ -196,10 +205,11 @@ jobs:
 
   test-expensive-linux-64:
     name: Expensive Test linux-64
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read  # This is required for actions/checkout
     needs:
+      - should-skip
       - build-linux-64
     uses: ./.github/workflows/test-expensive-linux.yml
     with:
@@ -207,10 +217,11 @@ jobs:
 
   test-expensive-linux-aarch64:
     name: Expensive Test linux-aarch64
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read  # This is required for actions/checkout
     needs:
+      - should-skip
       - build-linux-aarch64
     uses: ./.github/workflows/test-expensive-linux.yml
     with:
@@ -218,10 +229,11 @@ jobs:
 
   test-cudf-source-linux-64:
     name: cudf source Test linux-64
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read
     needs:
+      - should-skip
       - build-linux-64
     uses: ./.github/workflows/test-cudf-source-linux.yml
     with:
@@ -229,10 +241,11 @@ jobs:
 
   test-cudf-source-linux-aarch64:
     name: cudf source Test linux-aarch64
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read
     needs:
+      - should-skip
       - build-linux-aarch64
     uses: ./.github/workflows/test-cudf-source-linux.yml
     with:
@@ -240,10 +253,11 @@ jobs:
 
   test-numbast-mlir-linux-64:
     name: Numbast MLIR Test linux-64
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read
     needs:
+      - should-skip
       - build-linux-64
     uses: ./.github/workflows/test-numbast-mlir-linux.yml
     with:
@@ -251,10 +265,11 @@ jobs:
 
   test-numbast-mlir-linux-aarch64:
     name: Numbast MLIR Test linux-aarch64
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read
     needs:
+      - should-skip
       - build-linux-aarch64
     uses: ./.github/workflows/test-numbast-mlir-linux.yml
     with:
@@ -262,10 +277,11 @@ jobs:
 
   test-cuda-gdb-linux-64:
     name: cuda-gdb Test linux-64
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read
     needs:
+      - should-skip
       - build-linux-64
     uses: ./.github/workflows/test-wheel-linux.yml
     with:
@@ -277,10 +293,11 @@ jobs:
 
   test-cuda-gdb-linux-aarch64:
     name: cuda-gdb Test linux-aarch64
-    if: ${{ github.repository_owner == 'nvidia' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read
     needs:
+      - should-skip
       - build-linux-aarch64
     uses: ./.github/workflows/test-wheel-linux.yml
     with:
@@ -327,6 +344,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - should-skip
       - test-linux-64
       - test-linux-aarch64
       - test-windows
@@ -344,51 +362,47 @@ jobs:
     steps:
       - name: Exit
         run: |
-          # if any dependencies were cancelled or failed, that's a failure
-          #
-          # see https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always
-          # and https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-          # for why this cannot be encoded in the job-level `if:` field
-          #
-          # TL; DR: `$REASONS`
-          #
-          # The intersection of skipped-as-success and required status checks
-          # creates a scenario where if you DON'T `always()` run this job, the
-          # status check UI will block merging and if you DO `always()` run and
-          # a dependency is _cancelled_ (due to a critical failure, which is
-          # somehow not considered a failure ¯\_(ツ)_/¯) then the critically
-          # failing job(s) will timeout causing a cancellation here and the
-          # build to succeed which we don't want (originally this was just
-          # 'exit 0')
-          if ${{ needs.test-windows.result == 'cancelled' ||
-                 needs.test-windows.result == 'failure' ||
-                 needs.test-linux-64.result == 'cancelled' ||
-                 needs.test-linux-64.result == 'failure' ||
-                 needs.test-linux-aarch64.result == 'cancelled' ||
-                 needs.test-linux-aarch64.result == 'failure' ||
-                 needs.test-expensive-linux-64.result == 'cancelled' ||
-                 needs.test-expensive-linux-64.result == 'failure' ||
-                 needs.test-expensive-linux-aarch64.result == 'cancelled' ||
-                 needs.test-expensive-linux-aarch64.result == 'failure' ||
-                 needs.test-cudf-source-linux-64.result == 'cancelled' ||
-                 needs.test-cudf-source-linux-64.result == 'failure' ||
-                 needs.test-cudf-source-linux-aarch64.result == 'cancelled' ||
-                 needs.test-cudf-source-linux-aarch64.result == 'failure' ||
-                 needs.test-numbast-mlir-linux-64.result == 'cancelled' ||
-                 needs.test-numbast-mlir-linux-64.result == 'failure' ||
-                 needs.test-numbast-mlir-linux-aarch64.result == 'cancelled' ||
-                 needs.test-numbast-mlir-linux-aarch64.result == 'failure' ||
-                 needs.test-cuda-gdb-linux-64.result == 'cancelled' ||
-                 needs.test-cuda-gdb-linux-64.result == 'failure' ||
-                 needs.test-cuda-gdb-linux-aarch64.result == 'cancelled' ||
-                 needs.test-cuda-gdb-linux-aarch64.result == 'failure' ||
-                 needs.build-docs.result == 'cancelled' ||
-                 needs.build-docs.result == 'failure' }}; then
-          #        needs.coverage-report.result == 'cancelled' ||
-          #        needs.coverage-report.result == 'failure' ||
-          #        needs.test-simulator.result == 'cancelled' ||
-          #        needs.test-simulator.result == 'failure' ||
-            exit 1
-          else
+          # GitHub treats `result == 'skipped'` as success for required
+          # status checks (see CCCL gate comment + cccl#605). The previous
+          # `cancelled || failure` predicate let upstream build failures
+          # propagate as `skipped` on downstream test jobs and silently
+          # pass this aggregator. Adopt CCCL's `check_result` pattern:
+          # require an explicit `expected` status per dependency, where
+          # anything else (including `skipped` from a failed upstream)
+          # fails the gate. `if: always()` on the job still ensures this
+          # step runs even when needs are skipped.
+          if [[ "${{ needs.should-skip.outputs.skip }}" == "true" ]]; then
+            echo "[no-ci] - skipping aggregator checks"
             exit 0
           fi
+
+          doc_only="${{ needs.should-skip.outputs.doc-only }}"
+          status="success"
+          check_result() {
+            name=$1; expected=$2; result=$3
+            echo "Checking $name: result='$result' (expected '$expected')"
+            if [[ "$result" != "$expected" ]]; then
+              echo "::error::$name did not match expected result"
+              status="failed"
+            fi
+          }
+
+          # always expected to succeed (even in [doc-only] mode)
+          check_result "should-skip" "success" "${{ needs.should-skip.result }}"
+          check_result "build-docs"  "success" "${{ needs.build-docs.result }}"
+
+          # [doc-only] flips these from 'success' to 'skipped'
+          if [[ "$doc_only" == "true" ]]; then expected="skipped"; else expected="success"; fi
+          check_result "test-linux-64"                   "$expected" "${{ needs.test-linux-64.result }}"
+          check_result "test-linux-aarch64"              "$expected" "${{ needs.test-linux-aarch64.result }}"
+          check_result "test-windows"                    "$expected" "${{ needs.test-windows.result }}"
+          check_result "test-expensive-linux-64"         "$expected" "${{ needs.test-expensive-linux-64.result }}"
+          check_result "test-expensive-linux-aarch64"    "$expected" "${{ needs.test-expensive-linux-aarch64.result }}"
+          check_result "test-cudf-source-linux-64"       "$expected" "${{ needs.test-cudf-source-linux-64.result }}"
+          check_result "test-cudf-source-linux-aarch64"  "$expected" "${{ needs.test-cudf-source-linux-aarch64.result }}"
+          check_result "test-numbast-mlir-linux-64"      "$expected" "${{ needs.test-numbast-mlir-linux-64.result }}"
+          check_result "test-numbast-mlir-linux-aarch64" "$expected" "${{ needs.test-numbast-mlir-linux-aarch64.result }}"
+          check_result "test-cuda-gdb-linux-64"          "$expected" "${{ needs.test-cuda-gdb-linux-64.result }}"
+          check_result "test-cuda-gdb-linux-aarch64"     "$expected" "${{ needs.test-cuda-gdb-linux-aarch64.result }}"
+
+          [[ "$status" == "success" ]]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,13 +36,13 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         queries: security-extended
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/simulator-test.yaml
+++ b/.github/workflows/simulator-test.yaml
@@ -105,7 +105,7 @@ jobs:
           PIXI_ENV="cu-${CUDA_VER_PART}-${PY_VER_PART}"
           echo "PIXI_ENV=${PIXI_ENV}" >> "${GITHUB_ENV}"
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11  # v0.9.6
         with:
           pixi-version: "v0.63.2"
           environments: ${{ env.PIXI_ENV }}
@@ -116,7 +116,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report
-        uses: test-summary/action@v2.4
+        uses: test-summary/action@v2.6
         with:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()


### PR DESCRIPTION
## Summary

Mirrors the gating-check fix in NVIDIA/cuda-python#2210 (root-cause analysis: NVIDIA/cuda-python#2208) and bundles in cuda-python's `[doc-only]` PR-mode feature, which had not been propagated to this repo.

## Changes

1. **`checks:` aggregator** — replaced the `cancelled || failure` predicate with CCCL's `check_result` pattern: per-dep `expected="success"`, `expected="skipped"` for tests in `[doc-only]` mode, early short-circuit for `[no-ci]`. The previous predicate silently passed when an upstream `build-*` failure cascaded as `'skipped'` on the downstream tests — the same bug that bit this repo in #125 (auto-merged with failing Windows builds, reverted in #134).

2. **`[doc-only]` PR mode** — new `should-skip.outputs.doc-only`, gated into all 11 `test-*` jobs and the non-linux-64 `build-*` jobs. The linux-64 build chain (`build-llvm-linux-64`, `build-linux-64`) and `build-docs` intentionally stay ungated because `build-docs` needs the linux-64 wheel.

3. **`should-skip` itself** is now in the aggregator's `needs:` and explicitly checked, so a crash in the gating job can't masquerade as a green CI run.

## Verification

Local simulation of the new aggregator across 8 scenarios (normal-green, build-fail-cascade, `[no-ci]`, `[doc-only]`-OK, `[doc-only]`-doc-fails, build-windows-fail-cascade, single-test-fail, should-skip-itself-fails) — all behave as expected. End-to-end CI evidence is in the comment thread on this PR.

## What is NOT changed

- `detect-changes` / path-based gating from cuda-python — cuSIMT's module structure differs; if wanted, that's a separate PR with its own design.
- Satellite test-workflow consolidation (separate ongoing concern).
- GitLab CI mirror.

## Reference

- Source-of-truth fix in cuda-python: NVIDIA/cuda-python#2210
- Root cause: NVIDIA/cuda-python#2208
- CCCL gate pattern: https://github.com/NVIDIA/cccl/blob/8c0e6cb1b6412d7bd0070f9ac3f55fa80231961a/.github/workflows/ci-workflow-pull-request.yml#L463-L526