### PR TITLE
Infer launch bounds from launch-time block size

### DIFF
--- a/src/numba_cuda_mlir/caching.py
+++ b/src/numba_cuda_mlir/caching.py
@@ -130,6 +130,7 @@ class MLIRCache(Cache):
             ("lto", targetoptions.get("lto")),
             ("output", targetoptions.get("output", "ptx")),
             ("chip", gpu_target["chip"]),
+            ("launch_bounds", targetoptions.get("launch_bounds")),
         )
         return (*key, option_key)
 

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -380,6 +380,14 @@ def _launch_config_dict_from_key(launch_config_key):
     return {name: value for name, value in launch_config_key}
 
 
+def _launch_config_thread_count(launch_config):
+    block = launch_config["block"]
+    threads = 1
+    for dim in block:
+        threads *= dim
+    return threads
+
+
 def _normalize_launch_sharedmem(sharedmem):
     if sharedmem is None:
         return 0
@@ -539,8 +547,16 @@ class _ArgMarshaller:
         extensions = (
             self._extensions if self._has_extension_snapshot else getattr(disp, "extensions", ())
         )
+        extensions_use_launch_config = _extensions_use_launch_config(extensions)
+        implicit_launch_bounds_only = (
+            not extensions_use_launch_config
+            and disp is not None
+            and getattr(disp, "_implicit_launch_bounds_enabled", False)
+        )
         active_launch_config = (
-            self._launch_config if _extensions_use_launch_config(extensions) else None
+            self._launch_config
+            if (extensions_use_launch_config or implicit_launch_bounds_only)
+            else None
         )
         active_launch_config_key = _launch_config_key(active_launch_config)
         if active_launch_config_key is None:
@@ -555,6 +571,8 @@ class _ArgMarshaller:
             best, has_match = disp._resolve_overload(argtypes, allow_unsafe=True)
         else:
             overload_argtypes = disp._launch_config_overload_argtypes(active_launch_config_key)
+            if not overload_argtypes and implicit_launch_bounds_only:
+                overload_argtypes = tuple(disp.overloads)
             if not overload_argtypes:
                 return device_args, argtypes
             for sig_args in overload_argtypes:
@@ -1530,7 +1548,14 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
 
     @property
     def _launch_config_enabled(self):
-        return _extensions_use_launch_config(self.extensions)
+        return _extensions_use_launch_config(self.extensions) or self._implicit_launch_bounds_enabled
+
+    @property
+    def _implicit_launch_bounds_enabled(self):
+        return (
+            not self.targetoptions.get("device", False)
+            and self.targetoptions.get("launch_bounds") is None
+        )
 
     def _get_kernel_dispatcher(self, launch_config):
         dispatcher, _ = self._get_kernel_dispatcher_and_generation(launch_config)
@@ -1674,11 +1699,18 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         griddim, blockdim = normalize_kernel_dimensions(griddim, blockdim)
         if cluster is not None:
             cluster = normalize_kernel_dimensions(cluster, (1, 1, 1))[0]
-        launch_config_enabled = self._launch_config_enabled
+        launch_config_enabled = _extensions_use_launch_config(self.extensions)
         extension_key = tuple(_ObjectIdentityKey(ext) for ext in self.extensions)
         configured_sharedmem = sharedmem
         if launch_config_enabled:
             configured_sharedmem = _normalize_launch_sharedmem(sharedmem)
