### PR TITLE
Fix nested record field access lowering

### DIFF
--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -1030,16 +1030,15 @@ def lower_array_getitem(builder, target, args, kwargs):
 
     # Check if this is a record array
     array_numba_type = builder.get_numba_type(args[0].name)
-    if isinstance(array_numba_type.dtype, Record):
-        return _lower_record_array_getitem(builder, target, args, kwargs)
-
-    # Check if this is a nested array (embedded in a record)
     from numba_cuda_mlir.types import NestedArray
 
     if isinstance(array_numba_type, NestedArray):
         from numba_cuda_mlir.lowering.record import lower_nested_array_getitem_int
 
         return lower_nested_array_getitem_int(builder, target, args, kwargs)
+
+    if isinstance(array_numba_type.dtype, Record):
+        return _lower_record_array_getitem(builder, target, args, kwargs)
 
     array = builder.load_var(args[0])
     # Handle both variable and constant indices
@@ -1512,16 +1511,15 @@ def lower_array_setitem(builder: MLIRLower, target, args, kwargs):
 
     # Check if this is a record array
     array_numba_type = builder.get_numba_type(args[0].name)
-    if isinstance(array_numba_type.dtype, Record):
-        return _lower_record_array_setitem(builder, target, args, kwargs)
-
-    # Check if this is a nested array (embedded in a record)
     from numba_cuda_mlir.types import NestedArray
 
     if isinstance(array_numba_type, NestedArray):
         from numba_cuda_mlir.lowering.record import lower_nested_array_setitem_int
 
         return lower_nested_array_setitem_int(builder, target, args, kwargs)
+
+    if isinstance(array_numba_type.dtype, Record):
+        return _lower_record_array_setitem(builder, target, args, kwargs)
 
     array = builder.load_var(args[0])
     index = builder.load_var(args[1])

