### PR TITLE
[Debug Info] Fix bitwise logic ops result types

### DIFF
--- a/src/numba_cuda_mlir/numba_cuda/typing/builtins.py
+++ b/src/numba_cuda_mlir/numba_cuda/typing/builtins.py
@@ -170,6 +170,17 @@ def choose_result_int(*inputs):
     return types.Integer.from_bitwidth(bitwidth, signed)
 
 
+def choose_result_int_bitwise(*inputs):
+    """Choose the integer result type for bitwise logic ops (&, |, ^).
+
+    Unlike choose_result_int, this does not enforce a minimum width of
+    ``intp``.
+    """
+    bitwidth = max(tp.bitwidth for tp in inputs)
+    signed = any(tp.signed for tp in inputs)
+    return types.Integer.from_bitwidth(bitwidth, signed)
+
+
 # The "machine" integer types to take into consideration for operator typing
 # (according to the integer typing NBEP)
 machine_ints = sorted(set((types.intp, types.int64))) + sorted(set((types.uintp, types.uint64)))
@@ -179,6 +190,14 @@ machine_ints = sorted(set((types.intp, types.int64))) + sorted(set((types.uintp,
 integer_binop_cases = tuple(
     signature(choose_result_int(op1, op2), op1, op2)
     for op1, op2 in itertools.product(machine_ints, machine_ints)
+)
+
+# Bitwise logic cases cover all machine-integer widths so that narrower
+# types are matched exactly and not widened to int64.
+_all_integer_types = sorted(types.signed_domain) + sorted(types.unsigned_domain)
+integer_bitwise_cases = tuple(
+    signature(choose_result_int_bitwise(op1, op2), op1, op2)
+    for op1, op2 in itertools.product(_all_integer_types, _all_integer_types)
 )
 
 
@@ -295,9 +314,9 @@ class BitwiseRightShift(BitwiseShiftOperation):
     pass
 
 
-class BitwiseLogicOperation(BinOp):
+class BitwiseLogicOperation(ConcreteTemplate):
     cases = [signature(types.boolean, types.boolean, types.boolean)]
-    cases += list(integer_binop_cases)
+    cases += list(integer_bitwise_cases)
     unsafe_casting = False
 
 

--- a/tests/test_debuginfo.py
+++ b/tests/test_debuginfo.py
@@ -774,3 +774,31 @@ def test_mlir_poly_scalar_var_runtime_debug():
         out = cuda.device_array(1, dtype=np.float64)
         kernel[1, 1](out, *flags)
         assert out.copy_to_host()[0] == expected
+
+
+def test_mlir_di_bitwise_result_int32():
+    """Bitwise AND/OR/XOR on int32 operands must appear as int32 in DWARF (nvbug5936795)."""
+
+    def k(out, a, b):
+        result_and = a & b
+        result_or = a | b
+        result_xor = a ^ b
+        out[0] = result_and
+        out[1] = result_or
+        out[2] = result_xor
+
+    mlir = compiler.compile_mlir(
+        k,
+        types.void(types.int32[:], types.int32, types.int32),
+        debug=True,
+        opt=False,
+    )
+    testing.filecheck(
+        """
+        CHECK: #[[INT32:di_basic_type[0-9]*]] = #llvm.di_basic_type<{{.*}}name = "int32"{{.*}}sizeInBits = 32{{.*}}DW_ATE_signed
+        CHECK: di_local_variable<{{.*}}name = "result_and"{{.*}}type = #[[INT32]]
+        CHECK: di_local_variable<{{.*}}name = "result_or"{{.*}}type = #[[INT32]]
+        CHECK: di_local_variable<{{.*}}name = "result_xor"{{.*}}type = #[[INT32]]
+        """,
+        mlir,
+    )


### PR DESCRIPTION
When a CUDA kernel applies a bitwise logic operator (`&`, `|`, `^`) to two `int32` operands, the result variable is annotated as `int64` in the DWARF debug information. This widening is part of Numba's integer typing NBEP, intentional for arithmetic operators, but it is unnecessary for bitwise operators: AND, OR, and XOR. The result of a bitwise operation always fits in the wider of the two operand types, so no promotion is needed.