### PR TITLE
Resolve various CI issues

### DIFF
--- a/ci/tools/run-cudf-source-tests
+++ b/ci/tools/run-cudf-source-tests
@@ -116,6 +116,7 @@ GROUPBY_UDF="${CUDF_DIR}/python/cudf/cudf/tests/groupby/test_apply.py"
 NRT_STATS="${CUDF_DIR}/python/cudf/cudf/tests/private_objects/test_nrt_stats.py"
 
 COMMON_ARGS=(
+  -p "no:cases"
   -W "ignore::UserWarning"
   -W "ignore::numba_cuda_mlir.numba_cuda.core.errors.NumbaPerformanceWarning"
   -W "ignore:Linking LTOIR with optimization_level"

--- a/src/numba_cuda_mlir/numba_cuda/np/arrayobj.py
+++ b/src/numba_cuda_mlir/numba_cuda/np/arrayobj.py
@@ -6354,7 +6354,7 @@ def impl_np_vstack(tup):
         return impl
 
 
-if numpy_version >= (2, 0):
+if (2, 0) <= numpy_version < (2, 5):
     overload(np.row_stack)(impl_np_vstack)
 
 


### PR DESCRIPTION
- Fixes a recent ecosystem breakage between pytest and a plugin we don't actually need to run our cudf test subset, dropping this plugin for now. 
- Fixes a CI issue related to the removal of a deprecated numpy api