### PR TITLE
[CI] Pin numba < 0.66 until numba-cuda is patched

### DIFF
--- a/ci/tools/run-expensive-tests
+++ b/ci/tools/run-expensive-tests
@@ -103,11 +103,13 @@ wheel="${wheels[0]}"
 
 if [[ "${LOCAL_CTK}" == 1 ]]; then
   "${PIP}" install "${wheel}" --group "test-cu${TEST_CUDA_MAJOR}" \
+    "numba<0.66" \
     "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.28.1" \
     "cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "cuda-core[cu${TEST_CUDA_MAJOR}]"
 else
   "${PIP}" install "${wheel}[cu${TEST_CUDA_MAJOR}]" --group "test-cu${TEST_CUDA_MAJOR}" \
+    "numba<0.66" \
     "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.28.1" \
     "cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "cuda-core[cu${TEST_CUDA_MAJOR}]" \


### PR DESCRIPTION
This will unblock us faster. Will revert once numba-cuda is patched and the numba version is pinned.