### PR TITLE
Add dump nvvm env

### DIFF
--- a/cext/mlir-llvm70/lib/CAPI.cpp
+++ b/cext/mlir-llvm70/lib/CAPI.cpp
@@ -116,6 +116,72 @@ int llvm70_translate_gpu_module_from_op(
   }
 }
 
+/// Translate a gpu.module Operation* to old (LLVM 7 dialect) NVVM IR text.
+/// This is the IR that would be handed to libnvvm by
+/// llvm70_translate_gpu_module_from_op; exposing it lets callers dump the
+/// NVVM IR for debugging (e.g. NUMBA_CUDA_MLIR_DUMP_NVVM) without compiling
+/// to PTX. libnvvm/libdevice are not needed because no compilation happens.
+int llvm70_translate_gpu_module_to_nvvm_ir_from_op(
+    void *raw_op,
+    const char *chip, const char *data_layout,
+    const char *libllvm, int gen_lineinfo,
+    char **out, size_t *out_len, char **err_out) {
+
+  *out = nullptr;
+  *out_len = 0;
+  *err_out = nullptr;
+
+  if (!raw_op) {
+    *err_out = copyCString("null Operation*");
+    return 1;
+  }
+
+  auto *op = static_cast<mlir::Operation *>(raw_op);
+  auto gpuMod = mlir::dyn_cast<mlir::gpu::GPUModuleOp>(op);
+  if (!gpuMod) {
+    *err_out = copyCString("Operation is not a gpu.module");
+    return 1;
+  }
+
+  llvm70::LLVM70Options opts;
+  opts.chip = chip ? chip : "sm_80";
+  opts.dataLayout = (data_layout && data_layout[0]) ? data_layout
+                                                    : kDefaultDataLayout;
+  if (libllvm && libllvm[0]) opts.libLLVMPath = libllvm;
+  opts.debugLevel = gen_lineinfo;  // 0=none, 1=lineinfo, 2=full debug
+
+  llvm::install_fatal_error_handler(fatalErrorHandler, nullptr);
+
+  try {
+    auto irOrErr = llvm70::translateToNVVMIR(gpuMod, opts);
+    llvm::remove_fatal_error_handler();
+
+    if (!irOrErr) {
+      std::string msg = llvm::toString(irOrErr.takeError());
+      *err_out = copyCString(msg.c_str());
+      return 1;
+    }
+
+    const std::string &ir = *irOrErr;
+    *out = static_cast<char *>(malloc(ir.size()));
+    if (!*out) {
+      *err_out = copyCString("malloc failed");
+      return 1;
+    }
+    memcpy(*out, ir.data(), ir.size());
+    *out_len = ir.size();
+    return 0;
+  } catch (const std::exception &e) {
+    llvm::remove_fatal_error_handler();
+    *err_out = copyCString(e.what());
+    return 1;
+  } catch (...) {
+    llvm::remove_fatal_error_handler();
+    *err_out = copyCString("unknown exception");
+    return 1;
+  }
+}
+
 void llvm70_free(void *ptr) { free(ptr); }
 
 } // extern "C"

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ctypes
+import itertools
 import os
+import sys
 from io import StringIO
+from pathlib import Path
 
 from numba_cuda_mlir._mlir.passmanager import PassManager
 from numba_cuda_mlir._mlir.dialects import llvm
@@ -246,6 +249,54 @@ def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
     return result
 
 
