### PR TITLE
Support namedtuple unpacking in MLIR lowering

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1568,6 +1568,13 @@ extern "C" __global__ void
                 index_type = self.get_numba_type(index.name)
             case _:
                 raise NotImplementedError(f"lowering getitem {target} = {value}[{index}]")
+
+        if isinstance(value_type, types.BaseNamedTuple) and isinstance(index, int):
+            result = self.load_var(value)[index]
+            self.incref(target_type, result)
+            self.store_var(target, result)
+            return
+
         signature = target_type(value_type, index_type)
         if builder := self.get_registered_builder(operator.getitem, signature):
             builder(self, target, [value, index], [])

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -110,6 +110,20 @@ def test_captured_namedtuple_getattr():
     assert r[0] == np.float32(1)
 
 
+def test_captured_namedtuple_unpack():
+    LD = namedtuple("LD", ["a", "b", "c"])
+    dim = LD(2, 4, 8)
+    out = np.zeros(1, dtype=np.int64)
+
+    @cuda.jit
+    def kernel(out):
+        a, b, c = dim
+        out[0] = a + b + c
+
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, 14)
+
+
 @pytest.mark.parametrize(
     "Point, vals, dtypes",
     [


### PR DESCRIPTION
Extract statically indexed namedtuple elements in lower_getitem_expr_assign so captured namedtuples can unpack in kernels (src/numba_cuda_mlir/mlir_lowering.py:1575).

Add test_captured_namedtuple_unpack to cover compilation and execution of the captured global namedtuple repro (tests/test_tuple.py:124).

Closes #110 