### PR TITLE
Add full support for big dynamic smem

### DIFF
--- a/cext/launcher/cuda_shim.h
+++ b/cext/launcher/cuda_shim.h
@@ -49,6 +49,7 @@ typedef enum {
     CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z              = 7,
     CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR     = 75,
     CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR     = 76,
+    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN = 97,
 } CUdevice_attribute;
 
 /* ---- pointer / function attributes ------------------------------------- */
@@ -58,6 +59,7 @@ typedef enum {
 } CUpointer_attribute;
 
 typedef enum {
+    CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES = 1,
     CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8,
 } CUfunction_attribute;
 

--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -1871,8 +1871,22 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
         }
     }
 
-    // Configure dynamic shared memory if needed (default limit is typically 48KB)
-    if (sharedmem > 48 * 1024) {
+    // Configure dynamic shared memory if needed.
+    //
+    // Every function has a default cap on dynamic shared memory
+    // (CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES). This default is the
+    // device's standard per-block limit (typically 48 KiB) minus any static
+    // shared memory the kernel uses, so it can be anything up to 48 KiB. When
+    // the requested dynamic shared memory exceeds this default, we must
+    // explicitly opt in to the larger limit, otherwise the driver rejects the
+    // launch with CUDA_ERROR_INVALID_VALUE.
+    //
+    // We compare against the function's actual default (queried at runtime)
+    // rather than a hard-coded 48 KiB so that the window [default, 48 KiB] is
+    // reachable. A kernel asking for exactly 48 KiB while using even a single
+    // byte of static shared memory has a default below 48 KiB and therefore
+    // needs the opt-in.
+    {
         // Convert CUkernel to CUfunction for attribute configuration
         CUfunction cu_function = nullptr;
         CUkernel cu_kernel = kernel_iter->second.cukernel.kernel;
@@ -1883,16 +1897,74 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
                         get_cuda_error(func_res));
         }
 
-        CUresult attr_res = g_cuFuncSetAttribute(
-            cu_function,
+        // The function's default dynamic limit is the device's standard
+        // per-block limit minus the kernel's static shared memory
+        // (CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK -
+        //  CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES).
+        int default_dyn_limit = 0;
+        CUresult get_res = g_cuFuncGetAttribute(
+            &default_dyn_limit,
             CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-            sharedmem
+            cu_function
         );
-
-        if (attr_res != CUDA_SUCCESS) {
+        if (get_res != CUDA_SUCCESS) {
             return raise(PyExc_RuntimeError,
-                        "Failed to set max dynamic shared memory size to %d bytes: %s",
-                        sharedmem, get_cuda_error(attr_res));
+                        "Failed to query max dynamic shared memory size: %s",
+                        get_cuda_error(get_res));
+        }
+
+        if (sharedmem > default_dyn_limit) {
+            // Surface a clear error if the request exceeds what the device can
+            // provide instead of letting the attribute set fail with an opaque
+            // INVALID_VALUE.
+            //
+            // The device opt-in limit (CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_
+            // PER_BLOCK_OPTIN) covers the *total* per-block shared memory, i.e.
+            // static + dynamic. The kernel's static shared memory therefore
+            // reduces the dynamic budget, so we subtract it before comparing.
+            // Otherwise we could opt in to a dynamic size that, combined with
+            // static usage, overflows the device limit and fails at launch.
+            int max_optin = 0;
+            CUdevice dev;
+            if (g_cuCtxGetDevice(&dev) == CUDA_SUCCESS) {
+                g_cuDeviceGetAttribute(
+                    &max_optin,
+                    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+                    dev
+                );
+            }
+
+            int static_smem = 0;
+            CUresult static_res = g_cuFuncGetAttribute(
+                &static_smem,
+                CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
+                cu_function
+            );
+            if (static_res != CUDA_SUCCESS) {
+                return raise(PyExc_RuntimeError,
+                            "Failed to query static shared memory size: %s",
+                            get_cuda_error(static_res));
+            }
+
+            if (max_optin > 0 && sharedmem > max_optin - static_smem) {
+                return raise(PyExc_ValueError,
+                            "Requested dynamic shared memory (%d bytes) plus the kernel's "
+                            "static shared memory (%d bytes) exceeds the device maximum "
+                            "opt-in shared memory per block (%d bytes)",
+                            sharedmem, static_smem, max_optin);
+            }
+
+            CUresult attr_res = g_cuFuncSetAttribute(
+                cu_function,
+                CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                sharedmem
+            );
+
+            if (attr_res != CUDA_SUCCESS) {
+                return raise(PyExc_RuntimeError,
+                            "Failed to set max dynamic shared memory size to %d bytes: %s",
+                            sharedmem, get_cuda_error(attr_res));
+            }
         }
     }
 

