### PR TITLE
Register Boolean signatures for bitwise operators and add invert lowering

### DIFF
--- a/src/numba_cuda_mlir/lowering/math.py
+++ b/src/numba_cuda_mlir/lowering/math.py
@@ -449,16 +449,25 @@ def iadd_cg(builder, target, args, kwargs):
 
 
 @lower(operator.ior, types.Integer, types.Integer)
+@lower(operator.ior, types.Boolean, types.Boolean)
+@lower(operator.ior, types.Boolean, types.Integer)
+@lower(operator.ior, types.Integer, types.Boolean)
 def ior_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.ior, builder, target, args, kwargs)
 
 
 @lower(operator.iand, types.Integer, types.Integer)
+@lower(operator.iand, types.Boolean, types.Boolean)
+@lower(operator.iand, types.Boolean, types.Integer)
+@lower(operator.iand, types.Integer, types.Boolean)
 def iand_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.iand, builder, target, args, kwargs)
 
 
 @lower(operator.ixor, types.Integer, types.Integer)
+@lower(operator.ixor, types.Boolean, types.Boolean)
+@lower(operator.ixor, types.Boolean, types.Integer)
+@lower(operator.ixor, types.Integer, types.Boolean)
 def ixor_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.ixor, builder, target, args, kwargs)
 
@@ -883,6 +892,9 @@ def ilshift_cg(builder, target, args, kwargs):
 
 
 @lower(operator.and_, types.Integer, types.Integer)
+@lower(operator.and_, types.Boolean, types.Boolean)
+@lower(operator.and_, types.Boolean, types.Integer)
+@lower(operator.and_, types.Integer, types.Boolean)
 def and_cg(builder, target, args, kwargs):
     assert not kwargs, "and_cg does not accept any keyword arguments"
     assert len(args) == 2, "and_cg expects 2 arguments"
@@ -896,6 +908,9 @@ def and_cg(builder, target, args, kwargs):
 
 
 @lower(operator.or_, types.Integer, types.Integer)
+@lower(operator.or_, types.Boolean, types.Boolean)
+@lower(operator.or_, types.Boolean, types.Integer)
+@lower(operator.or_, types.Integer, types.Boolean)
 def or_cg(builder, target, args, kwargs):
     assert not kwargs, "or_cg does not accept any keyword arguments"
     assert len(args) == 2, "or_cg expects 2 arguments"
@@ -909,6 +924,9 @@ def or_cg(builder, target, args, kwargs):
 
 
 @lower(operator.xor, types.Integer, types.Integer)
+@lower(operator.xor, types.Boolean, types.Boolean)
+@lower(operator.xor, types.Boolean, types.Integer)
+@lower(operator.xor, types.Integer, types.Boolean)
 def xor_cg(builder, target, args, kwargs):
     assert not kwargs, "xor_cg does not accept any keyword arguments"
     assert len(args) == 2, "xor_cg expects 2 arguments"
@@ -918,6 +936,21 @@ def xor_cg(builder, target, args, kwargs):
     lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type)
     rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type)
     result = arith.xori(lhs, rhs)
+    builder.store_var(target, result)
+
+
+@lower(operator.invert, types.Integer)
+@lower(operator.invert, types.Boolean)
+def invert_cg(builder, target, args, kwargs):
+    """Bitwise NOT: xor with all-ones (~True is False for booleans)."""
+    assert not kwargs, "invert_cg does not accept any keyword arguments"
+    assert len(args) == 1, "invert_cg expects 1 argument"
+    target_type = builder.get_numba_type(target.name)
+    target_mlir_type = builder.get_mlir_type(target_type)
+    operand = lowering_utilities.convert(builder.load_var(args[0]), target_mlir_type)
+    fill = 1 if isinstance(target_type, types.Boolean) else -1
+    all_ones = lowering_utilities.constant(fill, target_mlir_type)
+    result = arith.xori(operand, all_ones)
     builder.store_var(target, result)
 
 

