### PR TITLE
Merge LTO error-code globals with common linkage

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -388,7 +388,7 @@ class MLIRLower(object):
             )
             if not already_exists:
                 with ir.InsertionPoint.at_block_begin(gpu_block):
-                    linkage = ir.Attribute.parse("#llvm.linkage<external>")
+                    linkage = ir.Attribute.parse("#llvm.linkage<common>")
                     llvm.GlobalOp(
                         T.i32(),
                         ERROR_CODE_GLOBAL_NAME,

--- a/tests/test_kernel_exceptions.py
+++ b/tests/test_kernel_exceptions.py
@@ -6,6 +6,9 @@
 import numpy as np
 import pytest
 from numba_cuda_mlir import cuda
+from numba_cuda_mlir.numba_cuda import require_context, types
+from numba_cuda_mlir.numba_cuda.testing import skip_if_nvjitlink_missing
+from numba_cuda_mlir.tools import get_gpu_compute_capability
 
 
 @cuda.jit
@@ -55,7 +58,48 @@ def test_error_global_in_ptx():
     ptx, _ = compile_ptx(tuple_bounds_check_kernel, sig)
 
     assert "__numba_cuda_mlir_error_code" in ptx, "Error global not found in PTX"
-    assert ".visible .global" in ptx, "Error global should be visible"
+    assert ".common .global" in ptx, "Error global should be common"
+
+
+@skip_if_nvjitlink_missing("nvJitLink missing")
+@require_context
+def test_ltoir_device_functions_share_error_global():
+    """Independently compiled device functions can be linked together."""
+
+    def op_a(x):
+        return x + 1
+
+    def op_b(x):
+        return x + 2
+
+    signature = types.int32(types.int32)
+    lto_a, _ = cuda.compile(
+        op_a,
+        signature,
+        device=True,
+        abi="c",
+        abi_info={"abi_name": "op_a"},
+        output="ltoir",
+    )
+    lto_b, _ = cuda.compile(
+        op_b,
+        signature,
+        device=True,
+        abi="c",
+        abi_info={"abi_name": "op_b"},
+        output="ltoir",
+    )
+    major, minor = get_gpu_compute_capability(tuple)
+
+    from cuda.bindings import nvjitlink
+
+    handle = nvjitlink.create(2, ["-lto", f"-arch=sm_{major}{minor}"])
+    try:
+        nvjitlink.add_data(handle, nvjitlink.InputType.LTOIR, lto_a, len(lto_a), "op_a")
+        nvjitlink.add_data(handle, nvjitlink.InputType.LTOIR, lto_b, len(lto_b), "op_b")
+        nvjitlink.complete(handle)
+    finally:
+        nvjitlink.destroy(handle)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use common linkage for the mutable zero-initialized error-code global so nvJitLink can merge definitions from independently compiled device-function LTOIR objects. The global remains available for host error reporting (src/numba_cuda_mlir/mlir_lowering.py:391).

Assert the emitted common PTX global and link two separately compiled LTOIR device functions in one nvJitLink invocation (tests/test_kernel_exceptions.py:52, tests/test_kernel_exceptions.py:64).

This closes #119.