+_nvvm_dump_counter = itertools.count()
+
+# Bitcode magic ('BC' 0xC0 0xDE). libnvvm input is usually serialized bitcode,
+# but may also be textual LLVM IR depending on the serialization path.
+_BITCODE_MAGIC = b"BC\xc0\xde"
+
+
+def _maybe_dump_nvvm(nvvm_ir: bytes) -> None:
+    """Dump the NVVM IR fed to libnvvm when NUMBA_CUDA_MLIR_DUMP_NVVM is set.
+
+    The behaviour is controlled by ``config.CUDA_DUMP_NVVM`` (the
+    ``NUMBA_CUDA_MLIR_DUMP_NVVM`` environment variable), which may be set to
+    ``1``/``true``/``yes``/``stderr`` to print to stderr, or to a file or
+    directory path to write the IR to disk. Textual IR is written with a
+    ``.ll`` suffix; bitcode is written with a ``.bc`` suffix.
+    """
+    from numba_cuda_mlir.numba_cuda import config
+
+    target = config.CUDA_DUMP_NVVM
+    if not target:
+        return
+
+    is_bitcode = nvvm_ir[:4] == _BITCODE_MAGIC
+
+    if target.lower() in {"1", "true", "yes", "stderr"}:
+        if is_bitcode:
+            print(
+                f"=============== NVVM IR (bitcode, {len(nvvm_ir)} bytes) ===============\n"
+                "Set NUMBA_CUDA_MLIR_DUMP_NVVM=<file|dir> to write the bitcode to disk.\n",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"=============== NVVM IR ===============\n\n"
+                f"{nvvm_ir.decode('utf-8', errors='replace')}\n",
+                file=sys.stderr,
+            )
+        return
+
+    path = Path(target)
+    if path.exists() and path.is_dir():
+        ext = "bc" if is_bitcode else "ll"
+        name = f"nvvm-{os.getpid()}-{next(_nvvm_dump_counter)}.{ext}"
+        path = path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(nvvm_ir)
+
+
 def _operation_to_text(operation, *, preserve_debug_info=False) -> str:
     if not preserve_debug_info:
         return str(operation)
@@ -269,13 +320,15 @@ def _prepare_llvm_ir(module, dump=False, preserve_debug_info=False) -> bytes:
     ctk_major, ctk_minor = get_cuda_runtime_version()
 
     if os.name == "nt":
-        return translate_gpu_module_to_libnvvm_ir(
+        nvvm_ir = translate_gpu_module_to_libnvvm_ir(
             _operation_to_text(gpu_mod.operation, preserve_debug_info=preserve_debug_info),
             ctk_major,
             ctk_minor,
             dump=dump,
             emit_text_ir=preserve_debug_info,
         )
+        _maybe_dump_nvvm(nvvm_ir)
+        return nvvm_ir
 
     from numba_cuda_mlir._cext import downgrade_for_libnvvm
 
@@ -284,7 +337,9 @@ def _prepare_llvm_ir(module, dump=False, preserve_debug_info=False) -> bytes:
     if dump:
         print(f"=============== LLVM IR ===============\n\n{dump_llvmir(llvm_mod)}\n\n")
 
-    return downgrade_for_libnvvm(llvm_mod, llvm_ctx, ctk_major, ctk_minor, LLVM_C_LIB_PATH)
+    nvvm_ir = downgrade_for_libnvvm(llvm_mod, llvm_ctx, ctk_major, ctk_minor, LLVM_C_LIB_PATH)
+    _maybe_dump_nvvm(nvvm_ir)
+    return nvvm_ir
 
 
 def _nvvm_options(cc: str, target_options=None, **extra) -> dict:

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -149,6 +149,17 @@ def _get_llvm70_capi():
         ctypes.POINTER(ctypes.c_size_t),  # out_len
         ctypes.POINTER(ctypes.c_char_p),  # err_out
     ]
+    lib.llvm70_translate_gpu_module_to_nvvm_ir_from_op.restype = ctypes.c_int
+    lib.llvm70_translate_gpu_module_to_nvvm_ir_from_op.argtypes = [
+        ctypes.c_void_p,  # raw_op (Operation*)
+        ctypes.c_char_p,  # chip
+        ctypes.c_char_p,  # data_layout
+        ctypes.c_char_p,  # libllvm
+        ctypes.c_int,  # gen_lineinfo
+        ctypes.POINTER(ctypes.c_char_p),  # out
+        ctypes.POINTER(ctypes.c_size_t),  # out_len
+        ctypes.POINTER(ctypes.c_char_p),  # err_out
+    ]
     lib.llvm70_free.restype = None
     lib.llvm70_free.argtypes = [ctypes.c_void_p]
     _llvm70_capi = lib
@@ -169,6 +180,45 @@ def _get_op_ptr(op) -> ctypes.c_void_p:
     ptr.restype = ctypes.c_void_p
     ptr.argtypes = [ctypes.py_object, ctypes.c_char_p]
     return ptr(capsule, b"numba_cuda_mlir._mlir.ir.Operation._CAPIPtr")
