### PR TITLE
ENH: Add support for inspect_llvm

### DIFF
--- a/cext/mlir-llvm70/lib/CAPI.cpp
+++ b/cext/mlir-llvm70/lib/CAPI.cpp
@@ -41,7 +41,7 @@ int llvm70_translate_gpu_module_from_op(
     void *raw_op,
     const char *chip, const char *data_layout,
     const char *libllvm, const char *libnvvm, const char *libdevice,
-    int gen_lto, int opt_level, int gen_lineinfo,
+    int gen_lto, int gen_llvmir, int opt_level, int gen_lineinfo,
     char **out, size_t *out_len, char **err_out) {
 
   *out = nullptr;
@@ -87,7 +87,9 @@ int llvm70_translate_gpu_module_from_op(
   llvm::install_fatal_error_handler(fatalErrorHandler, nullptr);
 
   try {
-    auto ptxOrErr = llvm70::translateToPTX(gpuMod, opts);
+    auto ptxOrErr = gen_llvmir != 0
+      ? llvm70::translateToNVVMIR(gpuMod, opts)
+      : llvm70::translateToPTX(gpuMod, opts);
     llvm::remove_fatal_error_handler();
 
     if (!ptxOrErr) {

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -2127,12 +2127,6 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             overloads[LaunchConfigInspectableKey(sig_args, launch_config_key)] = cres
         return overloads
 
-    def inspect_llvm(self, sig=None):
-        raise NotImplementedError(
-            "inspect_llvm is not supported. "
-            "Use inspect_mlir() to inspect the MLIR module or inspect_asm() to inspect the PTX."
-        )
-
     def inspect_asm(self, signature=None):
         """Get generated PTX.
 
@@ -2153,6 +2147,36 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         ptx = get_ptx(cres)
         cres.metadata["ptx"] = ptx
         return ptx
+
+    def inspect_llvm(self, signature=None, legacy=False):
+        """Get generated LLVM-IR.
+
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
+
+        Passing 'legacy=True' results in generating LLVM-IR from legacy
+        LLVM-7, a version that utilized typed pointers instead of the
+        more modern opaque pointers (more details can be found in the
+        following URL: https://llvm.org/docs/OpaquePointers.html).
+
+        Although modern LLVM-IR utilize opaque pointers by default on the
+        Blackwell architecture (and onwards), the legacy flag gives users
+        the ability to generate the older LLVM-IR code without having to
+        be on the pre-Blackwell architectures.
+        """
+        if signature is None:
+            return {sig: self.inspect_asm(sig) for sig in self.overloads}
+        cres = self._find_overload(signature)
+        key = "llvmir_legacy" if legacy else "llvmir"
+        llvmir = cres.metadata.get(key)
+        if llvmir:
+            return llvmir
+
+        from numba_cuda_mlir.mlir_optimization import get_llvmir
+
+        llvmir = get_llvmir(cres, target_options=None, legacy=legacy)
+        cres.metadata[key] = llvmir
+        return llvmir
 
     def inspect_mlir(self, sig=None):
         """Get generated MLIR.

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -612,7 +612,7 @@ def optimize(cres):
                 preserve_debug_info=target_options.get("debug", False)
                 or target_options.get("lineinfo", False),
             )
-            cres.metadata["llvmir"] = llvm_ir
+            cres.metadata["llvmir"] = llvm_ir.decode()
 
         linker = cres.metadata["linker"].recreate_with_lto()
 

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -140,6 +140,7 @@ def _get_llvm70_capi():
         ctypes.c_char_p,  # libnvvm
         ctypes.c_char_p,  # libdevice
         ctypes.c_int,  # gen_lto
+        ctypes.c_int,  # gen_llvmir
         ctypes.c_int,  # opt_level
         ctypes.c_int,  # gen_lineinfo
         ctypes.POINTER(ctypes.c_char_p),  # out
@@ -168,7 +169,7 @@ def _get_op_ptr(op) -> ctypes.c_void_p:
     return ptr(capsule, b"numba_cuda_mlir._mlir.ir.Operation._CAPIPtr")
 
 
-def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
+def _call_llvm70_capi(module, target_options, gen_lto=False, gen_llvmir=False) -> bytes:
     """Compile MLIR gpu.module via in-process LLVM70 C API (raw Operation*)."""
     from numba_cuda_mlir._mlir.dialects import gpu
     from numba_cuda_mlir.tools import get_gpu_compute_capability
@@ -228,6 +229,7 @@ def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
         libnvvm.encode(),
         libdevice.encode(),
         1 if gen_lto else 0,
+        1 if gen_llvmir else 0,
         opt_level,
         debug_level,
         ctypes.byref(out),
@@ -323,6 +325,37 @@ def _compile_to_ltoir(llvm_ir: bytes, libdevice, nvvm_opts: dict) -> bytes:
     cu.verify()
     cu.lazy_add_module(libdevice.get())
     return cu.compile()
+
+
+def get_llvmir(cres, target_options=None, legacy=False) -> str:
+    key = "llvmir_legacy" if legacy else "llvmir"
+    llvmir = cres.metadata.get(key)
+    if llvmir:
+        return llvmir
+    if target_options is None:
+        target_options = cres.metadata["targetoptions"]
+
+    with context.get_context():
+        module = ir.Module.parse(cres.metadata["mlir_module_optimized"])
+        run_pre_codegen_patterns(module)
+
+        chip = target_options.get("chip")
+        if not chip:
+            from numba_cuda_mlir.tools import get_gpu_compute_capability
+
+            chip = get_gpu_compute_capability()
+        cc = chip.replace("sm_", "")
+
+        if _needs_llvm70_path(cc) or legacy:
+            llvmir = _call_llvm70_capi(module, target_options, gen_llvmir=legacy)
+        else:
+            llvmir = _prepare_llvm_ir(
+                module,
+                dump=target_options.get("dump_llvmir", False),
+                preserve_debug_info=target_options.get("debug", False)
+                or target_options.get("lineinfo", False),
+            )
+    return llvmir.decode()
 
 
 def get_ptx(cres, target_options=None) -> str:
@@ -579,6 +612,7 @@ def optimize(cres):
                 preserve_debug_info=target_options.get("debug", False)
                 or target_options.get("lineinfo", False),
             )
+            cres.metadata["llvmir"] = llvm_ir
 
         linker = cres.metadata["linker"].recreate_with_lto()
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from numba_cuda_mlir import cuda, types
+from numba_cuda_mlir.tools import generate_mangled_name
+
+import pytest
+
+
+class TestDispatcherMethods:
+    @pytest.mark.parametrize("legacy", [False, True])
+    def test_inspect_llvm(self, legacy):
+        @cuda.jit(device=True)
+        def foo(x, y):
+            return x + y
+
+        args = (types.int32, types.int32)
+        cres = foo.compile_device(args)
+
+        fname = generate_mangled_name(cres.fndesc.qualname, cres.fndesc.argtypes)
+        # Verify that the function name has "foo" in it as in the python name
+        assert "foo" in fname
+
+        # Check that the compiled function name is in the LLVM
+        llvm = foo.inspect_llvm(args, legacy=legacy)
+        assert fname in llvm

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -7,19 +7,28 @@ import pytest
 
 
 class TestDispatcherMethods:
-    @pytest.mark.parametrize("legacy", [False, True])
-    def test_inspect_llvm(self, legacy):
+    @pytest.mark.parametrize(
+        "legacy,source_filename,ptr_type",
+        [
+            pytest.param(False, "LLVMDialectModule", "ptr %0", id="modern-IR"),
+            pytest.param(True, "llvm70_module", "i8*", id="legacy-IR"),
+        ],
+    )
+    def test_inspect_llvm(self, legacy, source_filename, ptr_type):
         @cuda.jit(device=True)
-        def foo(x, y):
-            return x + y
+        def foo(arr, y):
+            arr[0] = y
 
-        args = (types.int32, types.int32)
+        args = (types.int32[:], types.int32)
         cres = foo.compile_device(args)
 
         fname = generate_mangled_name(cres.fndesc.qualname, cres.fndesc.argtypes)
         # Verify that the function name has "foo" in it as in the python name
         assert "foo" in fname
 
-        # Check that the compiled function name is in the LLVM
         llvm = foo.inspect_llvm(args, legacy=legacy)
-        assert fname in llvm
+
+        # Check that the compiled function name and expected pointer type
+        # made it to the resulting LLVM
+        assert f'source_filename = "{source_filename}"' in llvm
+        assert f"{fname}({ptr_type}" in llvm


### PR DESCRIPTION
Resolves #95

This PR allows users to use the `inspect_llvm` function to retrieve LLVM-IR code from a JIT-compiled function. There actually wasn't too much involved because the library has already done lots of the heavy-lifting. To be specific, when an architecture's compute capable version is above 10, LLVM-IR is automatically generated during the compilation phase.

Much of the PR is actually handling the instance where the architecture pre-dates Blackwell. Actually, it turns out that for older architectures, PTX is automatically generated from the MLIR input, while more modern architectures has the MLIR -> LLVM IR -> PTX flow and for that reason, we didn't have any LLVM-IR code to cache. However, it turns out that there is a `translateToNVVMIR` function that can be leveraged in `cext/mlir-llvm70/lib/CAPI.cpp` to give us the LLVM-IR we seek.

Additionally, the older LLVM-IR will never need to be used anywhere outside of `inspect_llvm`, so there's no need to try and generate this code in the compilation state for users just so it’s cached for future use.

I also generated a basic test (very similar to an upstreamed version) that asserts that checks for a mangled name being present in the LLVM-IR code.