--- a/src/numba_cuda_mlir/lowering/record.py
+++ b/src/numba_cuda_mlir/lowering/record.py
@@ -106,6 +106,8 @@ def lower_record_getattr(
     if isinstance(field_numba_type, NestedArray):
         # Nested array field - create a memref pointing to the data
         result = _load_nested_array_field(builder, field_ptr, field_numba_type, record_type)
+    elif isinstance(field_numba_type, Record):
+        result = field_ptr
     else:
         # Scalar field - load directly
         field_mlir_type = builder.get_mlir_type(field_numba_type)
@@ -333,6 +335,8 @@ def lower_record_static_getitem_str(builder, target, args, kwargs):
 
     if isinstance(field_numba_type, NestedArray):
         result = _load_nested_array_field(builder, field_ptr, field_numba_type, record_type)
+    elif isinstance(field_numba_type, Record):
+        result = field_ptr
     else:
         field_mlir_type = builder.get_mlir_type(field_numba_type)
         field_storage_type = builder.get_storage_type(field_numba_type)
@@ -384,6 +388,8 @@ def lower_record_static_getitem_int(builder, target, args, kwargs):
 
     if isinstance(field_numba_type, NestedArray):
         result = _load_nested_array_field(builder, field_ptr, field_numba_type, record_type)
+    elif isinstance(field_numba_type, Record):
+        result = field_ptr
     else:
         field_mlir_type = builder.get_mlir_type(field_numba_type)
         field_storage_type = builder.get_storage_type(field_numba_type)
@@ -508,7 +514,9 @@ def lower_nested_array_getitem_int(builder, target, args, kwargs):
 
     # Load and return the element
     elem_mlir_type = builder.get_mlir_type(nested_type.dtype)
-    if _is_complex_type(elem_mlir_type):
+    if isinstance(nested_type.dtype, Record):
+        result = elem_ptr
+    elif _is_complex_type(elem_mlir_type):
         struct_type = _get_llvm_struct_for_complex(elem_mlir_type)
         struct_val = llvm.load(struct_type, elem_ptr)
         result = _llvm_struct_to_complex(struct_val, elem_mlir_type)
@@ -591,7 +599,9 @@ def lower_nested_array_getitem_tuple(builder, target, args, kwargs):
 
     # Load and return the element
     elem_mlir_type = builder.get_mlir_type(nested_type.dtype)
-    if _is_complex_type(elem_mlir_type):
+    if isinstance(nested_type.dtype, Record):
+        result = elem_ptr
+    elif _is_complex_type(elem_mlir_type):
         struct_type = _get_llvm_struct_for_complex(elem_mlir_type)
         struct_val = llvm.load(struct_type, elem_ptr)
         result = _llvm_struct_to_complex(struct_val, elem_mlir_type)

--- a/tests/test_record_dtype.py
+++ b/tests/test_record_dtype.py
@@ -28,6 +28,8 @@ recordwithvaluestorage = np.dtype([("h", np.float16), ("flag", np.bool_)], align
 
 nestedrecordwitharray = np.dtype([("inner", [("a", np.float64), ("b", np.float64)], (1,))])
 
+nestedrecordwith2darray = np.dtype([("inner", [("a", np.float64), ("b", np.float64)], (2, 2))])
+
 nestedrecord = np.dtype([("inner", [("a", np.float64), ("b", np.float64)])])
 
 
@@ -275,6 +277,19 @@ class TestRecordFieldAccess:
         np.testing.assert_equal(result[0]["inner"][0]["b"], 22.0)
         np.testing.assert_equal(scalar_result[0]["inner"]["a"], 33.0)
         np.testing.assert_equal(scalar_result[0]["inner"]["b"], 44.0)
+
+    def test_read_tuple_indexed_nested_record_field(self):
+        @cuda.jit
+        def read_field(ary, out):
+            out[0] = ary[0]["inner"][0, 1]["a"]
+
+        arr = np.zeros(1, dtype=nestedrecordwith2darray)
+        arr[0]["inner"][0, 1]["a"] = 42.0
+        arr = cuda.to_device(arr)
+        out = cuda.to_device(np.zeros(1, dtype=np.float64))
+
+        read_field[1, 1](arr, out)
+        np.testing.assert_equal(out.copy_to_host()[0], 42.0)
 
 
 @pytest.mark.skip(reason="Causes memory errors")

--- a/tests/test_record_dtype.py
+++ b/tests/test_record_dtype.py
@@ -26,6 +26,10 @@ recordwith2darray = np.dtype([("i", np.int32), ("j", np.float32, (3, 2))])
 
 recordwithvaluestorage = np.dtype([("h", np.float16), ("flag", np.bool_)], align=True)
 
+nestedrecordwitharray = np.dtype([("inner", [("a", np.float64), ("b", np.float64)], (1,))])
+
+nestedrecord = np.dtype([("inner", [("a", np.float64), ("b", np.float64)])])
+
 
 class TestRecordTypeModel:
     """Test that Record types can be converted to MLIR types."""
@@ -252,6 +256,25 @@ class TestRecordFieldAccess:
         result = arr.copy_to_host()
         np.testing.assert_allclose(result["h"], np.array([1.5, 2.5], dtype=np.float16))
         np.testing.assert_array_equal(result["flag"], np.array([True, False]))
+
+    @pytest.mark.skipif(not cuda.is_available(), reason="CUDA not available")
+    def test_set_nested_record_fields(self):
+        @cuda.jit
+        def set_fields(ary, scalar_ary):
+            ary[0]["inner"][0]["a"] = 11.0
+            ary[0]["inner"][0]["b"] = 22.0
+            scalar_ary[0]["inner"]["a"] = 33.0
+            scalar_ary[0]["inner"]["b"] = 44.0
+
+        arr = cuda.to_device(np.zeros(2, dtype=nestedrecordwitharray))
+        scalar_arr = cuda.to_device(np.zeros(2, dtype=nestedrecord))
+        set_fields[1, 1](arr, scalar_arr)
+        result = arr.copy_to_host()
+        scalar_result = scalar_arr.copy_to_host()
+        np.testing.assert_equal(result[0]["inner"][0]["a"], 11.0)
+        np.testing.assert_equal(result[0]["inner"][0]["b"], 22.0)
+        np.testing.assert_equal(scalar_result[0]["inner"]["a"], 33.0)
+        np.testing.assert_equal(scalar_result[0]["inner"]["b"], 44.0)
 
 
 @pytest.mark.skip(reason="Causes memory errors")


### PR DESCRIPTION
Dispatch NestedArray access before record-array lowering and preserve nested Record addresses instead of loading them as pointer values (src/numba_cuda_mlir/lowering/numpy.py:1033, src/numba_cuda_mlir/lowering/record.py:109).

Cover shaped and direct nested structured-dtype field writes (tests/test_record_dtype.py:263).

This closes #156.