+
+
+def _maybe_dump_llvm70_nvvm(lib, raw_op, chip, libllvm, debug_level) -> None:
+    """Dump the LLVM70-path NVVM IR when NUMBA_CUDA_MLIR_DUMP_NVVM is set.
+
+    The CAPI translates straight to PTX/LTOIR, so the NVVM IR is regenerated
+    here via the text-only entry point and routed through ``_maybe_dump_nvvm``.
+    """
+    from numba_cuda_mlir.numba_cuda import config
+
+    if not config.CUDA_DUMP_NVVM:
+        return
+
+    out = ctypes.c_char_p()
+    out_len = ctypes.c_size_t()
+    err_out = ctypes.c_char_p()
+
+    rc = lib.llvm70_translate_gpu_module_to_nvvm_ir_from_op(
+        raw_op,
+        chip.encode(),
+        None,
+        libllvm.encode(),
+        debug_level,
+        ctypes.byref(out),
+        ctypes.byref(out_len),
+        ctypes.byref(err_out),
+    )
+
+    if rc != 0:
+        msg = err_out.value.decode() if err_out.value else "unknown error"
+        if err_out.value:
+            lib.llvm70_free(err_out)
+        raise RuntimeError(f"llvm70 NVVM IR generation failed: {msg}")
+
+    try:
+        _maybe_dump_nvvm(ctypes.string_at(out, out_len.value))
+    finally:
+        if out.value:
+            lib.llvm70_free(out)
 
 
 def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
@@ -218,6 +268,11 @@ def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
         debug_level = 1
     else:
         debug_level = 0
+
+    # Dump the (LLVM 7 dialect) NVVM IR before compiling to PTX/LTO, if
+    # requested. The CAPI PTX/LTO entry point keeps the NVVM IR internal, so we
+    # regenerate it via a dedicated translation that skips libnvvm compilation.
+    _maybe_dump_llvm70_nvvm(lib, raw_op, chip, libllvm, debug_level)
 
     out = ctypes.c_char_p()
     out_len = ctypes.c_size_t()

--- a/src/numba_cuda_mlir/numba_cuda/core/config.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/config.py
@@ -463,6 +463,11 @@ class _EnvReloader:
         # vector type) stores: when set, force opt_level=0 on LTO links
         CUDA_DISABLE_LTO_OPT = _readenv("NUMBA_CUDA_MLIR_DISABLE_LTO_OPT", int, 0)
 
+        # Dump the NVVM IR fed to libnvvm before PTX/LTO generation. Set to
+        # "1"/"true"/"yes"/"stderr" to print to stderr, or to a file or
+        # directory path to write the IR to disk.
+        CUDA_DUMP_NVVM = _readenv("NUMBA_CUDA_MLIR_DUMP_NVVM", str, "")
+
         # Whether the default stream is the per-thread default stream
         CUDA_PER_THREAD_DEFAULT_STREAM = _readenv("NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM", int, 0)
 