+        elif self._implicit_launch_bounds_enabled:
+            try:
+                configured_sharedmem = _normalize_launch_sharedmem(sharedmem)
+            except TypeError:
+                pass
+            else:
+                launch_config_enabled = True
         cache_key = (
             launch_config_enabled,
             extension_key,
@@ -2318,17 +2350,28 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 if cb not in self._module_teardown_callbacks:
                     self._module_teardown_callbacks.append(cb)
 
-    def _find_launch_config_overload_locked(self, argtypes, launch_config_key):
+    def _find_launch_config_overload_locked(
+        self, argtypes, launch_config_key, implicit_launch_bounds=False
+    ):
         # Exact hits are O(1). Compatible fallback scans the bounded launch
         # overload table to preserve existing overload-reuse semantics.
         exact = self._launch_config_overloads.get((argtypes, launch_config_key))
         if exact is not None:
             return exact
+        implicit_threads = None
+        if implicit_launch_bounds:
+            implicit_threads = _launch_config_thread_count(
+                _launch_config_dict_from_key(launch_config_key)
+            )
         reusable = None
         for (sig_args, key), cres in self._launch_config_overloads.items():
+            if implicit_threads is not None:
+                if _launch_config_thread_count(_launch_config_dict_from_key(key)) != implicit_threads:
+                    continue
+            elif key != launch_config_key:
+                continue
             if (
-                key == launch_config_key
-                and len(sig_args) == len(argtypes)
+                len(sig_args) == len(argtypes)
                 and all(self._can_reuse_overload(s, r) for s, r in zip(sig_args, argtypes))
             ):
                 reusable = cres
@@ -2408,8 +2451,13 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         if not has_extension_snapshot:
             active_extensions = self.extensions
         force_launch_config = getattr(_compile_arg_types, "force_launch_config", False)
+        implicit_launch_bounds = self._implicit_launch_bounds_enabled
+        extensions_use_launch_config = _extensions_use_launch_config(active_extensions)
+        implicit_launch_bounds_only = implicit_launch_bounds and not (
+            force_launch_config or extensions_use_launch_config
+        )
         active_launch_config = None
-        if force_launch_config or _extensions_use_launch_config(active_extensions):
+        if force_launch_config or extensions_use_launch_config or implicit_launch_bounds:
             active_launch_config = getattr(_compile_arg_types, "launch_config", None)
         active_launch_config_key = _launch_config_key(active_launch_config)
         active_launch_config_generation = None
@@ -2431,7 +2479,9 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             # launch.
             with self._launch_config_lock:
                 reusable = self._find_launch_config_overload_locked(
-                    argtypes, active_launch_config_key
+                    argtypes,
+                    active_launch_config_key,
+                    implicit_launch_bounds=implicit_launch_bounds_only,
                 )
                 if reusable is not None:
                     self._launch_config_cache_hits[(argtypes, active_launch_config_key)] += 1
@@ -2448,8 +2498,15 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 with self._launch_config_lock:
                     candidate_overloads = {}
                     for (sig_args, key), cres in self._launch_config_overloads.items():
-                        if key == active_launch_config_key:
-                            candidate_overloads[sig_args] = cres
+                        if implicit_launch_bounds_only:
+                            if (
+                                _launch_config_thread_count(_launch_config_dict_from_key(key))
+                                != _launch_config_thread_count(active_launch_config)
+                            ):
+                                continue
+                        elif key != active_launch_config_key:
+                            continue
+                        candidate_overloads[sig_args] = cres
                 generic_note = (
                     f"; {len(self.overloads)} generic overload(s) ignored because "
                     "active extensions use launch metadata"
@@ -2462,6 +2519,15 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     candidate_sig_args=tuple(candidate_overloads),
                 )
                 if not has_any:
+                    if implicit_launch_bounds_only:
+                        best, has_any = self._resolve_overload(argtypes, allow_unsafe=True)
+                        if not has_any:
+                            raise TypeError(
+                                f"No matching definition for argument type(s) {argtypes}"
+                            )
+                        if len(best) > 1:
+                            self._raise_ambiguous(argtypes, best)
+                        return _result(self.overloads[best[0]])
                     # Generic overloads are not a safe fallback here: opt-in
                     # extensions may lower code from __launch_config__ metadata.
                     raise TypeError(
@@ -2498,23 +2564,40 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             if has_extension_snapshot:
                 targetoptions["extensions"] = active_extensions
             if active_launch_config is not None:
-                targetoptions["__launch_config__"] = dict(active_launch_config)
+                if force_launch_config or extensions_use_launch_config:
+                    targetoptions["__launch_config__"] = dict(active_launch_config)
+                if implicit_launch_bounds:
+                    targetoptions["launch_bounds"] = _launch_config_thread_count(
+                        active_launch_config
+                    )
+        cache = self._cache
+        if implicit_launch_bounds_only and active_launch_config_key is not None:
+            if not isinstance(self._cache, NullCache):
+                cache = MLIRCache(self.py_func, targetoptions)
 
         # Try to load from disk cache
         mlir_target.ensure_initialized()
         sig = typing.signature(types.none, *argtypes)
         # Launch-specialized compiles use an in-memory cache because the
         # generic in-memory and on-disk cache keys do not include launch metadata.
-        if active_launch_config_key is None:
-            cres = self._cache.load_overload(sig, mlir_target.target_context)
+        if active_launch_config_key is None or implicit_launch_bounds_only:
+            cres = cache.load_overload(sig, mlir_target.target_context)
             if cres is not None:
                 self._cache_hits[argtypes] += 1
                 wrapped = CompileResult(cres)
-                self.overloads[argtypes] = wrapped
+                if active_launch_config_key is None:
+                    self.overloads[argtypes] = wrapped
+                else:
+                    with self._launch_config_lock:
+                        self._launch_config_overloads.setdefault(
+                            (tuple(wrapped.signature.args), active_launch_config_key), wrapped
+                        )
+                    if implicit_launch_bounds_only:
+                        self.overloads.setdefault(tuple(wrapped.signature.args), wrapped)
                 return _result(wrapped)
 
         # Cache miss - need to compile
-        if active_launch_config_key is None:
+        if active_launch_config_key is None or implicit_launch_bounds_only:
             self._cache_misses[argtypes] += 1
 
         # Compile using mlir_compiler_entry which handles annotations and AST transforms
@@ -2535,11 +2618,15 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     retry_launch_config_compile = True
                 else:
                     existing = self._find_launch_config_overload_locked(
-                        argtypes, active_launch_config_key
+                        argtypes,
+                        active_launch_config_key,
+                        implicit_launch_bounds=implicit_launch_bounds_only,
                     )
                     if existing is None and normalized_args != argtypes:
                         existing = self._find_launch_config_overload_locked(
-                            normalized_args, active_launch_config_key
+                            normalized_args,
+                            active_launch_config_key,
+                            implicit_launch_bounds=implicit_launch_bounds_only,
                         )
                     if existing is not None:
                         # A duplicate compile can lose a race to another thread that
@@ -2547,8 +2634,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                         # without publishing callbacks from an unused module.
                         return _result(existing)
                     self._launch_config_cache_misses[(argtypes, active_launch_config_key)] += 1
-                    emit_launch_config_cache_notice = not self._launch_config_cache_notice_emitted
-                    self._launch_config_cache_notice_emitted = True
+                    if not implicit_launch_bounds_only:
+                        emit_launch_config_cache_notice = (
+                            not self._launch_config_cache_notice_emitted
+                        )
+                        self._launch_config_cache_notice_emitted = True
                     self._propagate_compile_callbacks(result.metadata)
                     self._apply_shared_memory_carveout(wrapped)
                     # Preserve both the native dispatcher request types and the
@@ -2559,6 +2649,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     self._launch_config_overloads.setdefault(
                         (normalized_args, active_launch_config_key), wrapped
                     )
+                    if implicit_launch_bounds_only:
+                        self.overloads.setdefault(normalized_args, wrapped)
             if retry_launch_config_compile:
                 if launch_config_retry_budget <= 0:
                     raise RuntimeError(
@@ -2579,8 +2671,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             self.overloads[result.signature.args] = wrapped
 
         # Save to disk cache
-        if active_launch_config_key is None:
-            self._cache.save_overload(sig, result)
+        if active_launch_config_key is None or implicit_launch_bounds_only:
+            cache.save_overload(sig, result)
 
         return _result(wrapped)
 

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -77,6 +77,10 @@ def restore_compile_arg_types():
     descriptor_mod._compile_arg_types.__dict__.update(state)
 
 
+def _skip_target_resolution(dispatcher, monkeypatch):
+    monkeypatch.setattr(dispatcher, "_resolve_target_options", lambda: None)
+
+
 def test_arg_marshaller_exposes_launch_config_during_launch():
     dispatcher = _Dispatcher()
     launch_config = {
@@ -335,7 +339,34 @@ def test_configure_cache_tracks_mutated_non_launch_extensions(monkeypatch):
     assert generic._extensions == []
     assert updated is not generic
     assert updated._extensions == [extension]
-    assert updated._launch_config is None
+    assert updated._launch_config == generic._launch_config
+
+
+def test_implicit_launch_bounds_enable_launch_config_without_extensions(monkeypatch):
+    def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
+        return lambda *args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    marshaller = dispatcher.configure((2, 1, 1), (16, 8, 1))
+
+    assert marshaller._launch_config == {
+        "grid": (2, 1, 1),
+        "block": (16, 8, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    assert marshaller._kernel_dispatcher is not dispatcher._c
+
+    explicit = descriptor_mod.MLIRDispatcher(kernel, targetoptions={"launch_bounds": 128})
+    explicit_marshaller = explicit.configure(2, 32)
+
+    assert explicit_marshaller._launch_config is None
+    assert explicit_marshaller._kernel_dispatcher is explicit._c
 
 
 def test_launch_config_configure_reports_invalid_sharedmem():
@@ -440,6 +471,7 @@ def test_compile_impl_generic_applies_shared_memory_carveout(monkeypatch):
         return CompilerResult()
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    monkeypatch.setattr(dispatcher, "_resolve_target_options", lambda: None)
     monkeypatch.setattr(
         dispatcher,
         "_apply_shared_memory_carveout",
@@ -551,7 +583,7 @@ def test_plain_kernel_uses_default_native_dispatcher():
     def kernel(out):
         pass
 
-    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel, targetoptions={"launch_bounds": 32})
     config = {
         "grid": (1, 1, 1),
         "block": (32, 1, 1),
@@ -674,7 +706,7 @@ def test_launch_config_enabled_tracks_mutated_extensions():
     def kernel():
         pass
 
-    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel, targetoptions={"launch_bounds": 32})
     assert (
         dispatcher._get_kernel_dispatcher(
             {
@@ -718,7 +750,12 @@ def test_configure_cache_tracks_mutated_extensions(monkeypatch):
     dispatcher.extensions.append(_LaunchConfigExtension())
     launch_sensitive = dispatcher.configure(1, 32)
 
-    assert generic._launch_config is None
+    assert generic._launch_config == {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
     assert generic_after_clear is not generic
     assert launch_sensitive is not generic
     assert launch_sensitive._launch_config == {
@@ -1159,7 +1196,7 @@ def test_compile_ignores_stale_launch_config_after_extension_removed():
         pass
 
     dispatcher = descriptor_mod.MLIRDispatcher(
-        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()], "launch_bounds": 32}
     )
     sig_args = (types.float32,)
     compile_result = _CompileResult(sig_args)
@@ -1200,6 +1237,7 @@ def test_retained_marshaller_compiles_with_extension_snapshot_after_mutation(mon
         return CompilerResult()
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    _skip_target_resolution(dispatcher, monkeypatch)
 
     launch_config = {
         "grid": (1, 1, 1),
@@ -1235,7 +1273,7 @@ def test_disabled_coercion_ignores_stale_launch_config_after_extension_removed()
         pass
 
     dispatcher = descriptor_mod.MLIRDispatcher(
-        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()], "launch_bounds": 32}
     )
     dispatcher.overloads[(types.float32,)] = _CompileResult((types.float32,))
     dispatcher.disable_compile()
@@ -1358,6 +1396,7 @@ def test_compile_impl_launch_config_publishes_aliases_and_skips_disk_cache(monke
         return CompilerResult(tuple(override_argtypes), f"cubin-{len(compile_calls)}".encode())
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    _skip_target_resolution(dispatcher, monkeypatch)
     monkeypatch.setattr(
         dispatcher._cache,
         "save_overload",
@@ -1407,12 +1446,64 @@ def test_compile_impl_launch_config_publishes_aliases_and_skips_disk_cache(monke
         dispatcher._launch_config_overloads[((types.int64,), second_launch_key)].metadata["cubin"]
         == b"cubin-2"
     )
-    assert not dispatcher.overloads
+    assert dispatcher.overloads
     assert saved_overloads == []
     assert trace_messages == [
         "Persistent disk cache is disabled for launch-config-specialized "
         "compiles because the disk cache key does not include launch metadata."
     ]
+
+
+def test_compile_impl_sets_implicit_launch_bounds_from_launch_config(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel, targetoptions={"chip": "sm_90"})
+    compile_calls = []
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"implicit", "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append(dict(targetoptions))
+        return CompilerResult()
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    monkeypatch.setattr(dispatcher, "_resolve_target_options", lambda: None)
+
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (16, 8, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.launch_config = launch_config
+
+    assert dispatcher._compile_impl([1]) == (b"implicit", "kernel", False)
+
+    assert len(compile_calls) == 1
+    assert "__launch_config__" not in compile_calls[0]
+    assert compile_calls[0]["launch_bounds"] == 128
+    assert dispatcher.targetoptions.get("launch_bounds") is None
+    assert (types.int32,) in dispatcher.overloads
+    assert (
+        dispatcher._launch_config_overloads[((types.int32,), launch_key)].metadata["cubin"]
+        == b"implicit"
+    )
+
+    descriptor_mod._compile_arg_types.launch_config = {
+        "grid": (2, 1, 1),
+        "block": (128, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    assert dispatcher._compile_impl([1]) == (b"implicit", "kernel", False)
+    assert len(compile_calls) == 1
 
 
 def test_compile_impl_launch_config_separates_same_signature_by_grid(monkeypatch):
@@ -1436,6 +1527,7 @@ def test_compile_impl_launch_config_separates_same_signature_by_grid(monkeypatch
         return CompilerResult(f"cubin-{len(compile_calls)}".encode())
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    _skip_target_resolution(dispatcher, monkeypatch)
 
     first_launch_config = {
         "grid": (1, 1, 1),
@@ -1516,6 +1608,7 @@ def test_compile_impl_discards_callbacks_after_generation_retry(monkeypatch):
         return CompilerResult(b"accepted", accepted_setup_callback)
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    _skip_target_resolution(dispatcher, monkeypatch)
     descriptor_mod._compile_arg_types.types = (types.int32,)
     descriptor_mod._compile_arg_types.launch_config = launch_config
 
@@ -1563,6 +1656,7 @@ def test_compile_impl_discards_callbacks_from_duplicate_launch_compile(monkeypat
         return CompilerResult()
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    _skip_target_resolution(dispatcher, monkeypatch)
     descriptor_mod._compile_arg_types.types = (types.int32,)
     descriptor_mod._compile_arg_types.launch_config = launch_config
 
@@ -1639,6 +1733,7 @@ def test_compile_launch_config_signature_forces_launch_rebuild_without_extension
         return CompilerResult()
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    _skip_target_resolution(dispatcher, monkeypatch)
 
     with pytest.warns(
         descriptor_mod.NumbaPerformanceWarning,
@@ -1664,7 +1759,7 @@ def test_disabled_launch_config_reduce_skips_launch_sigs_after_extension_removed
         pass
 
     dispatcher = descriptor_mod.MLIRDispatcher(
-        kernel, targetoptions={"extensions": [_LaunchConfigExtension()]}
+        kernel, targetoptions={"extensions": [_LaunchConfigExtension()], "launch_bounds": 32}
     )
     launch_config = {
         "grid": (1, 1, 1),
@@ -1723,3 +1818,28 @@ def test_launch_config_specializes_same_signature_launches():
     assert kernel.signatures
     assert kernel.nopython_signatures
     assert kernel.launch_config_overloads
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_implicit_launch_bounds_specializes_same_signature_launches():
+    @cuda.jit
+    def kernel():
+        pass
+
+    kernel[1, 32]()
+    kernel[1, 64]()
+
+    mlir_by_key = kernel.inspect_mlir()
+    launch_entries = {
+        tuple(dict(key.launch_config_key)["block"]): mlir
+        for key, mlir in mlir_by_key.items()
+        if isinstance(key, descriptor_mod.LaunchConfigInspectableKey)
+    }
+
+    generic_sig = next(iter(kernel.overloads))
+    generic_mlir = kernel.inspect_mlir(generic_sig)
+    assert "nvvm.maxntid" in generic_mlir
+    assert "32" in generic_mlir
+    assert set(launch_entries) == {(64, 1, 1)}
+    assert "nvvm.maxntid" in launch_entries[(64, 1, 1)]
+    assert "64" in launch_entries[(64, 1, 1)]


### PR DESCRIPTION
Use launch-time block dimensions to infer an effective launch_bounds value when a kernel is launched without explicit launch_bounds in the jit options. This lets compilation see the max threads per block constraint needed for register allocation, matching numba-cuda behavior more closely.

The implicit path reuses PR #70's launch-config dispatch machinery, but keeps ordinary kernels distinct from launch-config extensions: it does not expose __launch_config__, reuses by effective block thread count, preserves generic overload fallback for explicit signatures, and keeps persistent cache support by including launch_bounds in the cache key.

Tests cover implicit launch-bound target options, same-bound reuse, explicit launch_bounds preserving the old path, and inspection compatibility.

Short walkthrough:
- descriptor.py: enables launch-config-sensitive compilation for ordinary kernels only when launch_bounds is absent, then injects launch_bounds = prod(blockdim) into compile target options.
- descriptor.py: keeps PR #70 extension behavior strict, while allowing implicit launch-bound kernels to reuse generic overloads and populate kernel.overloads for compatibility.
- caching.py: adds launch_bounds to the persistent cache key so different inferred bounds do not collide.
- test_descriptor_launch_config.py: adds focused regression coverage for inferred bounds and adjusts expectations for the compatibility overload entry.