### PR TITLE
Lower signed integer % and // with sign-aware widening and floored semantics

### DIFF
--- a/src/numba_cuda_mlir/lowering/math.py
+++ b/src/numba_cuda_mlir/lowering/math.py
@@ -819,14 +819,29 @@ def mod_cg(builder, target, args, kwargs):
     assert len(args) == 2, "mod_cg expects 2 arguments"
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
+    # MLIR integer types here are signless; signedness must come from the
+    # Numba type so that operand widening sign-extends signed values.
+    # Non-integer targets keep convert's unsigned default.
+    signed = isinstance(target_type, types.Integer) and target_type.signed
     lhs, rhs = args
-    lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type)
-    rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type)
+    lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type, signed=signed)
+    rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type, signed=signed)
 
     match target_mlir_type:
         case ir.IntegerType():
-            # For integers: use signed integer remainder
-            result = arith.remsi(lhs, rhs)
+            if signed:
+                # Python floored modulo: the result takes the sign of the
+                # divisor. arith.remsi truncates toward zero, so add the
+                # divisor when the remainder is nonzero and its sign
+                # disagrees with the divisor's ((rem ^ rhs) < 0).
+                rem = arith.remsi(lhs, rhs)
+                zero = lowering_utilities.constant(0, rem.type)
+                sign_mismatch = arith.cmpi(arith.CmpIPredicate.slt, arith.xori(rem, rhs), zero)
+                rem_nonzero = arith.cmpi(arith.CmpIPredicate.ne, rem, zero)
+                needs_fix = arith.andi(sign_mismatch, rem_nonzero)
+                result = arith.addi(rem, arith.select(needs_fix, rhs, zero))
+            else:
+                result = arith.remui(lhs, rhs)
         case ir.FloatType():
             # For floats: implement a % b = a - floor(a/b) * b
             div = arith.divf(lhs, rhs)
@@ -939,10 +954,14 @@ def floordiv_cg(builder, target, args, kwargs):
             div_result = arith.divf(lhs, rhs)
             result = math_dialect.floor(div_result)
         case ir.IntegerType():
-            # For signed integers, use floordivsi
-            lhs = lowering_utilities.convert(lhs, target_mlir_type)
-            rhs = lowering_utilities.convert(rhs, target_mlir_type)
-            if target_mlir_type.is_signed:
+            # MLIR integer types here are signless (is_signed is always
+            # False), so signedness must come from the Numba type — both
+            # for the widening conversion (extsi vs extui) and for the
+            # choice of division op.
+            signed = target_type.signed
+            lhs = lowering_utilities.convert(lhs, target_mlir_type, signed=signed)
+            rhs = lowering_utilities.convert(rhs, target_mlir_type, signed=signed)
+            if signed:
                 result = arith.floordivsi(lhs, rhs)
             else:
                 # For unsigned, regular division is the same as floor division