--- a/tests/test_dump_nvvm.py
+++ b/tests/test_dump_nvvm.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from numba_cuda_mlir import mlir_optimization
+from numba_cuda_mlir.numba_cuda import config
+
+BITCODE = b"BC\xc0\xde\x00\x01\x02\x03"
+TEXT_IR = b"; ModuleID = 'kernel'\ndefine void @foo() {\n  ret void\n}\n"
+
+
+@pytest.fixture
+def dump_nvvm(monkeypatch):
+    """Set config.CUDA_DUMP_NVVM for the duration of a test."""
+
+    def _set(value):
+        monkeypatch.setattr(config, "CUDA_DUMP_NVVM", value)
+
+    return _set
+
+
+def test_dump_nvvm_disabled_is_noop(dump_nvvm, tmp_path, capsys):
+    dump_nvvm("")
+    mlir_optimization._maybe_dump_nvvm(BITCODE)
+    assert capsys.readouterr().err == ""
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_dump_nvvm_text_to_stderr(dump_nvvm, capsys):
+    dump_nvvm("stderr")
+    mlir_optimization._maybe_dump_nvvm(TEXT_IR)
+    err = capsys.readouterr().err
+    assert "NVVM IR" in err
+    assert "define void @foo()" in err
+
+
+def test_dump_nvvm_bitcode_to_stderr_is_summarized(dump_nvvm, capsys):
+    dump_nvvm("1")
+    mlir_optimization._maybe_dump_nvvm(BITCODE)
+    err = capsys.readouterr().err
+    assert "bitcode" in err
+    assert f"{len(BITCODE)} bytes" in err
+
+
+def test_dump_nvvm_bitcode_to_directory(dump_nvvm, tmp_path):
+    dump_nvvm(str(tmp_path))
+    mlir_optimization._maybe_dump_nvvm(BITCODE)
+    dumps = list(tmp_path.iterdir())
+    assert len(dumps) == 1
+    assert dumps[0].suffix == ".bc"
+    assert dumps[0].read_bytes() == BITCODE
+
+
+def test_dump_nvvm_text_to_directory(dump_nvvm, tmp_path):
+    dump_nvvm(str(tmp_path))
+    mlir_optimization._maybe_dump_nvvm(TEXT_IR)
+    dumps = list(tmp_path.iterdir())
+    assert len(dumps) == 1
+    assert dumps[0].suffix == ".ll"
+    assert dumps[0].read_bytes() == TEXT_IR
+
+
+def test_dump_nvvm_to_explicit_file(dump_nvvm, tmp_path):
+    target = tmp_path / "nested" / "out.bc"
+    dump_nvvm(str(target))
+    mlir_optimization._maybe_dump_nvvm(BITCODE)
+    assert target.read_bytes() == BITCODE


### PR DESCRIPTION
# Add `NUMBA_CUDA_MLIR_DUMP_NVVM` to dump NVVM IR before PTX/LTO generation

## Summary

Adds a new `NUMBA_CUDA_MLIR_DUMP_NVVM` environment variable that dumps the NVVM
IR (the LLVM IR actually handed to libnvvm) right before PTX/LTOIR is generated.
This is a debugging aid for inspecting exactly what the compiler feeds into
libnvvm, after MLIR lowering and the libnvvm-compatibility downgrades have been
applied.

## Motivation

We could already dump the MLIR module and the pre-downgrade LLVM IR, but there
was no way to capture the final NVVM IR that libnvvm consumes. When diagnosing
codegen/libnvvm issues, having that exact input is the most useful artifact.

## What changed

- **`config.py`**: Register the variable through the standard config machinery as
  `config.CUDA_DUMP_NVVM` (alongside the other `NUMBA_CUDA_MLIR_*` options), so it
  benefits from env reload and `.numba_config.yaml` support.
- **`mlir_optimization.py`**: Add a `_maybe_dump_nvvm()` helper and call it from
  `_prepare_llvm_ir()`. Since `_prepare_llvm_ir()` produces the bytes consumed by
  both `_compile_to_ptx()` and `_compile_to_ltoir()`, a single hook covers both
  the regular PTX path and the LTO path, as well as the `get_ptx()` / `optimize()`
  entry points.
- **`tests/test_dump_nvvm.py`**: Unit tests for the helper (no GPU required).

## Usage

| Value | Behavior |
| --- | --- |
| _(unset / empty)_ | Disabled (default, no-op) |
| `1`, `true`, `yes`, `stderr` | Print to stderr |
| `<directory>` | Write to `<dir>/nvvm-<pid>-<n>.{bc,ll}` |
| `<file>` | Write to that exact path (parent dirs created) |

The libnvvm input is usually serialized **bitcode**, so the helper detects the
bitcode magic (`BC\xC0\xDE`): on-disk dumps use a `.bc` suffix for bitcode and
`.ll` for textual IR. When printing to stderr, bitcode is summarized (byte count)
rather than dumped as raw binary, while textual IR is printed in full.

```bash
# Print to stderr
NUMBA_CUDA_MLIR_DUMP_NVVM=1 python my_kernel.py

# Write each compilation's NVVM IR into a directory
NUMBA_CUDA_MLIR_DUMP_NVVM=/tmp/nvvm-dumps python my_kernel.py