--- a/tests/test_bitwise.py
+++ b/tests/test_bitwise.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+from numba_cuda_mlir import cuda
+
+
+def test_boolean_bitwise_and_or_xor():
+    @cuda.jit
+    def k(inp, out):
+        a = inp[0] > 0
+        b = inp[1] > 0
+        out[0] = 1 if a & b else 0
+        out[1] = 1 if a | b else 0
+        out[2] = 1 if a ^ b else 0
+
+    inp = cuda.to_device(np.array([1, 0], dtype=np.int32))
+    out = cuda.to_device(np.zeros(3, dtype=np.int32))
+    k[1, 1](inp, out)
+    np.testing.assert_array_equal(out.copy_to_host(), [0, 1, 1])
+
+    inp = cuda.to_device(np.array([1, 1], dtype=np.int32))
+    k[1, 1](inp, out)
+    np.testing.assert_array_equal(out.copy_to_host(), [1, 1, 0])
+
+
+def test_boolean_inplace_bitwise():
+    @cuda.jit
+    def k(inp, out):
+        acc_and = True
+        acc_or = False
+        acc_xor = False
+        for i in range(inp.shape[0]):
+            flag = inp[i] > 0
+            acc_and &= flag
+            acc_or |= flag
+            acc_xor ^= flag
+        out[0] = 1 if acc_and else 0
+        out[1] = 1 if acc_or else 0
+        out[2] = 1 if acc_xor else 0
+
+    inp = cuda.to_device(np.array([1, 0, 1], dtype=np.int32))
+    out = cuda.to_device(np.zeros(3, dtype=np.int32))
+    k[1, 1](inp, out)
+    np.testing.assert_array_equal(out.copy_to_host(), [0, 1, 0])
+
+
+def test_mixed_boolean_integer_bitwise():
+    @cuda.jit
+    def k(inp, out):
+        flag = inp[0] > 0
+        out[0] = inp[1] & flag
+        out[1] = inp[1] | flag
+        out[2] = flag ^ inp[1]
+
+    inp = cuda.to_device(np.array([1, 6], dtype=np.int32))
+    out = cuda.to_device(np.zeros(3, dtype=np.int32))
+    k[1, 1](inp, out)
+    np.testing.assert_array_equal(out.copy_to_host(), [6 & 1, 6 | 1, 1 ^ 6])
+
+
+def test_boolean_invert():
+    @cuda.jit
+    def k(inp, out):
+        a = inp[0] > 0
+        b = ~a
+        out[0] = 1 if b else 0
+        out[1] = 1 if ~b else 0
+
+    inp = cuda.to_device(np.array([0], dtype=np.int32))
+    out = cuda.to_device(np.zeros(2, dtype=np.int32))
+    k[1, 1](inp, out)
+    np.testing.assert_array_equal(out.copy_to_host(), [1, 0])
+
+
+def test_integer_invert():
+    @cuda.jit
+    def k(i32_io, u32_io, i8_io):
+        i32_io[1] = ~i32_io[0]
+        u32_io[1] = ~u32_io[0]
+        i8_io[1] = ~i8_io[0]
+
+    i32_io = cuda.to_device(np.array([5, 0], dtype=np.int32))
+    u32_io = cuda.to_device(np.array([5, 0], dtype=np.uint32))
+    i8_io = cuda.to_device(np.array([-1, 0], dtype=np.int8))
+    k[1, 1](i32_io, u32_io, i8_io)
+    assert i32_io.copy_to_host()[1] == ~np.int32(5)
+    assert u32_io.copy_to_host()[1] == np.uint32(~np.uint32(5))
+    assert i8_io.copy_to_host()[1] == ~np.int8(-1)


### PR DESCRIPTION
Fixes #186.

Bitwise operators reject Boolean operands and `~` has no lowering; see the issue for the repro.

Changes in `lowering/math.py`:

- `&`, `|`, `^` and their in-place forms gain `(Boolean, Boolean)` and mixed Boolean/Integer signatures on the existing builders, matching numba-cuda's `_implement_bitwise_operators` coverage.
- `operator.invert` lowers as xor with all-ones: -1 for integers, 1 for booleans, so `~True` is `False` as for `np.bool_`.

Tests: `tests/test_bitwise.py` covers the boolean binary and in-place forms, mixed boolean/integer operands, boolean invert, and integer invert across int32/uint32/int8. All five fail on main; all pass with this change. Full test suite run against a main baseline with no new failures, on an RTX 4070 SUPER, CUDA 12.

---
Written by Chris' bot, re-written repeatedly by Chris.