--- a/tests/test_integer_division.py
+++ b/tests/test_integer_division.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+from numba_cuda_mlir import cuda
+from numba_cuda_mlir.types import int32
+
+WRAP_SEGMENTS = int32(5)
+
+
+def test_signed_mod_negative_dividend():
+    """% on runtime int32 values follows Python floored-modulo semantics."""
+
+    @cuda.jit
+    def k(a, b, out):
+        i = cuda.grid(1)
+        if i < a.size:
+            out[i] = int32(a[i]) % int32(b[i])
+
+    a = np.array([-6, -5, -4, -3, -2, -1, 0, 1, 6, -6, 6, 7, -7], dtype=np.int32)
+    b = np.array([5, 5, 5, 5, 5, 5, 5, 5, 5, -5, -5, -3, 3], dtype=np.int32)
+    out = cuda.to_device(np.zeros_like(a))
+    k[1, 32](cuda.to_device(a), cuda.to_device(b), out)
+    expected = np.array([int(x) % int(y) for x, y in zip(a, b)], dtype=np.int32)
+    np.testing.assert_array_equal(out.copy_to_host(), expected)
+
+
+def test_signed_mod_frozen_constant_divisor():
+    """% with a frozen-constant divisor and a runtime dividend.
+
+    Literal-on-literal modulo folds in Python before lowering, so this
+    is the smallest form that exercises the emitted MLIR.
+    """
+
+    @cuda.jit
+    def k(a, out):
+        i = cuda.grid(1)
+        if i < a.size:
+            out[i] = int32(a[i]) % WRAP_SEGMENTS
+
+    a = np.array([-6, -5, -1, 0, 4, 6, -2147483648, 2147483647], dtype=np.int32)
+    out = cuda.to_device(np.zeros_like(a))
+    k[1, 32](cuda.to_device(a), out)
+    expected = np.array([int(x) % 5 for x in a], dtype=np.int32)
+    np.testing.assert_array_equal(out.copy_to_host(), expected)
+
+
+def test_signed_floordiv_negative_operands():
+    """// on runtime int32 values floors toward negative infinity."""
+
+    @cuda.jit
+    def k(a, b, out):
+        i = cuda.grid(1)
+        if i < a.size:
+            out[i] = int32(a[i]) // int32(b[i])
+
+    a = np.array([-6, -5, -1, 0, 6, -7, 7, -2147483648], dtype=np.int32)
+    b = np.array([5, 5, 5, 5, 5, 3, -3, 7], dtype=np.int32)
+    out = cuda.to_device(np.zeros_like(a))
+    k[1, 32](cuda.to_device(a), cuda.to_device(b), out)
+    expected = np.array([int(x) // int(y) for x, y in zip(a, b)], dtype=np.int32)
+    np.testing.assert_array_equal(out.copy_to_host(), expected)
+
+
+def test_signed_mod_floordiv_int64():
+    """64-bit signed % and // keep floored semantics (no widening involved)."""
+
+    @cuda.jit
+    def k(a, b, mod_out, div_out):
+        i = cuda.grid(1)
+        if i < a.size:
+            mod_out[i] = a[i] % b[i]
+            div_out[i] = a[i] // b[i]
+
+    a = np.array([-(2**40) - 3, 2**40 + 3, -6, 6], dtype=np.int64)
+    b = np.array([7, -7, 5, -5], dtype=np.int64)
+    mod_out = cuda.to_device(np.zeros_like(a))
+    div_out = cuda.to_device(np.zeros_like(a))
+    k[1, 32](cuda.to_device(a), cuda.to_device(b), mod_out, div_out)
+    np.testing.assert_array_equal(
+        mod_out.copy_to_host(),
+        np.array([int(x) % int(y) for x, y in zip(a, b)], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(
+        div_out.copy_to_host(),
+        np.array([int(x) // int(y) for x, y in zip(a, b)], dtype=np.int64),
+    )
+
+
+def test_unsigned_mod_floordiv():
+    """Unsigned % and // use unsigned ops on zero-extended operands."""
+
+    @cuda.jit
+    def k(a, b, mod_out, div_out):
+        i = cuda.grid(1)
+        if i < a.size:
+            mod_out[i] = a[i] % b[i]
+            div_out[i] = a[i] // b[i]
+
+    a = np.array([4294967290, 7, 4294967295, 10], dtype=np.uint32)
+    b = np.array([5, 5, 5, 3], dtype=np.uint32)
+    mod_out = cuda.to_device(np.zeros_like(a))
+    div_out = cuda.to_device(np.zeros_like(a))
+    k[1, 32](cuda.to_device(a), cuda.to_device(b), mod_out, div_out)
+    np.testing.assert_array_equal(mod_out.copy_to_host(), a % b)
+    np.testing.assert_array_equal(div_out.copy_to_host(), a // b)
+
+
+def test_float_mod_unchanged():
+    """Float % keeps the floored a - floor(a/b) * b lowering."""
+
+    @cuda.jit
+    def k(a, b, out):
+        i = cuda.grid(1)
+        if i < a.size:
+            out[i] = a[i] % b[i]
+
+    a = np.array([-7.5, 7.5, -1.0, 5.25], dtype=np.float64)
+    b = np.array([3.0, -3.0, 4.0, 2.0], dtype=np.float64)
+    out = cuda.to_device(np.zeros_like(a))
+    k[1, 32](cuda.to_device(a), cuda.to_device(b), out)
+    np.testing.assert_allclose(out.copy_to_host(), a % b, rtol=1e-15)


### PR DESCRIPTION
Fixes #184.

Signed `%` and `//` return wrong values for negative runtime operands; see the issue for the repro and analysis.

Changes in `lowering/math.py`:

- `mod_cg` and `floordiv_cg` take signedness from the Numba target type instead of the signless MLIR type, and pass it to the operand widening so negative values sign-extend.
- Signed `%` adjusts the `arith.remsi` result by the divisor when the remainder is nonzero and its sign disagrees with the divisor's, matching Python's floored modulo. Unsigned `%` uses `arith.remui`.
- Signed `//` uses `arith.floordivsi`; the unsigned path is unchanged.

Tests: `tests/test_integer_division.py` covers negative dividends and divisors, a frozen-constant divisor (literal-on-literal folds in Python and hides the bug), int64, INT32_MIN edge values, and positive-operand and unsigned regressions. Four of six fail on main; all pass with this change. Full test suite run against a main baseline with no new failures, on an RTX 4070 SUPER, CUDA 12.

---
Written by Chris' bot, re-written repeatedly by Chris.
