### PR TITLE
Revert "[CI] Pin numba < 0.66 until numba-cuda is patched"

### DIFF
--- a/ci/tools/run-expensive-tests
+++ b/ci/tools/run-expensive-tests
@@ -103,12 +103,12 @@ wheel="${wheels[0]}"
 
 if [[ "${LOCAL_CTK}" == 1 ]]; then
   "${PIP}" install "${wheel}" --group "test-cu${TEST_CUDA_MAJOR}" \
-    "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.28.1" \
+    "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.30.4" \
     "cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "cuda-core[cu${TEST_CUDA_MAJOR}]"
 else
   "${PIP}" install "${wheel}[cu${TEST_CUDA_MAJOR}]" --group "test-cu${TEST_CUDA_MAJOR}" \
-    "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.28.1" \
+    "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.30.4" \
     "cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "cuda-core[cu${TEST_CUDA_MAJOR}]" \
     "cuda-toolkit[cudart]==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*"

--- a/ci/tools/run-expensive-tests
+++ b/ci/tools/run-expensive-tests
@@ -103,13 +103,11 @@ wheel="${wheels[0]}"
 
 if [[ "${LOCAL_CTK}" == 1 ]]; then
   "${PIP}" install "${wheel}" --group "test-cu${TEST_CUDA_MAJOR}" \
-    "numba<0.66" \
     "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.28.1" \
     "cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "cuda-core[cu${TEST_CUDA_MAJOR}]"
 else
   "${PIP}" install "${wheel}[cu${TEST_CUDA_MAJOR}]" --group "test-cu${TEST_CUDA_MAJOR}" \
-    "numba<0.66" \
     "numba-cuda[cu${TEST_CUDA_MAJOR}]==0.28.1" \
     "cuda-bindings==${TEST_CUDA_MAJOR}.${TEST_CUDA_MINOR}.*" \
     "cuda-core[cu${TEST_CUDA_MAJOR}]" \


### PR DESCRIPTION
Reverts NVIDIA/numba-cuda-mlir#175.

numba-cuda 0.30.4 was released, including the necessary fix (https://github.com/NVIDIA/numba-cuda/pull/905).