### PR TITLE
Add native complex32 type support

### DIFF
--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -132,7 +132,8 @@ def _lower_array_complex_real_imag(builder, target, array_var, attr):
     complex_array = builder.load_var(array_var)
     array_type = complex_array.type
     rank = array_type.rank
-    float_type = array_type.element_type.element_type
+    array_numba_type = builder.get_numba_type(array_var.name)
+    float_type = builder.get_storage_type(array_numba_type.dtype.underlying_float)
 
     dyn = ir.ShapedType.get_dynamic_size()
     dyn_s = ir.ShapedType.get_dynamic_stride_or_offset()

--- a/src/numba_cuda_mlir/numba_cuda/np/numpy_support.py
+++ b/src/numba_cuda_mlir/numba_cuda/np/numpy_support.py
@@ -194,7 +194,10 @@ def as_dtype(nbtype):
     """
     nbtype = types.unliteral(nbtype)
     if isinstance(nbtype, (types.Complex, types.Integer, types.Float)):
-        return np.dtype(str(nbtype))
+        try:
+            return np.dtype(str(nbtype))
+        except TypeError as exc:
+            raise errors.NumbaNotImplementedError(nbtype) from exc
     if isinstance(nbtype, (types.Boolean)):
         return np.dtype("?")
     if isinstance(nbtype, (types.NPDatetime, types.NPTimedelta)):

--- a/src/numba_cuda_mlir/numba_cuda/typeconv/rules.py
+++ b/src/numba_cuda_mlir/numba_cuda/typeconv/rules.py
@@ -49,9 +49,11 @@ def _init_casting_rules(tm):
     tcr.promote_unsafe(types.float16, types.float32)
     tcr.promote_unsafe(types.float32, types.float64)
 
+    tcr.safe(types.float16, types.complex32)
     tcr.safe(types.float32, types.complex64)
     tcr.safe(types.float64, types.complex128)
 
+    tcr.promote_unsafe(types.complex32, types.complex64)
     tcr.promote_unsafe(types.complex64, types.complex128)
 
     # Allow integers to cast ot void*

--- a/src/numba_cuda_mlir/numba_cuda/types/__init__.py
+++ b/src/numba_cuda_mlir/numba_cuda/types/__init__.py
@@ -79,6 +79,7 @@ float32 = Float("float32")
 float64 = Float("float64")
 float16 = Float("float16")
 
+complex32 = Complex("complex32", float16)
 complex64 = Complex("complex64", float32)
 complex128 = Complex("complex128", float64)
 
@@ -93,7 +94,7 @@ signed_domain = frozenset([int8, int16, int32, int64])
 unsigned_domain = frozenset([uint8, uint16, uint32, uint64])
 integer_domain = signed_domain | unsigned_domain
 real_domain = frozenset([float32, float64])
-complex_domain = frozenset([complex64, complex128])
+complex_domain = frozenset([complex32, complex64, complex128])
 number_domain = real_domain | integer_domain | complex_domain
 
 # Integer Aliases
@@ -184,6 +185,7 @@ all_str = """
     boolean
     float32
     float64
+    complex32
     complex64
     complex128
     bool_

--- a/src/numba_cuda_mlir/numba_cuda/types/abstract.py
+++ b/src/numba_cuda_mlir/numba_cuda/types/abstract.py
@@ -267,15 +267,22 @@ class Number(Hashable):
         """
         Unify the two number types using Numpy's rules.
         """
+        from numba_cuda_mlir.numba_cuda import types
         from numba_cuda_mlir.numba_cuda.np import numpy_support
 
         if isinstance(other, Number):
             # XXX: this can produce unsafe conversions,
             # e.g. would unify {int64, uint64} to float64
-            a = numpy_support.as_dtype(self)
-            b = numpy_support.as_dtype(other)
+            has_complex32 = types.complex32 in (self, other)
+            a = numpy_support.as_dtype(self.underlying_float if self == types.complex32 else self)
+            b = numpy_support.as_dtype(
+                other.underlying_float if other == types.complex32 else other
+            )
             sel = np.promote_types(a, b)
