### PR TITLE
Prioritize MLIR unicode comparison typing

### DIFF
--- a/src/numba_cuda_mlir/typing/unicode.py
+++ b/src/numba_cuda_mlir/typing/unicode.py
@@ -23,6 +23,7 @@ for _op in _COMPARISON_OPS:
 
     class UnicodeComparisonTemplate(AbstractTemplate):
         key = _op
+        metadata = {"target": "cuda"}
 
         def generic(self, args, kws):
             a, b = args

--- a/tests/test_string_types.py
+++ b/tests/test_string_types.py
@@ -7,11 +7,37 @@ constant-folded. The backend value type is !llvm.ptr (i8*, null-terminated)
 when materialized; see numba_cuda_mlir.models.StringLiteralModel.
 """
 
+import operator
+
 import numpy as np
 import pytest
 
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir import testing
+
+
+def test_string_literal_eq_inline_overload_prefers_mlir_typing():
+    from numba_cuda_mlir.extending import overload, typing_registry
+    from numba_cuda_mlir.typing.unicode import registry
+
+    eq_template = next(template for template in registry.functions if template.key is operator.eq)
+    assert eq_template.metadata["target"] == "cuda"
+
+    def arrangement():
+        raise NotImplementedError
+
+    @overload(arrangement, strict=False, inline="always", typing_registry=typing_registry)
+    def _ol_arrangement():
+        value = "col_major"
+        return lambda: value
+
+    @cuda.jit
+    def kernel(out):
+        out[0] = 1 if arrangement() == "col_major" else 0
+
+    out = np.zeros(1, dtype=np.int64)
+    kernel[1, 1](out)
+    assert out[0] == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Mark UnicodeComparisonTemplate as CUDA-target-specific so it resolves before generic Numba-CUDA unicode and charseq overloads. This avoids compiling unused comparison implementations during literal equality typing (src/numba_cuda_mlir/typing/unicode.py:24-32).

Add an inline-overload regression matching issue #165 and verify both CUDA template priority and comparison behavior
(tests/test_string_types.py:19-40).

This closes issue #165.