### PR TITLE
Harden CPython free-threading support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(ALLOW_WARNINGS "Don't treat warnings as errors" OFF)
+option(
+    NUMBA_CUDA_MLIR_PY_GIL_DISABLED
+    "Build Python extension modules for a free-threaded CPython runtime"
+    OFF
+)
 if (NOT ALLOW_WARNINGS)
     if(MSVC)
         add_compile_options(/WX)

--- a/cext/CMakeLists.txt
+++ b/cext/CMakeLists.txt
@@ -23,6 +23,13 @@ function(add_numba_cuda_mlir_python_module target)
         ${NC_EXT_INCLUDE_DIRS}
     )
 
+    # The official Windows free-threaded Python installer does not expose
+    # Py_GIL_DISABLED through its headers. setup.py derives this option from
+    # sysconfig so the extensions compile against the correct CPython ABI.
+    if(WIN32 AND NUMBA_CUDA_MLIR_PY_GIL_DISABLED)
+        target_compile_definitions(${target} PRIVATE Py_GIL_DISABLED=1)
+    endif()
+
     if(WIN32)
         target_link_libraries(${target} PRIVATE Python::Module)
     endif()

--- a/cext/helperlib/_helpermod.cpp
+++ b/cext/helperlib/_helpermod.cpp
@@ -66,22 +66,48 @@ PyMODINIT_FUNC PyInit__helperlib(void) {
 
     if (m == NULL)
         return NULL;
+#if !defined(Py_LIMITED_API) && defined(Py_GIL_DISABLED)
+    if (PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+#endif
 
-    PyModule_AddObject(m, "c_helpers", build_c_helpers_dict());
-    PyModule_AddIntConstant(m, "long_min", LONG_MIN);
-    PyModule_AddIntConstant(m, "long_max", LONG_MAX);
-    PyModule_AddIntConstant(m, "py_buffer_size", sizeof(Py_buffer));
-    PyModule_AddIntConstant(m, "py_gil_state_size", sizeof(PyGILState_STATE));
-    PyModule_AddIntConstant(m, "py_unicode_1byte_kind", PyUnicode_1BYTE_KIND);
-    PyModule_AddIntConstant(m, "py_unicode_2byte_kind", PyUnicode_2BYTE_KIND);
-    PyModule_AddIntConstant(m, "py_unicode_4byte_kind", PyUnicode_4BYTE_KIND);
+    PyObject *c_helpers = build_c_helpers_dict();
+    if (c_helpers == NULL)
+        goto error;
+    if (PyModule_AddObjectRef(m, "c_helpers", c_helpers)) {
+        Py_DECREF(c_helpers);
+        goto error;
+    }
+    Py_DECREF(c_helpers);
+
+    if (PyModule_AddIntConstant(m, "long_min", LONG_MIN))
+        goto error;
+    if (PyModule_AddIntConstant(m, "long_max", LONG_MAX))
+        goto error;
+    if (PyModule_AddIntConstant(m, "py_buffer_size", sizeof(Py_buffer)))
+        goto error;
+    if (PyModule_AddIntConstant(m, "py_gil_state_size", sizeof(PyGILState_STATE)))
+        goto error;
+    if (PyModule_AddIntConstant(m, "py_unicode_1byte_kind", PyUnicode_1BYTE_KIND))
+        goto error;
+    if (PyModule_AddIntConstant(m, "py_unicode_2byte_kind", PyUnicode_2BYTE_KIND))
+        goto error;
+    if (PyModule_AddIntConstant(m, "py_unicode_4byte_kind", PyUnicode_4BYTE_KIND))
+        goto error;
 #if (PY_MAJOR_VERSION == 3)
 #if ((PY_MINOR_VERSION == 10) || (PY_MINOR_VERSION == 11))
-    PyModule_AddIntConstant(m, "py_unicode_wchar_kind", PyUnicode_WCHAR_KIND);
+    if (PyModule_AddIntConstant(m, "py_unicode_wchar_kind", PyUnicode_WCHAR_KIND))
+        goto error;
 #endif
 #endif
 
     return m;
+
+error:
+    Py_DECREF(m);
+    return NULL;
 }
 
 } // extern "C"

--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 #include <algorithm>
@@ -37,6 +38,7 @@ PyObject* g_shape_pyunicode;
 PyObject* g_data_pyunicode;
 PyObject* g_strides_pyunicode;
 PyObject* g___dlpack___pyunicode;
+PyObject* g_int64_pyunicode;
 
 PyTypeObject* g_torch_Tensor_type;
 PyTypeObject* g_torch_cuda_Stream_type;
@@ -405,10 +407,20 @@ struct LaunchHelper {
     }
 };
 