-            return numpy_support.from_dtype(sel)
+            unified = numpy_support.from_dtype(sel)
+            if has_complex32 and isinstance(unified, types.Float):
+                return next(ty for ty in types.complex_domain if ty.underlying_float == unified)
+            return unified
 
 
 class Callable(Type):

--- a/src/numba_cuda_mlir/numba_cuda/typing/npydecl.py
+++ b/src/numba_cuda_mlir/numba_cuda/typing/npydecl.py
@@ -508,7 +508,9 @@ for func in ["sum", "argsort", "nonzero", "ravel"]:
 # Numpy scalar constructors
 
 # Register np.int8, etc. as converters to the equivalent Numba types
-np_types = set(getattr(np, str(nb_type)) for nb_type in types.number_domain)
+np_types = set(
+    getattr(np, str(nb_type)) for nb_type in types.number_domain if hasattr(np, str(nb_type))
+)
 np_types.add(np.bool_)
 # Those may or may not be aliases (depending on the Numpy build / version)
 np_types.add(np.intc)

--- a/src/numba_cuda_mlir/types.py
+++ b/src/numba_cuda_mlir/types.py
@@ -67,6 +67,7 @@ from numba_cuda_mlir.numba_cuda.types import (
     uint16,
     uint32,
     uint64,
+    complex32,
     complex64,
     complex128,
     bool,

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -118,6 +118,28 @@ def test_shared_memory_complex_real_imag(complex_dtype, float_dtype):
     np.testing.assert_allclose(out_imag, inp.imag)
 
 
+def test_shared_memory_complex32_real_imag():
+    @cuda.jit
+    def kernel(inp_real, inp_imag, out_real, out_imag):
+        tid = cuda.threadIdx.x
+        sm = cuda.shared.array(N_SHARED, dtype=types.complex32)
+        sm[tid] = types.complex32(inp_real[tid], inp_imag[tid])
+        cuda.syncthreads()
+        out_real[tid] = sm.real[tid]
+        out_imag[tid] = sm.imag[tid]
+
+    rng = np.random.default_rng(42)
+    inp_real = rng.standard_normal(N_SHARED).astype(np.float16)
+    inp_imag = rng.standard_normal(N_SHARED).astype(np.float16)
+    out_real = np.zeros(N_SHARED, dtype=np.float16)
+    out_imag = np.zeros(N_SHARED, dtype=np.float16)
+
+    kernel[1, N_SHARED](inp_real, inp_imag, out_real, out_imag)
+
+    np.testing.assert_allclose(out_real, inp_real)
+    np.testing.assert_allclose(out_imag, inp_imag)
+
+
 @pytest.mark.parametrize(
     "complex_type",
     [

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -10,6 +10,29 @@ from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir import cuda
 
 
+def test_complex32_signature():
+    @cuda.jit
+    def kernel(value, out):
+        out[0] = value.real + value.imag
+
+    kernel.compile("void(complex32, float16[:])")
+
+
+def test_complex32_local_array_arithmetic():
+    @cuda.jit
+    def kernel(out):
+        values = cuda.local.array(2, dtype=types.complex32)
+        values[0] = types.complex32(1.5, -2.0)
+        values[1] = values[0] * values[0] + values[0]
+        out[0] = values[1].real
+        out[1] = values[1].imag
+
+    out = np.zeros(2, dtype=np.float16)
+    kernel[1, 1](out)
+
+    np.testing.assert_equal(out, np.array([-0.25, -8.0], dtype=np.float16))
+
+
 class TestAtomicOnComplexComponents(unittest.TestCase):
     def test_atomic_on_real_1d(self):
         @cuda.jit


### PR DESCRIPTION
Initial support for complex numbers in numba-cuda-mlir was limited to the NumPy types. Issue #163 asks for a native complex32 type (not in NumPy), this PR introduces the basic typing rules and a basic test to support this.

This closes #163.