### PR TITLE
Support compile-time tuple slicing

### DIFF
--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -1399,6 +1399,16 @@ def lower_uni_tuple_getitem(builder, target, args, kwargs):
             raise InternalCompilerError(f"Tuple index must be an integer, got {type(args[1])}")
 
 
+@lower("static_getitem", types.UniTuple, types.SliceLiteral)
+@lower("static_getitem", types.Tuple, types.SliceLiteral)
+def lower_static_tuple_slice(builder, target, args, kwargs):
+    tup = builder.load_var(args[0])
+    index = args[1]
+    assert isinstance(tup, tuple), f"Expected Python tuple, got {type(tup)}"
+    assert isinstance(index, slice), f"Expected slice, got {type(index)}"
+    builder.store_var(target, tup[index])
+
+
 def _lower_record_array_setitem(builder, target, args, kwargs):
     """
     Handle array[index] = record where array.dtype is Record.

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1303,10 +1303,7 @@ extern "C" __global__ void
             case "static_getitem":
                 value_type = self.get_numba_type(expr.value.name)
                 index = expr.index
-                if (
-                    not isinstance(value_type, types.BaseTuple)
-                    and expr.index_var is not None
-                ):
+                if not isinstance(value_type, types.BaseTuple) and expr.index_var is not None:
                     index = expr.index_var
                 self.lower_getitem_expr_assign(target, expr.value, index)
             case "call":

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1301,8 +1301,13 @@ extern "C" __global__ void
             case "getitem" | "typed_getitem":
                 self.lower_getitem_expr_assign(target, expr.value, expr.index)
             case "static_getitem":
-                # For static_getitem, use index_var if available, otherwise use the constant index
-                index = expr.index_var if expr.index_var is not None else expr.index
+                value_type = self.get_numba_type(expr.value.name)
+                index = expr.index
+                if (
+                    not isinstance(value_type, types.BaseTuple)
+                    and expr.index_var is not None
+                ):
+                    index = expr.index_var
                 self.lower_getitem_expr_assign(target, expr.value, index)
             case "call":
                 args = list(expr.args)
@@ -1561,7 +1566,9 @@ extern "C" __global__ void
         value_type = self.get_numba_type(value.name)
         match index:
             case int():
-                index_type = types.int64
+                index_type = types.IntegerLiteral(index)
+            case slice():
+                index_type = numba_types.SliceLiteral(index)
             case str():
                 index_type = types.StringLiteral(index)
             case numba_ir.Var():

--- a/tests/numba_cuda_tests/cudapy/test_array_args.py
+++ b/tests/numba_cuda_tests/cudapy/test_array_args.py
@@ -7,7 +7,6 @@ from collections import namedtuple
 import numba_cuda_mlir
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.testing import NumbaCUDATestCase
-import pytest
 
 
 class TestCudaArrayArg(NumbaCUDATestCase):
@@ -103,7 +102,6 @@ class TestCudaArrayArg(NumbaCUDATestCase):
 
         self.assertEqual(r[0], 0)
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_tuple_of_empty_tuples(self):
         @numba_cuda_mlir.cuda.jit
         def f(r, x):
@@ -117,7 +115,6 @@ class TestCudaArrayArg(NumbaCUDATestCase):
         self.assertEqual(r[0], 3)
         self.assertEqual(r[1], 0)
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_tuple_of_tuples(self):
         @numba_cuda_mlir.cuda.jit
         def f(r, x):
@@ -145,7 +142,6 @@ class TestCudaArrayArg(NumbaCUDATestCase):
         self.assertEqual(r[7], 9)
         self.assertEqual(r[8], 10)
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_tuple_of_tuples_and_scalars(self):
         @numba_cuda_mlir.cuda.jit
         def f(r, x):
@@ -183,7 +179,6 @@ class TestCudaArrayArg(NumbaCUDATestCase):
 
         np.testing.assert_equal(x0, x1 + x2)
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_tuple_of_array_scalar_tuple(self):
         @numba_cuda_mlir.cuda.jit
         def f(r, x):

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -7,6 +7,17 @@ import numpy as np
 import pytest
 
 
+def test_compile_time_tuple_slice():
+    @cuda.jit
+    def kernel(out):
+        rev = (2, 4)[::-1]
+        out[0] = rev[0]
+
+    out = np.zeros(1, dtype=np.int64)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, (4,))
+
+
 def test_tuple_builtin_hetero_tuple():
     @cuda.jit
     def k(r_int, r_float, x):
@@ -157,7 +168,6 @@ def test_empty_tuple():
     assert r[0] == 0
 
 
-@pytest.mark.xfail(reason="nested tuple indexing NYI")
 def test_tuple_of_empty_tuples():
     @cuda.jit
     def f(r, x):
@@ -171,7 +181,6 @@ def test_tuple_of_empty_tuples():
     assert r[1] == 0
 
 
-@pytest.mark.xfail(reason="nested tuple indexing NYI")
 def test_tuple_of_tuples():
     @cuda.jit
     def f(r, x):
@@ -192,7 +201,6 @@ def test_tuple_of_tuples():
     np.testing.assert_array_equal(r, expected)
 
 
-@pytest.mark.xfail(reason="nested tuple indexing NYI")
 def test_tuple_of_tuples_and_scalars():
     @cuda.jit
     def f(r, x):
@@ -229,7 +237,6 @@ def test_tuple_of_arrays():
     np.testing.assert_equal(x0, x1 + x2)
 
 
-@pytest.mark.xfail(reason="heterogeneous tuple of arrays/scalars/tuples NYI")
 def test_tuple_of_array_scalar_tuple():
     @cuda.jit
     def f(r, x):


### PR DESCRIPTION
Preserve literal indices for tuple static_getitem while retaining index-variable lowering for other containers (src/numba_cuda_mlir/mlir_lowering.py:1303-1314).

Type integer and slice constants as literals, then lower tuple slices through compile-time Python slicing (src/numba_cuda_mlir/mlir_lowering.py:1567-1583; src/numba_cuda_mlir/lowering/numpy.py:1402-1409).

Closes issue #111 and enable tuple cases that no longer ICE (tests/test_tuple.py:10-18; tests/numba_cuda_tests/cudapy/test_array_args.py:105-190).