-LaunchHelper* g_helper_freelist;  // protected by the GIL
+LaunchHelper* g_helper_freelist;
+
+#ifdef Py_GIL_DISABLED
+std::mutex& helper_freelist_mutex() {
+    static auto* mutex = new std::mutex;
+    return *mutex;
+}
+#endif
 
 struct LaunchHelperDeleter {
     void operator() (LaunchHelper* helper) const {
+#ifdef Py_GIL_DISABLED
+        std::lock_guard<std::mutex> guard(helper_freelist_mutex());
+#endif
         helper->next_free = g_helper_freelist;
         g_helper_freelist = helper;
     }
@@ -418,6 +430,9 @@ using LaunchHelperPtr = std::unique_ptr<LaunchHelper, LaunchHelperDeleter>;
 
 
 LaunchHelperPtr launch_helper_get() {
+#ifdef Py_GIL_DISABLED
+    std::lock_guard<std::mutex> guard(helper_freelist_mutex());
+#endif
     if (g_helper_freelist) {
         LaunchHelper* ret = g_helper_freelist;
         g_helper_freelist = ret->next_free;
@@ -989,9 +1004,9 @@ Status extract_dlpack(PyObject* pyobj, LaunchHelper& helper) {
 
 inline Status extract_np_datetime(PyObject* pyobj, bool is_constant, LaunchHelper& helper) {
     // numpy.datetime64/timedelta64 are stored as int64 internally.
-    // Call arg.view('int64') to get the numpy.int64 scalar, then extract.
-    static PyObject* view_arg = PyUnicode_InternFromString("int64");
-    PyPtr int_view = steal(PyObject_CallMethod(pyobj, "view", "O", view_arg));
+    // Call view() with the cached "int64" PyUnicode to get the numpy.int64
+    // scalar, then extract.
+    PyPtr int_view = steal(PyObject_CallMethod(pyobj, "view", "O", g_int64_pyunicode));
     if (!int_view) return ErrorRaised;
     int64_t value = pylong_as<int64_t>(int_view.get());
     if (PyErr_Occurred()) return ErrorRaised;
@@ -1445,6 +1460,7 @@ struct KernelDispatcher {
     PyPtr compile_func;
     PyPtr ensure_context_func;
     std::vector<bool> constant_arg_flags;
+    std::recursive_mutex launch_mutex;
     ProfileMap arg_profiles;
     FamilyMap kernel_families;
 };
@@ -1751,6 +1767,8 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
         if (!current_stream.is_ok()) return ErrorRaised;
         launch_stream = *current_stream;
     }
+
+    std::lock_guard<std::recursive_mutex> launch_guard(dispatcher.launch_mutex);
 
     PythonArgProfile* profile = dispatcher.arg_profiles.find(helper->pyarg_types);
     if (!profile) {
@@ -2395,6 +2413,7 @@ Status kernel_init(PyObject* m) {
     INIT_STRING_CONSTANT(data);
     INIT_STRING_CONSTANT(strides);
     INIT_STRING_CONSTANT(__dlpack__);
+    INIT_STRING_CONSTANT(int64);
 
     try_get_torch_globals();
     try_get_cupy_globals();

--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -1460,10 +1460,6 @@ struct KernelDispatcher {
     PyPtr compile_func;
     PyPtr ensure_context_func;
     std::vector<bool> constant_arg_flags;
-#ifdef Py_GIL_DISABLED
-    std::unique_ptr<std::recursive_mutex> launch_mutex =
-        std::make_unique<std::recursive_mutex>();
-#endif
     ProfileMap arg_profiles;
     FamilyMap kernel_families;
 };
@@ -1759,10 +1755,6 @@ bool try_clarify_launch_out_of_resources_error(CUkernel kernel, const Grid& bloc
 Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional<Grid> cluster,
               std::optional<CUstream> stream, int sharedmem,
               PyObject* const* pyargs, Py_ssize_t num_pyargs) {
-#ifdef Py_GIL_DISABLED
-    std::lock_guard<std::recursive_mutex> launch_guard(*dispatcher.launch_mutex);
-#endif
-
     LaunchHelperPtr helper = launch_helper_get();
     get_pyarg_types(pyargs, num_pyargs, helper->pyarg_types);
 

--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -1460,7 +1460,10 @@ struct KernelDispatcher {
     PyPtr compile_func;
     PyPtr ensure_context_func;
     std::vector<bool> constant_arg_flags;
-    std::recursive_mutex launch_mutex;
+#ifdef Py_GIL_DISABLED
+    std::unique_ptr<std::recursive_mutex> launch_mutex =
+        std::make_unique<std::recursive_mutex>();
+#endif
     ProfileMap arg_profiles;
     FamilyMap kernel_families;
 };
@@ -1756,6 +1759,10 @@ bool try_clarify_launch_out_of_resources_error(CUkernel kernel, const Grid& bloc
 Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional<Grid> cluster,
               std::optional<CUstream> stream, int sharedmem,
               PyObject* const* pyargs, Py_ssize_t num_pyargs) {
+#ifdef Py_GIL_DISABLED
+    std::lock_guard<std::recursive_mutex> launch_guard(*dispatcher.launch_mutex);
+#endif
+
     LaunchHelperPtr helper = launch_helper_get();
     get_pyarg_types(pyargs, num_pyargs, helper->pyarg_types);
 
@@ -1767,8 +1774,6 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
         if (!current_stream.is_ok()) return ErrorRaised;
         launch_stream = *current_stream;
     }
-
-    std::lock_guard<std::recursive_mutex> launch_guard(dispatcher.launch_mutex);
 
     PythonArgProfile* profile = dispatcher.arg_profiles.find(helper->pyarg_types);
     if (!profile) {

--- a/cext/launcher/llvm_downgrade.cpp
+++ b/cext/launcher/llvm_downgrade.cpp
@@ -10,6 +10,7 @@
 #include <dlfcn.h>
 #endif
 #include <cstring>
+#include <mutex>
 #include <string_view>
 #include <vector>
 
@@ -182,6 +183,7 @@ LLVM_CAPI_OPTIONAL(DECLARE_FN)
 #undef DECLARE_FN
 
 static void* g_mlir_lib_handle;
+static std::mutex g_mlir_capi_mutex;
 
 static void* load_symbol(void* handle, const char* name) {
 #ifdef _WIN32
@@ -192,39 +194,68 @@ static void* load_symbol(void* handle, const char* name) {
 #endif
 }
 
+static void close_library_handle(void* handle) {
+    if (!handle) return;
+#ifdef _WIN32
+    FreeLibrary(reinterpret_cast<HMODULE>(handle));
+#else
+    dlclose(handle);
+#endif
+}
+
 Status load_mlir_capi(const char* lib_path) {
+    std::lock_guard<std::mutex> guard(g_mlir_capi_mutex);
+
     if (g_mlir_lib_handle)
         return OK;
 
+    void* handle = nullptr;
 #ifdef _WIN32
-    g_mlir_lib_handle = LoadLibraryA(lib_path);
-    if (!g_mlir_lib_handle)
+    handle = LoadLibraryA(lib_path);
+    if (!handle)
         return raise(PyExc_RuntimeError, "Failed to load %s: error %lu",
                      lib_path, GetLastError());
 #else
     // RTLD_LOCAL: keep bundled LLVM/MLIR symbols out of the process-global
     // namespace. See #170.
-    g_mlir_lib_handle = dlopen(lib_path, RTLD_NOW | RTLD_LOCAL);
-    if (!g_mlir_lib_handle)
+    handle = dlopen(lib_path, RTLD_NOW | RTLD_LOCAL);
+    if (!handle)
         return raise(PyExc_RuntimeError, "Failed to load %s: %s",
                      lib_path, dlerror());
 #endif
 
+#define DECLARE_LOCAL(ret, name, args) \
+    name##_fn local_##name = nullptr;
+
+    LLVM_CAPI_REQUIRED(DECLARE_LOCAL)
+    LLVM_CAPI_OPTIONAL(DECLARE_LOCAL)
+#undef DECLARE_LOCAL
+
 #define LOAD_REQUIRED(ret, name, args) \
-    g_##name = reinterpret_cast<name##_fn>(load_symbol(g_mlir_lib_handle, #name)); \
-    if (!g_##name) \
+    local_##name = reinterpret_cast<name##_fn>(load_symbol(handle, #name)); \
+    if (!local_##name) { \
+        close_library_handle(handle); \
         return raise(PyExc_RuntimeError, \
-                     "Symbol '%s' not found in %s", #name, lib_path);
+                     "Symbol '%s' not found in %s", #name, lib_path); \
+    }
 
     LLVM_CAPI_REQUIRED(LOAD_REQUIRED)
 #undef LOAD_REQUIRED
 
 #define LOAD_OPTIONAL(ret, name, args) \
-    g_##name = reinterpret_cast<name##_fn>(load_symbol(g_mlir_lib_handle, #name));
+    local_##name = reinterpret_cast<name##_fn>(load_symbol(handle, #name));
 
     LLVM_CAPI_OPTIONAL(LOAD_OPTIONAL)
 #undef LOAD_OPTIONAL
 
+#define PUBLISH_SYMBOL(ret, name, args) \
+    g_##name = local_##name;
+
+    LLVM_CAPI_REQUIRED(PUBLISH_SYMBOL)
+    LLVM_CAPI_OPTIONAL(PUBLISH_SYMBOL)
+#undef PUBLISH_SYMBOL
+
+    g_mlir_lib_handle = handle;
     return OK;
 }
 

--- a/cext/launcher/llvm_downgrade.cpp
+++ b/cext/launcher/llvm_downgrade.cpp
@@ -24,6 +24,7 @@ struct NvvmIrVersion {
 };
 
 static NvvmIrVersion g_nvvm_ir_version;
+static std::mutex g_nvvm_ir_version_mutex;
 
 // ---------------------------------------------------------------------------
 // LLVM C API types and constants (obtained from llvm-c/Core.h).
@@ -185,6 +186,20 @@ LLVM_CAPI_OPTIONAL(DECLARE_FN)
 static void* g_mlir_lib_handle;
 static std::mutex g_mlir_capi_mutex;
 
+static std::unique_lock<std::mutex> lock_from_python(std::mutex& mutex) {
+    std::unique_lock<std::mutex> guard(mutex, std::defer_lock);
+#ifdef Py_GIL_DISABLED
+    if (!guard.try_lock()) {
+        Py_BEGIN_ALLOW_THREADS
+        guard.lock();
+        Py_END_ALLOW_THREADS
+    }
+#else
+    guard.lock();
+#endif
+    return guard;
+}
+
 static void* load_symbol(void* handle, const char* name) {
 #ifdef _WIN32
     return reinterpret_cast<void*>(
@@ -204,16 +219,7 @@ static void close_library_handle(void* handle) {
 }
 
 Status load_mlir_capi(const char* lib_path) {
-    std::unique_lock<std::mutex> guard(g_mlir_capi_mutex, std::defer_lock);
-#ifdef Py_GIL_DISABLED
-    if (!guard.try_lock()) {
-        Py_BEGIN_ALLOW_THREADS
-        guard.lock();
-        Py_END_ALLOW_THREADS
-    }
-#else
-    guard.lock();
-#endif
+    auto guard = lock_from_python(g_mlir_capi_mutex);
 
     if (g_mlir_lib_handle)
         return OK;
@@ -812,10 +818,13 @@ PyObject* py_downgrade_for_libnvvm(PyObject* /*self*/, PyObject* args) {
     LLVMModuleRef llvm_mod = reinterpret_cast<LLVMModuleRef>(mod_ptr_int);
     LLVMContextRef llvm_ctx = reinterpret_cast<LLVMContextRef>(ctx_ptr_int);
 
-    g_nvvm_ir_version = {
-        nvvm_ir_major, nvvm_ir_minor, nvvm_debug_major, nvvm_debug_minor
-    };
-    adapt_for_libnvvm(llvm_mod, llvm_ctx);
+    {
+        auto guard = lock_from_python(g_nvvm_ir_version_mutex);
+        g_nvvm_ir_version = {
+            nvvm_ir_major, nvvm_ir_minor, nvvm_debug_major, nvvm_debug_minor
+        };
+        adapt_for_libnvvm(llvm_mod, llvm_ctx);
+    }
     downgrade_for_libnvvm(llvm_mod, llvm_ctx, ctk_major, ctk_minor);
 
     if (PyErr_Occurred()) {

--- a/cext/launcher/llvm_downgrade.cpp
+++ b/cext/launcher/llvm_downgrade.cpp
@@ -204,7 +204,16 @@ static void close_library_handle(void* handle) {
 }
 
 Status load_mlir_capi(const char* lib_path) {
-    std::lock_guard<std::mutex> guard(g_mlir_capi_mutex);
+    std::unique_lock<std::mutex> guard(g_mlir_capi_mutex, std::defer_lock);
+#ifdef Py_GIL_DISABLED
+    if (!guard.try_lock()) {
+        Py_BEGIN_ALLOW_THREADS
+        guard.lock();
+        Py_END_ALLOW_THREADS
+    }
+#else
+    guard.lock();
+#endif
 
     if (g_mlir_lib_handle)
         return OK;

--- a/cext/launcher/module.cpp
+++ b/cext/launcher/module.cpp
@@ -31,6 +31,10 @@ PyMODINIT_FUNC PyInit__cext() {
 
     PyPtr m = steal(PyModule_Create(&module_def));
     if (!m) return nullptr;
+#if !defined(Py_LIMITED_API) && defined(Py_GIL_DISABLED)
+    if (PyUnstable_Module_SetGIL(m.get(), Py_MOD_GIL_NOT_USED) < 0)
+        return nullptr;
+#endif
 
     if (!kernel_init(m.get()))
         return nullptr;

--- a/cext/launcher/py.cpp
+++ b/cext/launcher/py.cpp
@@ -9,17 +9,11 @@ void log_python_error(const char* filename, int line, const char* level, SavedEx
                       const char* fmt, ...) {
     ErrorGuard guard;
 
-    static PyObject* kwnames = NULL;
-    if (!kwnames) {
-        kwnames = Py_BuildValue("(s)", "exc_info");
-        if (!kwnames) return;
-    }
+    PyPtr kwnames = steal(Py_BuildValue("(s)", "exc_info"));
+    if (!kwnames) return;
 
-    static PyObject* logging = NULL;
-    if (!logging) {
-        logging = try_import("logging").release();
-        if (!logging) return;
-    }
+    PyPtr logging = try_import("logging");
+    if (!logging) return;
 
     va_list a;
     va_start(a, fmt);
@@ -41,7 +35,7 @@ void log_python_error(const char* filename, int line, const char* level, SavedEx
                      Py_XNewRef(exc.traceback.get()));
 
     PyObject* args[2] = {formatted_message.get(), Py_True};
-    PyObject* res = PyObject_Vectorcall(func.get(), args, 1, kwnames);
+    PyObject* res = PyObject_Vectorcall(func.get(), args, 1, kwnames.get());
     Py_XDECREF(res);
 
     PyErr_SetExcInfo(old_excinfo_type, old_excinfo_value, old_excinfo_tb);

--- a/cext/mlir-modern/CMakeLists.txt
+++ b/cext/mlir-modern/CMakeLists.txt
@@ -6,6 +6,7 @@ project(MLIRModernToNVVM LANGUAGES C CXX)
 
 find_package(LLVM REQUIRED CONFIG)
 find_package(MLIR REQUIRED CONFIG)
+find_package(Threads REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}" "${MLIR_CMAKE_DIR}")
 include(AddLLVM)
@@ -44,6 +45,7 @@ target_link_libraries(MLIRModernToNVVM
     LLVMCore
     LLVMBitWriter
     LLVMSupport
+    Threads::Threads
 )
 
 if(MSVC)
@@ -60,7 +62,11 @@ set_target_properties(MLIRModernToNVVM PROPERTIES
 add_executable(MLIRModernToNVVMSmoke
   ModernBridgeSmoke.cpp
 )
-target_link_libraries(MLIRModernToNVVMSmoke PRIVATE MLIRModernToNVVM)
+target_link_libraries(MLIRModernToNVVMSmoke
+  PRIVATE
+    MLIRModernToNVVM
+    Threads::Threads
+)
 set_target_properties(MLIRModernToNVVMSmoke PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
 )

--- a/cext/mlir-modern/ModernBridge.cpp
+++ b/cext/mlir-modern/ModernBridge.cpp
@@ -35,6 +35,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -48,6 +49,7 @@ struct NvvmIrVersion {
 };
 
 static NvvmIrVersion g_nvvm_ir_version;
+static std::mutex g_nvvm_ir_version_mutex;
 
 static void set_error(char **error_out, const std::string &message) {
     if (!error_out)
@@ -570,10 +572,6 @@ mlir_modern_to_nvvm_translate_for_libnvvm(
     if (error_out)
         *error_out = nullptr;
 
-    g_nvvm_ir_version = {
-        nvvm_ir_major, nvvm_ir_minor, nvvm_debug_major, nvvm_debug_minor
-    };
-
     if (!mlir_text || !out || !out_len) {
         set_error(error_out, "invalid null argument");
         return 1;
@@ -624,7 +622,13 @@ mlir_modern_to_nvvm_translate_for_libnvvm(
     if (dump_llvmir && !dump_module_to_stderr(*llvm_module, error_out))
         return 1;
 
-    adapt_for_libnvvm(*llvm_module, llvm_context);
+    {
+        std::lock_guard<std::mutex> guard(g_nvvm_ir_version_mutex);
+        g_nvvm_ir_version = {
+            nvvm_ir_major, nvvm_ir_minor, nvvm_debug_major, nvvm_debug_minor
+        };
+        adapt_for_libnvvm(*llvm_module, llvm_context);
+    }
     downgrade_for_libnvvm(*llvm_module, llvm_context, ctk_major, ctk_minor);
 
     bool ok = emit_text_ir

--- a/cext/mlir-modern/ModernBridgeSmoke.cpp
+++ b/cext/mlir-modern/ModernBridgeSmoke.cpp
@@ -4,9 +4,12 @@
  */
 #include "ModernBridge.h"
 
+#include <atomic>
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <thread>
+#include <vector>
 
 static int run_case(const char *name, const char *mlir, int ctk_major = 13,
                     int ctk_minor = 0, bool emit_text_ir = false) {
@@ -45,10 +48,71 @@ static int run_case(const char *name, const char *mlir, int ctk_major = 13,
     return 0;
 }
 
-int main() {
-    int failures = 0;
+static int run_version_case(const char *mlir, int ir_major, int ir_minor,
+                            int debug_major, int debug_minor) {
+    char *out = nullptr;
+    size_t out_len = 0;
+    char *error = nullptr;
+    int rc = mlir_modern_to_nvvm_translate_for_libnvvm(
+        mlir, std::strlen(mlir), 13, 0, ir_major, ir_minor, debug_major,
+        debug_minor, 0, 1, &out, &out_len, &error);
+    if (rc != 0) {
+        std::fprintf(stderr, "concurrent bridge case failed: %s\n",
+                     error ? error : "unknown error");
+        mlir_modern_to_nvvm_free(out);
+        mlir_modern_to_nvvm_free(error);
+        return 1;
+    }
 
-    static const char simple_kernel[] = R"MLIR(
+    std::string text(out ? out : "", out_len);
+    char expected[128];
+    std::snprintf(expected, sizeof(expected),
+                  "!{i32 %d, i32 %d, i32 %d, i32 %d}", ir_major,
+                  ir_minor, debug_major, debug_minor);
+    bool found = text.find(expected) != std::string::npos;
+    if (!found)
+        std::fprintf(stderr,
+                     "concurrent bridge case expected NVVM version %s\n",
+                     expected);
+    mlir_modern_to_nvvm_free(out);
+    return found ? 0 : 1;
+}
+
+static int run_concurrent_version_cases(const char *mlir) {
+    constexpr int num_threads = 8;
+    constexpr int rounds = 4;
+    std::atomic<int> ready{0};
+    std::atomic<int> failures{0};
+    std::atomic<bool> start{false};
+    std::vector<std::thread> workers;
+    workers.reserve(num_threads);
+
+    for (int worker = 0; worker < num_threads; ++worker) {
+        workers.emplace_back([&, worker] {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire))
+                std::this_thread::yield();
+
+            for (int round = 0; round < rounds; ++round) {
+                int version = 1000 + worker * rounds + round;
+                failures.fetch_add(
+                    run_version_case(mlir, version, version + 100,
+                                     version + 200, version + 300),
+                    std::memory_order_relaxed);
+            }
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) != num_threads)
+        std::this_thread::yield();
+    start.store(true, std::memory_order_release);
+
+    for (auto &worker : workers)
+        worker.join();
+    return failures.load(std::memory_order_relaxed) == 0 ? 0 : 1;
+}
+
+static const char simple_kernel[] = R"MLIR(
 gpu.module @kernels attributes {
   llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128",
   llvm.target_triple = "nvptx64-nvidia-cuda"
@@ -58,8 +122,13 @@ gpu.module @kernels attributes {
   }
 }
 )MLIR";
+
+int main() {
+    int failures = 0;
+
     failures += run_case("simple-kernel", simple_kernel);
     failures += run_case("simple-kernel-text", simple_kernel, 13, 0, true);
+    failures += run_concurrent_version_cases(simple_kernel);
 
     static const char nvvm_intrinsics[] = R"MLIR(
 gpu.module @kernels attributes {

--- a/cext/mviewbuf/mviewbuf.cpp
+++ b/cext/mviewbuf/mviewbuf.cpp
@@ -165,6 +165,7 @@ memoryview_get_extents_info(PyObject *self, PyObject *args)
     PyObject *shape = NULL, *strides = NULL;
     Py_ssize_t itemsize = 0;
     int ndim = 0;
+    size_t ndim_size = 0;
     PyObject* res = NULL;
 
     if (!PyArg_ParseTuple(args, "OOin", &shape, &strides, &ndim, &itemsize))
@@ -176,29 +177,49 @@ memoryview_get_extents_info(PyObject *self, PyObject *args)
     }
 
     if (itemsize <= 0) {
-        PyErr_SetString(PyExc_ValueError, "ndim <= 0");
+        PyErr_SetString(PyExc_ValueError, "itemsize <= 0");
         goto cleanup;
     }
 
-    shape_ary = (Py_ssize_t*)malloc(sizeof(Py_ssize_t) * ndim + 1);
-    strides_ary = (Py_ssize_t*)malloc(sizeof(Py_ssize_t) * ndim + 1);
-
     shape_tuple = PySequence_Fast(shape, "shape is not a sequence");
     if (!shape_tuple) goto cleanup;
+    if (PySequence_Fast_GET_SIZE(shape_tuple) != ndim) {
+        PyErr_SetString(PyExc_ValueError, "shape length does not match ndim");
+        goto cleanup;
+    }
+
+    strides_tuple = PySequence_Fast(strides, "strides is not a sequence");
+    if (!strides_tuple) goto cleanup;
+    if (PySequence_Fast_GET_SIZE(strides_tuple) != ndim) {
+        PyErr_SetString(PyExc_ValueError, "strides length does not match ndim");
+        goto cleanup;
+    }
+
+    if (ndim == 0) {
+        res = get_extents(NULL, NULL, ndim, itemsize, 0);
+        goto cleanup;
+    }
+
+    ndim_size = (size_t)ndim;
+    shape_ary = (Py_ssize_t*)malloc(sizeof(Py_ssize_t) * ndim_size);
+    strides_ary = (Py_ssize_t*)malloc(sizeof(Py_ssize_t) * ndim_size);
+    if (!shape_ary || !strides_ary) {
+        PyErr_NoMemory();
+        goto cleanup;
+    }
 
     for (i = 0; i < ndim; ++i) {
         shape_ary[i] = PyNumber_AsSsize_t(
                            PySequence_Fast_GET_ITEM(shape_tuple, i),
                            PyExc_OverflowError);
+        if (shape_ary[i] == -1 && PyErr_Occurred()) goto cleanup;
     }
-
-    strides_tuple = PySequence_Fast(strides, "strides is not a sequence");
-    if (!strides_tuple) goto cleanup;
 
     for (i = 0; i < ndim; ++i) {
         strides_ary[i] = PyNumber_AsSsize_t(
                            PySequence_Fast_GET_ITEM(strides_tuple, i),
                            PyExc_OverflowError);
+        if (strides_ary[i] == -1 && PyErr_Occurred()) goto cleanup;
     }
 
     res = get_extents(shape_ary, strides_ary, ndim, itemsize, 0);

--- a/cext/mviewbuf/mviewbuf.cpp
+++ b/cext/mviewbuf/mviewbuf.cpp
@@ -371,14 +371,23 @@ PyMODINIT_FUNC PyInit__mviewbuf(void) {
     PyObject *module = PyModule_Create(&moduledef);
     if (module == NULL)
         return NULL;
+#if !defined(Py_LIMITED_API) && defined(Py_GIL_DISABLED)
+    if (PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED) < 0) {
+        Py_DECREF(module);
+        return NULL;
+    }
+#endif
 
     MemAllocType.tp_new = PyType_GenericNew;
     if (PyType_Ready(&MemAllocType) < 0){
+        Py_DECREF(module);
         return NULL;
     }
 
-    Py_INCREF(&MemAllocType);
-    PyModule_AddObject(module, "MemAlloc", (PyObject*)&MemAllocType);
+    if (PyModule_AddObjectRef(module, "MemAlloc", (PyObject*)&MemAllocType) < 0) {
+        Py_DECREF(module);
+        return NULL;
+    }
 
     return module;
 }

--- a/cext/typeconv/_typeconv.cpp
+++ b/cext/typeconv/_typeconv.cpp
@@ -44,7 +44,16 @@ static struct PyModuleDef moduledef = {
 };
 
 PyMODINIT_FUNC PyInit__typeconv(void) {
-    return PyModule_Create(&moduledef);
+    PyObject *module = PyModule_Create(&moduledef);
+    if (module == NULL)
+        return NULL;
+#if !defined(Py_LIMITED_API) && defined(Py_GIL_DISABLED)
+    if (PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED) < 0) {
+        Py_DECREF(module);
+        return NULL;
+    }
+#endif
+    return module;
 }
 
 } // end extern C

--- a/cext/typeconv/typeconv.cpp
+++ b/cext/typeconv/typeconv.cpp
@@ -80,23 +80,36 @@ bool TypeManager::canUnsafeConvert(Type from, Type to) const {
 }
 
 void TypeManager::addPromotion(Type from, Type to) {
-    return addCompatibility(from, to, TCC_PROMOTE);
+    std::unique_lock<std::shared_mutex> guard(mutex);
+    addCompatibilityUnlocked(from, to, TCC_PROMOTE);
 }
 
 void TypeManager::addUnsafeConversion(Type from, Type to) {
-    return addCompatibility(from, to, TCC_CONVERT_UNSAFE);
+    std::unique_lock<std::shared_mutex> guard(mutex);
+    addCompatibilityUnlocked(from, to, TCC_CONVERT_UNSAFE);
 }
 
 void TypeManager::addSafeConversion(Type from, Type to) {
-    return addCompatibility(from, to, TCC_CONVERT_SAFE);
+    std::unique_lock<std::shared_mutex> guard(mutex);
+    addCompatibilityUnlocked(from, to, TCC_CONVERT_SAFE);
 }
 
 void TypeManager::addCompatibility(Type from, Type to, TypeCompatibleCode tcc) {
+    std::unique_lock<std::shared_mutex> guard(mutex);
+    addCompatibilityUnlocked(from, to, tcc);
+}
+
+void TypeManager::addCompatibilityUnlocked(Type from, Type to, TypeCompatibleCode tcc) {
     TypePair pair(from, to);
     tccmap.insert(pair, tcc);
 }
 
 TypeCompatibleCode TypeManager::isCompatible(Type from, Type to) const {
+    std::shared_lock<std::shared_mutex> guard(mutex);
+    return isCompatibleUnlocked(from, to);
+}
+
+TypeCompatibleCode TypeManager::isCompatibleUnlocked(Type from, Type to) const {
     if (from == to)
         return TCC_EXACT;
     TypePair pair(from, to);
@@ -109,6 +122,7 @@ int TypeManager::selectOverload(const Type sig[], const Type ovsigs[],
                                 int sigsz, int ovct, bool allow_unsafe,
                                 bool exact_match_required
                                ) const {
+    std::shared_lock<std::shared_mutex> guard(mutex);
     int count;
     if (ovct <= 16) {
         Rating ratings[16];
@@ -142,7 +156,7 @@ int TypeManager::_selectOverload(const Type sig[], const Type ovsigs[],
         Rating rate;
 
         for (int j = 0; j < sigsz; ++j) {
-            TypeCompatibleCode tcc = isCompatible(sig[j], entry[j]);
+            TypeCompatibleCode tcc = isCompatibleUnlocked(sig[j], entry[j]);
             if (tcc == TCC_FALSE ||
                 (tcc == TCC_CONVERT_UNSAFE && !allow_unsafe) ||
                 (tcc != TCC_EXACT && exact_match_required)) {

--- a/cext/typeconv/typeconv.hpp
+++ b/cext/typeconv/typeconv.hpp
@@ -3,6 +3,8 @@
 
 #ifndef NUMBA_TYPECONV_HPP_
 #define NUMBA_TYPECONV_HPP_
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -86,11 +88,15 @@ public:
                       ) const;
 
 private:
+    void addCompatibilityUnlocked(Type from, Type to, TypeCompatibleCode tcc);
+    TypeCompatibleCode isCompatibleUnlocked(Type from, Type to) const;
+
     int _selectOverload(const Type sig[], const Type ovsigs[], int &selected,
                         int sigsz, int ovct, bool allow_unsafe,
                         bool exact_match_required,
                         Rating ratings[], int candidates[]) const;
 
+    mutable std::shared_mutex mutex;
     TCCMap tccmap;
 };
 

--- a/ci/tools/env-vars
+++ b/ci/tools/env-vars
@@ -49,6 +49,11 @@ elif [[ "${1}" == "test" ]]; then
   TEST_CUDA_MAJOR="$(cut -d '.' -f 1 <<< ${CUDA_VER})"
   TEST_CUDA_MINOR="$(cut -d '.' -f 2 <<< ${CUDA_VER})"
   NUMBA_CUDA_MLIR_CUDA_ARTIFACT_BASENAME="numba-cuda-mlir-python${PYTHON_VERSION_FORMATTED}-${HOST_PLATFORM}"
+  if [[ "${PY_VER}" == *t ]]; then
+    NUMBA_CUDA_MLIR_FT_STRESS=1
+  else
+    NUMBA_CUDA_MLIR_FT_STRESS=0
+  fi
 #  # We don't test compute-sanitizer on CTK<12 because backporting fixes is too much effort
 #  # We only test compute-sanitizer on python 3.12 arbitrarily; we don't need to use sanitizer on the entire matrix
 #  # Only local ctk installs have compute-sanitizer; there is no wheel for it
@@ -64,6 +69,7 @@ elif [[ "${1}" == "test" ]]; then
     echo "SANITIZER_CMD="
     echo "TEST_CUDA_MAJOR=${TEST_CUDA_MAJOR}"
     echo "TEST_CUDA_MINOR=${TEST_CUDA_MINOR}"
+    echo "NUMBA_CUDA_MLIR_FT_STRESS=${NUMBA_CUDA_MLIR_FT_STRESS}"
   } >> "$GITHUB_ENV"
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ class BuildExtWithCmake(build_ext):
         if IS_WINDOWS:
             cmake_cmd += ["-G", "Ninja"]
         cmake_cmd += ["-B", build_dir, ROOT, f"-DCMAKE_BUILD_TYPE={build_type}"]
-        py_gil_disabled = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+        py_gil_disabled = sysconfig.get_config_var("Py_GIL_DISABLED") in (1, "1")
         cmake_cmd.append(f"-DNUMBA_CUDA_MLIR_PY_GIL_DISABLED={'ON' if py_gil_disabled else 'OFF'}")
         if IS_WINDOWS:
             # Static-link the MSVC C runtime (/MT) so each resulting DLL

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import sys
+import sysconfig
 from pathlib import Path
 
 from setuptools import setup
@@ -80,8 +81,6 @@ def _find_mlir_python_capi() -> str | None:
             if capi.exists():
                 return str(capi)
 
-    import sysconfig
-
     sp = Path(sysconfig.get_path("platlib"))
     mlir_libs = sp / "numba_cuda_mlir" / "_mlir" / "_mlir_libs"
     for capi_name in capi_names:
@@ -125,6 +124,8 @@ class BuildExtWithCmake(build_ext):
         if IS_WINDOWS:
             cmake_cmd += ["-G", "Ninja"]
         cmake_cmd += ["-B", build_dir, ROOT, f"-DCMAKE_BUILD_TYPE={build_type}"]
+        py_gil_disabled = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+        cmake_cmd.append(f"-DNUMBA_CUDA_MLIR_PY_GIL_DISABLED={'ON' if py_gil_disabled else 'OFF'}")
         if IS_WINDOWS:
             # Static-link the MSVC C runtime (/MT) so each resulting DLL
             # embeds its own CRT copy and has no external msvcp140 /

--- a/src/numba_cuda_mlir/cuda/__init__.py
+++ b/src/numba_cuda_mlir/cuda/__init__.py
@@ -35,6 +35,7 @@ HAS_NUMBA = False
 # `cuda.shared.array` resolve to the same callables we register typing/lowering
 # for.  Assign from importlib's return value so the star import from
 # numba_cuda_mlir.numba_cuda cannot leave stub attributes on this package.
+cudadrv = importlib.import_module("numba_cuda_mlir.cuda.cudadrv")
 const = importlib.import_module("numba_cuda_mlir.cuda.const")
 local = importlib.import_module("numba_cuda_mlir.cuda.local")
 shared = importlib.import_module("numba_cuda_mlir.cuda.shared")
@@ -53,7 +54,7 @@ shared_array = shared.array  # noqa: F401
 
 def __getattr__(name):
     """Lazy load modules to avoid circular import issues."""
-    if name in ("intrin", "tensor_map", "experimental", "cudadrv"):
+    if name in ("intrin", "tensor_map", "experimental"):
         import importlib
 
         module = importlib.import_module(f"numba_cuda_mlir.cuda.{name}")

--- a/src/numba_cuda_mlir/cuda/__init__.py
+++ b/src/numba_cuda_mlir/cuda/__init__.py
@@ -53,7 +53,7 @@ shared_array = shared.array  # noqa: F401
 
 def __getattr__(name):
     """Lazy load modules to avoid circular import issues."""
-    if name in ("intrin", "tensor_map", "experimental"):
+    if name in ("intrin", "tensor_map", "experimental", "cudadrv"):
         import importlib
 
         module = importlib.import_module(f"numba_cuda_mlir.cuda.{name}")

--- a/src/numba_cuda_mlir/cuda/cudadrv/__init__.py
+++ b/src/numba_cuda_mlir/cuda/cudadrv/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from importlib import import_module
+import sys
+
+
+_MODULE_NAMES = (
+    "devicearray",
+    "devices",
+    "driver",
+    "dummyarray",
+    "error",
+    "libs",
+    "linkable_code",
+    "mappings",
+    "ndarray",
+    "nvrtc",
+    "nvvm",
+    "runtime",
+)
+
+for _name in _MODULE_NAMES:
+    _module = import_module(f"numba_cuda_mlir.numba_cuda.cudadrv.{_name}")
+    globals()[_name] = _module
+    sys.modules[f"{__name__}.{_name}"] = _module
+
+__all__ = tuple(_MODULE_NAMES)
+
+del import_module, sys, _module, _name, _MODULE_NAMES

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -4,6 +4,7 @@ import collections
 from contextlib import contextmanager
 from dataclasses import dataclass
 import sys
+import sysconfig
 import os
 import threading
 from functools import cached_property
@@ -57,6 +58,25 @@ import pstats
 
 # Thread-local storage for passing original tuple arg types to _compile
 _compile_arg_types = threading.local()
+_PY_GIL_DISABLED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+_DISPATCHER_STATE_BOOTSTRAP_LOCK = threading.Lock()
+_DISPATCHER_STATE_ATTRS = (
+    "_launch_config_lock",
+    "_launch_lock",
+    "_launch_config_overloads",
+    "_launch_config_dispatchers",
+    "_launch_config_generation",
+    "_launch_config_cache_misses",
+    "_launch_config_cache_hits",
+    "_launch_config_cache_notice_emitted",
+    "_old_dispatchers",
+    "_configure_cache",
+    "_configure_cache_inflight",
+)
+
+
+def _new_dispatcher_rlock():
+    return threading.RLock()
 
 
 def _is_strided_memory_view(arg):
@@ -664,6 +684,26 @@ class _ArgMarshaller:
                 _compile_arg_types.extensions = previous_extensions
 
     def __call__(self, *args):
+        launch_lock = None
+        if self._dispatcher is not None:
+            launch_lock = getattr(self._dispatcher, "_launch_lock", _MISSING)
+            if launch_lock is _MISSING:
+                ensure_dispatcher_state = getattr(
+                    self._dispatcher, "_ensure_dispatcher_state", None
+                )
+                if ensure_dispatcher_state is not None:
+                    ensure_dispatcher_state()
+                    launch_lock = getattr(self._dispatcher, "_launch_lock", None)
+                else:
+                    launch_lock = None
+        if launch_lock is None:
+            return self._call_impl(*args)
+        # Free-threaded launches share caches, callbacks, and native dispatcher
+        # state across this marshaller path.
+        with launch_lock:
+            return self._call_impl(*args)
+
+    def _call_impl(self, *args):
         nargs = len(args)
         has_ext = bool(self._extensions)
 
@@ -1478,7 +1518,10 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         # created with inline="always".
         self._compiler.pipeline_class = get_compiler_class(targetoptions)
 
-        self._launch_config_lock = threading.RLock()
+        # Free-threaded launches take _launch_lock before configure/cache work
+        # that may take _launch_config_lock. Keep that order one-way.
+        self._launch_config_lock = _new_dispatcher_rlock()
+        self._launch_lock = _new_dispatcher_rlock() if _PY_GIL_DISABLED else None
         # Launch-specialized overloads are retained until either recompile() or
         # cache eviction, whichever happens first. Retained marshallers can
         # reinstall their native dispatcher after dispatcher cache eviction, but
@@ -1607,28 +1650,36 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
     def _ensure_dispatcher_state(self):
         # ReduceMixin restore paths may bypass __init__, so recreate the new
         # mutable caches lazily before paths that append or clear them.
-        if not hasattr(self, "_launch_config_lock"):
-            self._launch_config_lock = threading.RLock()
-        if not hasattr(self, "_launch_config_overloads"):
-            self._launch_config_overloads = {}
-        if not hasattr(self, "_launch_config_dispatchers"):
-            self._launch_config_dispatchers = collections.OrderedDict()
-        if not hasattr(self, "_launch_config_generation"):
-            self._launch_config_generation = 0
-        if not hasattr(self, "_launch_config_cache_misses"):
-            self._launch_config_cache_misses = collections.Counter()
-        if not hasattr(self, "_launch_config_cache_hits"):
-            self._launch_config_cache_hits = collections.Counter()
-        if not hasattr(self, "_launch_config_cache_notice_emitted"):
-            self._launch_config_cache_notice_emitted = False
-        if not hasattr(self, "_old_dispatchers"):
-            self._old_dispatchers = []
-        if not hasattr(self, "_configure_cache"):
-            self._configure_cache = collections.OrderedDict()
-        if not hasattr(self, "_configure_cache_inflight"):
-            self._configure_cache_inflight = {}
-        if "configure" not in self.__dict__:
-            self.configure = _ConfigureProxy(self)
+        if all(hasattr(self, name) for name in _DISPATCHER_STATE_ATTRS) and (
+            "configure" in self.__dict__
+        ):
+            return
+
+        with _DISPATCHER_STATE_BOOTSTRAP_LOCK:
+            if not hasattr(self, "_launch_config_lock"):
+                self._launch_config_lock = _new_dispatcher_rlock()
+            if not hasattr(self, "_launch_lock"):
+                self._launch_lock = _new_dispatcher_rlock() if _PY_GIL_DISABLED else None
+            if not hasattr(self, "_launch_config_overloads"):
+                self._launch_config_overloads = {}
+            if not hasattr(self, "_launch_config_dispatchers"):
+                self._launch_config_dispatchers = collections.OrderedDict()
+            if not hasattr(self, "_launch_config_generation"):
+                self._launch_config_generation = 0
+            if not hasattr(self, "_launch_config_cache_misses"):
+                self._launch_config_cache_misses = collections.Counter()
+            if not hasattr(self, "_launch_config_cache_hits"):
+                self._launch_config_cache_hits = collections.Counter()
+            if not hasattr(self, "_launch_config_cache_notice_emitted"):
+                self._launch_config_cache_notice_emitted = False
+            if not hasattr(self, "_old_dispatchers"):
+                self._old_dispatchers = []
+            if not hasattr(self, "_configure_cache"):
+                self._configure_cache = collections.OrderedDict()
+            if not hasattr(self, "_configure_cache_inflight"):
+                self._configure_cache_inflight = {}
+            if "configure" not in self.__dict__:
+                self.configure = _ConfigureProxy(self)
 
     def _clear_configure_cache(self):
         self._ensure_dispatcher_state()
@@ -2585,6 +2636,14 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         return _result(wrapped)
 
     def compile(self, sig, abi_info=None, output=None):
+        self._ensure_dispatcher_state()
+        launch_lock = self._launch_lock
+        if launch_lock is None:
+            return self._compile_public(sig, abi_info=abi_info, output=output)
+        with launch_lock:
+            return self._compile_public(sig, abi_info=abi_info, output=output)
+
+    def _compile_public(self, sig, abi_info=None, output=None):
         from numba_cuda_mlir.mlir_optimization import optimize
         from numba_cuda_mlir import mlir_compiler
         from numba_cuda_mlir.compiler import CompileResult
@@ -2892,7 +2951,13 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         have changed and you want the kernel to use the new values.
         """
         self._ensure_dispatcher_state()
+        launch_lock = self._launch_lock
+        if launch_lock is None:
+            return self._recompile_impl()
+        with launch_lock:
+            return self._recompile_impl()
 
+    def _recompile_impl(self):
         # Clear Python-side overloads
         self.overloads.clear()
 

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -15,7 +15,7 @@ import pytest
 
 
 def _is_free_threaded_python():
-    return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+    return sysconfig.get_config_var("Py_GIL_DISABLED") in (1, "1")
 
 
 def _run_python(code, *, env=None, timeout=60):

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -269,6 +269,82 @@ def test_compile_and_recompile_take_launch_lock(monkeypatch):
     ]
 
 
+def test_nvvm_ir_version_adaptation_is_thread_safe():
+    _require_free_threaded_python()
+    if os.name == "nt":
+        pytest.skip("the Windows ModernBridge path has a native smoke test")
+
+    from numba_cuda_mlir import _cext
+    from numba_cuda_mlir._mlir import ir
+    from numba_cuda_mlir._mlir.dialects import gpu, llvm
+    from numba_cuda_mlir.lowering_utilities.llvm_utils import (
+        LLVM_C_LIB_PATH,
+        translate_to_llvmir,
+    )
+
+    # Importing the dialect modules registers the operations used by the parser.
+    _ = gpu, llvm
+
+    module_text = """
+    module {
+      gpu.module @kernels attributes {
+        llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128",
+        llvm.target_triple = "nvptx64-nvidia-cuda"
+      } {
+        llvm.func @simple_kernel() attributes {gpu.kernel} {
+          llvm.return
+        }
+      }
+    }
+    """
+
+    def make_llvm_module():
+        with ir.Context():
+            module = ir.Module.parse(module_text)
+            return translate_to_llvmir(module.body.operations[0])
+
+    worker_count = 32
+    versions = [
+        (1000 + worker, 1100 + worker, 1200 + worker, 1300 + worker)
+        for worker in range(worker_count)
+    ]
+    baselines = []
+    for version in versions:
+        llvm_mod, llvm_ctx = make_llvm_module()
+        baselines.append(
+            _cext.downgrade_for_libnvvm(
+                llvm_mod,
+                llvm_ctx,
+                13,
+                0,
+                *version,
+                LLVM_C_LIB_PATH,
+            )
+        )
+
+    modules = [make_llvm_module() for _ in range(worker_count)]
+    start = threading.Barrier(worker_count)
+
+    def adapt(worker):
+        version = versions[worker]
+        llvm_mod, llvm_ctx = modules[worker]
+        start.wait()
+        result = _cext.downgrade_for_libnvvm(
+            llvm_mod,
+            llvm_ctx,
+            13,
+            0,
+            *version,
+            LLVM_C_LIB_PATH,
+        )
+        assert result == baselines[worker]
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = [executor.submit(adapt, worker) for worker in range(worker_count)]
+        for future in futures:
+            future.result()
+
+
 def test_cuda_dispatch_with_gc_stress():
     _require_free_threaded_python()
     if os.environ.get("NUMBA_CUDA_MLIR_FT_STRESS") != "1":

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -1,0 +1,362 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for CPython free-threaded execution."""
+
+from concurrent.futures import ThreadPoolExecutor
+import os
+import subprocess
+import sys
+import sysconfig
+import textwrap
+import threading
+import time
+
+import pytest
+
+
+def _is_free_threaded_python():
+    return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
+def _run_python(code, *, env=None, timeout=60):
+    child_env = os.environ.copy()
+    for key, value in (env or {}).items():
+        if value is None:
+            child_env.pop(key, None)
+        else:
+            child_env[key] = value
+
+    return subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::RuntimeWarning",
+            "-c",
+            textwrap.dedent(code),
+        ],
+        capture_output=True,
+        env=child_env,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _require_free_threaded_python():
+    if not _is_free_threaded_python():
+        pytest.skip("requires a free-threaded CPython build")
+
+
+def test_imports_do_not_enable_gil_by_default():
+    _require_free_threaded_python()
+
+    result = _run_python(
+        """
+        import sys
+        import warnings
+
+        warnings.filterwarnings(
+            "ignore",
+            message="The CUDA driver version is older than the backend version.*",
+            category=RuntimeWarning,
+        )
+
+        assert not sys._is_gil_enabled()
+        import importlib
+        import pkgutil
+        import numba_cuda_mlir
+        from numba_cuda_mlir import cuda
+
+        for module_info in pkgutil.iter_modules(numba_cuda_mlir.__path__):
+            if module_info.name.startswith("_") and module_info.name != "_version":
+                importlib.import_module(f"numba_cuda_mlir.{module_info.name}")
+
+        assert not sys._is_gil_enabled()
+        print("gil-disabled", cuda)
+        """,
+        env={"PYTHON_GIL": None},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "gil-disabled" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "args, match",
+    [
+        (((3,), (4,), -1, 4), "ndim is negative"),
+        (((3,), (4,), 1, 0), "itemsize <= 0"),
+        (((3,), (4,), 2, 4), "shape length does not match ndim"),
+        (((3, 4, 5), (16, 4), 2, 4), "shape length does not match ndim"),
+        (((3, 4), (16,), 2, 4), "strides length does not match ndim"),
+        (((3, 4), (16, 4, 1), 2, 4), "strides length does not match ndim"),
+    ],
+)
+def test_mviewbuf_rejects_invalid_extents_inputs(args, match):
+    from numba_cuda_mlir import _mviewbuf
+
+    with pytest.raises(ValueError, match=match):
+        _mviewbuf.memoryview_get_extents_info(*args)
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (((), (), 0, 8), (0, 8)),
+        (((3,), (4,), 1, 4), (0, 12)),
+        (((3,), (-4,), 1, 4), (-8, 4)),
+        (((3, 2), (8, 4), 2, 4), (0, 24)),
+    ],
+)
+def test_mviewbuf_gets_extents_info(args, expected):
+    from numba_cuda_mlir import _mviewbuf
+
+    assert _mviewbuf.memoryview_get_extents_info(*args) == expected
+
+
+def test_mviewbuf_concurrent_invalid_inputs_smoke():
+    from numba_cuda_mlir import _mviewbuf
+
+    cases = [
+        (((3,), (4,), -1, 4), "ndim is negative"),
+        (((3,), (4,), 1, 0), "itemsize <= 0"),
+        (((3,), (4,), 2, 4), "shape length does not match ndim"),
+        (((3, 4, 5), (16, 4), 2, 4), "shape length does not match ndim"),
+        (((3, 4), (16,), 2, 4), "strides length does not match ndim"),
+        (((3, 4), (16, 4, 1), 2, 4), "strides length does not match ndim"),
+    ]
+
+    def check_invalid_inputs(rounds):
+        for _ in range(rounds):
+            for args, match in cases:
+                with pytest.raises(ValueError, match=match):
+                    _mviewbuf.memoryview_get_extents_info(*args)
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        futures = [executor.submit(check_invalid_inputs, 200) for _ in range(16)]
+        for future in futures:
+            future.result()
+
+
+def test_typeconv_concurrent_access_smoke():
+    _require_free_threaded_python()
+
+    from numba_cuda_mlir import _typeconv
+    from numba_cuda_mlir.numba_cuda import types
+
+    tm = _typeconv.new_type_manager()
+    pairs = [
+        (types.int32._code, types.int64._code, ord("p"), "promote"),
+        (types.int32._code, types.float64._code, ord("s"), "safe"),
+        (types.float64._code, types.int32._code, ord("u"), "unsafe"),
+    ]
+
+    def writer(rounds):
+        for _ in range(rounds):
+            for from_code, to_code, compat_code, _ in pairs:
+                _typeconv.set_compatible(tm, from_code, to_code, compat_code)
+
+    def reader(rounds):
+        for _ in range(rounds):
+            for from_code, to_code, _, expected in pairs:
+                assert _typeconv.check_compatible(tm, from_code, to_code) in (
+                    None,
+                    expected,
+                )
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        futures = [executor.submit(writer, 200) for _ in range(4)]
+        futures.extend(executor.submit(reader, 400) for _ in range(12))
+        for future in futures:
+            future.result()
+
+    for from_code, to_code, _, expected in pairs:
+        assert _typeconv.check_compatible(tm, from_code, to_code) == expected
+
+
+def test_arg_marshaller_recreates_missing_launch_lock(monkeypatch):
+    _require_free_threaded_python()
+
+    from numba_cuda_mlir.descriptor import _ArgMarshaller
+
+    class Dispatcher:
+        def __init__(self):
+            self.ensure_count = 0
+
+        def _ensure_dispatcher_state(self):
+            self.ensure_count += 1
+            if not hasattr(self, "_launch_lock"):
+                self._launch_lock = threading.RLock()
+            if not hasattr(self, "_launch_config_lock"):
+                self._launch_config_lock = threading.RLock()
+
+    dispatcher = Dispatcher()
+    marshaller = _ArgMarshaller(lambda: None, dispatcher=dispatcher)
+
+    def call_impl(*args):
+        with dispatcher._launch_config_lock:
+            assert dispatcher._launch_lock._is_owned()
+        return "ok"
+
+    monkeypatch.setattr(marshaller, "_call_impl", call_impl)
+
+    assert marshaller() == "ok"
+    assert dispatcher.ensure_count == 1
+
+
+def test_dispatcher_state_bootstrap_lock_converges(monkeypatch):
+    from numba_cuda_mlir import descriptor
+
+    dispatcher = object.__new__(descriptor.MLIRDispatcher)
+    real_rlock = threading.RLock
+    created_locks = []
+    created_locks_guard = threading.Lock()
+
+    def tracking_rlock():
+        lock = real_rlock()
+        with created_locks_guard:
+            created_locks.append(lock)
+        time.sleep(0.01)
+        return lock
+
+    monkeypatch.setattr(descriptor, "_new_dispatcher_rlock", tracking_rlock)
+
+    start = threading.Barrier(16)
+
+    def bootstrap():
+        start.wait()
+        descriptor.MLIRDispatcher._ensure_dispatcher_state(dispatcher)
+        return dispatcher._launch_config_lock, dispatcher._launch_lock
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        futures = [executor.submit(bootstrap) for _ in range(16)]
+        states = [future.result() for future in futures]
+
+    assert {id(launch_config_lock) for launch_config_lock, _ in states} == {
+        id(dispatcher._launch_config_lock)
+    }
+    assert {id(launch_lock) for _, launch_lock in states} == {id(dispatcher._launch_lock)}
+    expected_lock_count = 2 if descriptor._PY_GIL_DISABLED else 1
+    assert len(created_locks) == expected_lock_count
+
+
+def test_compile_and_recompile_take_launch_lock(monkeypatch):
+    from numba_cuda_mlir import descriptor
+
+    dispatcher = object.__new__(descriptor.MLIRDispatcher)
+    descriptor.MLIRDispatcher._ensure_dispatcher_state(dispatcher)
+    launch_lock = threading.RLock()
+    dispatcher._launch_lock = launch_lock
+    calls = []
+
+    def compile_public(sig, abi_info=None, output=None):
+        assert launch_lock._is_owned()
+        calls.append(("compile", sig, abi_info, output))
+        return "compiled"
+
+    def recompile_impl():
+        assert launch_lock._is_owned()
+        calls.append(("recompile",))
+        return "recompiled"
+
+    monkeypatch.setattr(dispatcher, "_compile_public", compile_public)
+    monkeypatch.setattr(dispatcher, "_recompile_impl", recompile_impl)
+
+    assert dispatcher.compile("sig", abi_info="abi", output="out") == "compiled"
+    assert dispatcher.recompile() == "recompiled"
+    assert calls == [
+        ("compile", "sig", "abi", "out"),
+        ("recompile",),
+    ]
+
+
+def test_cuda_dispatch_with_gc_stress():
+    _require_free_threaded_python()
+    if os.environ.get("NUMBA_CUDA_MLIR_FT_STRESS") != "1":
+        pytest.skip("set NUMBA_CUDA_MLIR_FT_STRESS=1 to run CUDA free-threading stress")
+
+    result = _run_python(
+        """
+        from concurrent.futures import ThreadPoolExecutor
+        import gc
+        import os
+        import warnings
+
+        import numpy as np
+
+        warnings.filterwarnings(
+            "ignore",
+            message="The CUDA driver version is older than the backend version.*",
+            category=RuntimeWarning,
+        )
+
+        from numba_cuda_mlir import cuda
+        from numba_cuda_mlir.cuda.experimental import consteval, current_target_options
+
+        if not cuda.is_available():
+            print("cuda-unavailable")
+            raise SystemExit(0)
+
+        launch_workers = int(os.environ.get("NUMBA_CUDA_MLIR_FT_LAUNCH_WORKERS", "24"))
+        launch_iters = int(os.environ.get("NUMBA_CUDA_MLIR_FT_LAUNCH_ITERS", "16"))
+        gc_workers = int(os.environ.get("NUMBA_CUDA_MLIR_FT_GC_WORKERS", "8"))
+        gc_iters = int(os.environ.get("NUMBA_CUDA_MLIR_FT_GC_ITERS", "500"))
+        recompile_workers = int(os.environ.get("NUMBA_CUDA_MLIR_FT_RECOMPILE_WORKERS", "1"))
+        recompile_iters = int(os.environ.get("NUMBA_CUDA_MLIR_FT_RECOMPILE_ITERS", "4"))
+
+        class LaunchConfigExtension:
+            uses_launch_config = True
+
+            def prepare_args(self, ty, val, stream=None, retr=None):
+                return ty, val
+
+        @cuda.jit(extensions=[LaunchConfigExtension()])
+        def kernel(out, value):
+            i = cuda.grid(1)
+            if i < out.size:
+                out[i] = value + consteval(
+                    current_target_options()["__launch_config__"]["block"][0]
+                )
+
+        outputs = [
+            cuda.to_device(np.zeros(64, dtype=np.int32))
+            for _ in range(launch_workers)
+        ]
+        kernel[1, 32](outputs[0], 1)
+        assert outputs[0].copy_to_host()[0] == 33
+
+        def launch(worker):
+            out = outputs[worker]
+            for i in range(launch_iters):
+                block = 32 if i % 2 == 0 else 64
+                kernel[1, block](out, worker)
+                if i % 4 == 0:
+                    host = out.copy_to_host()
+                    assert host[0] in (worker + 32, worker + 64)
+
+        def collect():
+            for _ in range(gc_iters):
+                gc.collect()
+
+        def recompile():
+            for _ in range(recompile_iters):
+                kernel.recompile()
+
+        with ThreadPoolExecutor(
+            max_workers=launch_workers + gc_workers + recompile_workers
+        ) as executor:
+            futures = [executor.submit(launch, i) for i in range(launch_workers)]
+            futures.extend(executor.submit(collect) for _ in range(gc_workers))
+            futures.extend(executor.submit(recompile) for _ in range(recompile_workers))
+            for future in futures:
+                future.result()
+
+        print("dispatch-stress-ok")
+        """,
+        env={"PYTHON_GIL": "0"},
+        timeout=180,
+    )
+
+    assert result.returncode == 0, result.stderr
+    if "cuda-unavailable" in result.stdout:
+        pytest.skip("CUDA GPU required")
+    assert "dispatch-stress-ok" in result.stdout

--- a/tests/test_jit_compat.py
+++ b/tests/test_jit_compat.py
@@ -98,13 +98,24 @@ def test_jit_kwargs_inline_callable():
 
 
 def test_cuda_cudadrv_reexports_legacy_namespace():
-    from numba_cuda_mlir import cuda as compat_cuda
-    from numba_cuda_mlir.numba_cuda.cudadrv import devicearray, driver
-    import numba_cuda_mlir.cuda.cudadrv.devicearray as compat_devicearray
+    code = """
+        from numba_cuda_mlir import cuda as compat_cuda
 
-    assert compat_cuda.cudadrv.devicearray is devicearray
-    assert compat_cuda.cudadrv.driver is driver
-    assert compat_devicearray is devicearray
+        initial_cudadrv = compat_cuda.cudadrv
+        assert initial_cudadrv.__name__ == "numba_cuda_mlir.cuda.cudadrv"
+
+        from numba_cuda_mlir.numba_cuda.cudadrv import devicearray, driver
+        import numba_cuda_mlir.cuda.cudadrv.devicearray as compat_devicearray
+
+        assert compat_cuda.cudadrv is initial_cudadrv
+        assert initial_cudadrv.devicearray is devicearray
+        assert initial_cudadrv.driver is driver
+        assert compat_devicearray is devicearray
+        print("OK")
+    """
+    rc, stdout, stderr = _run_in_subprocess(code)
+    assert rc == 0, f"subprocess failed: {stderr}"
+    assert "OK" in stdout
 
 
 # --- MLIRDispatcher Resource Methods ---

--- a/tests/test_jit_compat.py
+++ b/tests/test_jit_compat.py
@@ -97,6 +97,16 @@ def test_jit_kwargs_inline_callable():
     assert "OK" in stdout
 
 
+def test_cuda_cudadrv_reexports_legacy_namespace():
+    from numba_cuda_mlir import cuda as compat_cuda
+    from numba_cuda_mlir.numba_cuda.cudadrv import devicearray, driver
+    import numba_cuda_mlir.cuda.cudadrv.devicearray as compat_devicearray
+
+    assert compat_cuda.cudadrv.devicearray is devicearray
+    assert compat_cuda.cudadrv.driver is driver
+    assert compat_devicearray is devicearray
+
+
 # --- MLIRDispatcher Resource Methods ---
 
 


### PR DESCRIPTION
## Summary

This PR hardens numba-cuda-mlir for CPython free-threaded execution and adds targeted stress coverage for the launch-config dispatch path that recently landed on `main`.

The changes are split into topical commits:

- mark the C extension modules as `Py_MOD_GIL_NOT_USED` under `Py_GIL_DISABLED`
- protect native shared state that was previously implicitly serialized by the GIL
- validate `_mviewbuf.memoryview_get_extents_info()` inputs before sequence indexing
- serialize per-dispatcher native launches at the Python launch boundary
- restore `cuda.cudadrv.driver` visibility when broad test-suite import order reaches `numba_cuda_mlir.cuda.cudadrv` first
- add CPython free-threading regression and stress tests

## Why

On `python3.14t`, extension modules must explicitly declare that they do not require the GIL. Without that declaration, importing the extensions can re-enable the GIL and mask no-GIL bugs.

The stress work also found a few places where existing behavior depended on implicit GIL serialization or unchecked Python input shape:

- launcher helper freelist access
- type-conversion compatibility map access
- concurrent launch-config dispatch through retained marshallers/native launchers
- short shape/stride sequences in `_mviewbuf`

## Validation

Local `python3.14t` environment:

- `PYTHON_GIL=0 .venv-ft/bin/python -m pytest -q tests/test_free_threading.py -k 'not cuda_dispatch_with_gc_stress'`
  - `5 passed, 1 deselected`
- `NUMBA_CUDA_MLIR_FT_STRESS=1 PYTHON_GIL=0 .venv-ft/bin/python -m pytest -q tests/test_free_threading.py`
  - `6 passed`
- `PYTHON_GIL=0 .venv-ft/bin/python -m pytest -q tests --ignore=tests/benchmarks -k 'not test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn' --maxfail=1 --tb=short`
  - `4317 passed, 78 skipped, 1 deselected, 332 xfailed, 59 warnings, 41 subtests passed`
- `ruff format --check src/numba_cuda_mlir/descriptor.py src/numba_cuda_mlir/cuda/cudadrv/__init__.py tests/test_free_threading.py`
- `ruff check src/numba_cuda_mlir/descriptor.py src/numba_cuda_mlir/cuda/cudadrv/__init__.py tests/test_free_threading.py`
- `git diff --check origin/main..HEAD`

## Known Environment Limits

- Full `tests` collection still imports `numba.cuda` from `tests/benchmarks/attention/test_attention.py`; `numba` was not installed in the local `python3.14t` environment.
- `test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn` requires `cuobjdump`, which was not present in the local Python CUDA wheel environment.
- `PYTHON_GIL=1` still fails in the MLIR nanobind layer with `TypeError: type 'nanobind.nb_type_0' is not an acceptable base type`; that is separate from the no-GIL free-threaded path covered here.