--- a/tests/test_large_smem.py
+++ b/tests/test_large_smem.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import numpy as np
+from cuda.bindings import driver
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir import types, tools
 
@@ -57,5 +58,159 @@ def test_shared_memory_96kb():
     np.testing.assert_array_equal(result, expected)
 
 
+def test_shared_memory_exactly_48kb_with_static_smem():
+    """Regression test for issue #143.
+
+    A kernel that requests exactly 48 KiB of dynamic shared memory while also
+    using a small amount of static shared memory must still launch. The default
+    per-function dynamic limit is 48 KiB minus the static usage, so the launcher
+    has to opt in to the larger limit. Previously the launcher only opted in for
+    ``sharedmem > 48 * 1024``, leaving the exactly-48-KiB case unreachable and
+    failing with CUDA_ERROR_INVALID_VALUE.
+    """
+
+    DYN_BYTES = 48 * 1024  # exactly 48 KiB
+    BLOCK_SIZE = 128
+
+    @cuda.jit
+    def k(out):
+        # 1 byte of static shared memory + the dynamic shared array. The static
+        # array must be written and read so the compiler cannot optimize it
+        # away, otherwise the kernel reports zero static shared memory.
+        flag = cuda.shared_array((1,), dtype=types.uint8)
+        smem = cuda.shared_array(0, dtype=types.uint8)
+        i = cuda.threadIdx.x
+        if i == 0:
+            flag[0] = types.uint8(7)
+        if i < smem.size:
+            smem[i] = types.uint8(i)
+        cuda.syncthreads()
+        if i == 0:
+            out[0] = types.int32(flag[0])
+
+    out = cuda.to_device(np.zeros(1, dtype=np.int32))
+
+    # Previously failed with CUDA_ERROR_INVALID_VALUE (invalid argument).
+    k[1, BLOCK_SIZE, 0, DYN_BYTES](out)
+    cuda.synchronize()
+
+    np.testing.assert_array_equal(out.copy_to_host(), np.array([7], dtype=np.int32))
+
+
+def test_shared_memory_exactly_48kb_no_static_smem():
+    """Exactly 48 KiB of dynamic shared memory with no static shared memory.
+
+    Without static shared memory the per-function default dynamic limit is the
+    full 48 KiB, so requesting exactly 48 KiB sits right at the boundary. This
+    guards the boundary behaviour of the launcher's opt-in logic.
+    """
+
+    DYN_BYTES = 48 * 1024  # exactly 48 KiB
+    BLOCK_SIZE = 128
+
+    @cuda.jit
+    def k(out):
+        smem = cuda.shared_array(0, dtype=types.uint8)
+        i = cuda.threadIdx.x
+        if i < smem.size:
+            smem[i] = types.uint8(i)
+        cuda.syncthreads()
+        if i == 0:
+            out[0] = 1
+
+    out = cuda.to_device(np.zeros(1, dtype=np.int32))
+
+    k[1, BLOCK_SIZE, 0, DYN_BYTES](out)
+    cuda.synchronize()
+
+    np.testing.assert_array_equal(out.copy_to_host(), np.array([1], dtype=np.int32))
+
+
+def _max_optin_shared_memory(device_id=0):
+    """Return the device's maximum opt-in dynamic shared memory per block."""
+    err, device = driver.cuDeviceGet(device_id)
+    assert err == driver.CUresult.CUDA_SUCCESS, err
+    err, max_optin = driver.cuDeviceGetAttribute(
+        driver.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        device,
+    )
+    assert err == driver.CUresult.CUDA_SUCCESS, err
+    return max_optin
+
+
+def test_shared_memory_exceeds_device_limit():
+    """Requesting more shared memory than the device allows must raise a clear error.
+
+    The launcher opts in to the larger dynamic shared memory limit, but clamps
+    the request to the device's maximum opt-in size. When the request exceeds
+    that maximum we should surface a descriptive ValueError instead of an opaque
+    CUDA_ERROR_INVALID_VALUE from the driver.
+    """
+
+    max_optin = _max_optin_shared_memory()
+    too_much = max_optin + 1024  # 1 KiB over what the device supports
+    BLOCK_SIZE = 128
+
+    @cuda.jit
+    def k(out):
+        smem = cuda.shared_array(0, dtype=types.uint8)
+        i = cuda.threadIdx.x
+        if i < smem.size:
+            smem[i] = types.uint8(i)
+        cuda.syncthreads()
+        if i == 0:
+            out[0] = 1
+
+    out = cuda.to_device(np.zeros(1, dtype=np.int32))
+
+    with pytest.raises(ValueError, match="exceeds the device maximum opt-in shared memory"):
+        k[1, BLOCK_SIZE, 0, too_much](out)
+        cuda.synchronize()
+
+
+def test_shared_memory_dynamic_plus_static_exceeds_device_limit():
+    """Dynamic + static shared memory must be checked against the device limit.
+
+    The device opt-in limit covers the total per-block shared memory (static +
+    dynamic). A request for exactly ``max_optin`` bytes of dynamic shared memory
+    fits on its own, but once the kernel's static shared memory is added the
+    block exceeds the device limit. The launcher must account for the static
+    usage and raise a descriptive ValueError rather than over-requesting and
+    failing at launch with an opaque CUDA_ERROR_INVALID_VALUE.
+    """
+
+    max_optin = _max_optin_shared_memory()
+    # Fits as dynamic-only (<= max_optin) but overflows once static is added.
+    dyn_bytes = max_optin
+    BLOCK_SIZE = 128
+
+    @cuda.jit
+    def k(out):
+        # Static shared memory consumes part of the per-block budget. It must be
+        # written and read so the compiler retains it (and reports a nonzero
+        # static shared size).
+        flag = cuda.shared_array((16,), dtype=types.uint8)
+        smem = cuda.shared_array(0, dtype=types.uint8)
+        i = cuda.threadIdx.x
+        if i < 16:
+            flag[i] = types.uint8(i)
+        cuda.syncthreads()
+        if i < smem.size:
+            smem[i] = flag[i % 16]
+        cuda.syncthreads()
+        if i == 0:
+            out[0] = types.int32(flag[0])
+
+    out = cuda.to_device(np.zeros(1, dtype=np.int32))
+
+    with pytest.raises(ValueError, match="static shared memory"):
+        k[1, BLOCK_SIZE, 0, dyn_bytes](out)
+        cuda.synchronize()
+
+
 if __name__ == "__main__":
     test_shared_memory_96kb()
+    test_shared_memory_exactly_48kb_with_static_smem()
+    test_shared_memory_exactly_48kb_no_static_smem()
+    test_shared_memory_exceeds_device_limit()
+    test_shared_memory_dynamic_plus_static_exceeds_device_limit()


### PR DESCRIPTION
# Fix dynamic shared memory launch failures at/above the 48 KiB threshold

Fixes #143

## Summary

A kernel that requests exactly **48 KiB** (or any amount above its per-function
default) of dynamic shared memory failed to launch with
`CUDA_ERROR_INVALID_VALUE`. The launcher only opted in to the larger dynamic
shared memory limit when `sharedmem > 48 * 1024`, so the usable window
`[default_dynamic_limit, 48 KiB]` was unreachable: the driver already rejects a
48 KiB request once any static shared memory is present, but the opt-in was
gated behind `> 48 KiB`.

## Root cause

In `cext/launcher/kernel.cpp` the opt-in was gated on a hard-coded constant:

```cpp
if (sharedmem > 48 * 1024) {
    g_cuFuncSetAttribute(cu_function,
                         CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                         sharedmem);
}