### PR TITLE
Register Boolean comparison lowerings with unsigned i1 semantics

### DIFF
--- a/src/numba_cuda_mlir/lowering/math.py
+++ b/src/numba_cuda_mlir/lowering/math.py
@@ -325,13 +325,15 @@ def _bin_op_cg(op, builder, target, args, kwargs):
 
     # Ensure numbers whose MLIR types are signless end up with the correct
     # operation. Without this logic, two input values with two unsigned integer
-    # types get a signed comparator operator and vice versa
-    is_unsigned = (
-        isinstance(lhs_type, types.Integer)
-        and isinstance(rhs_type, types.Integer)
-        and not lhs_type.signed
-        and not rhs_type.signed
-    )
+    # types get a signed comparator operator and vice versa. Booleans lower to
+    # i1 and must compare as unsigned, otherwise True (all-ones) orders below
+    # False.
+    def _is_unsigned_operand(operand_type):
+        if isinstance(operand_type, types.Boolean):
+            return True
+        return isinstance(operand_type, types.Integer) and not operand_type.signed
+
+    is_unsigned = _is_unsigned_operand(lhs_type) and _is_unsigned_operand(rhs_type)
 
     lhs, rhs = builder.load_var(lhs), builder.load_var(rhs)
 
@@ -395,31 +397,37 @@ def truediv_cg(builder, target, args, kwargs):
 
 
 @lower(operator.ne, types.Number, types.Number)
+@lower(operator.ne, types.Boolean, types.Boolean)
 def ne_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.ne, builder, target, args, kwargs)
 
 
 @lower(operator.eq, types.Number, types.Number)
+@lower(operator.eq, types.Boolean, types.Boolean)
 def eq_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.eq, builder, target, args, kwargs)
 
 
 @lower(operator.lt, types.Number, types.Number)
+@lower(operator.lt, types.Boolean, types.Boolean)
 def lt_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.lt, builder, target, args, kwargs)
 
 
 @lower(operator.le, types.Number, types.Number)
+@lower(operator.le, types.Boolean, types.Boolean)
 def le_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.le, builder, target, args, kwargs)
 
 
 @lower(operator.gt, types.Number, types.Number)
+@lower(operator.gt, types.Boolean, types.Boolean)
 def gt_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.gt, builder, target, args, kwargs)
 
 
 @lower(operator.ge, types.Number, types.Number)
+@lower(operator.ge, types.Boolean, types.Boolean)
 def ge_cg(builder, target, args, kwargs):
     return _bin_op_cg(operator.ge, builder, target, args, kwargs)
 

--- a/tests/test_bool.py
+++ b/tests/test_bool.py
@@ -18,3 +18,42 @@ def test_boolean():
     assert A.copy_to_host()[0] == 123
     k[1, 1](A, False)
     assert A.copy_to_host()[0] == 321
+
+
+def test_boolean_equality_comparisons():
+    @cuda.jit
+    def k(inp, out):
+        a = inp[0] > 0
+        b = inp[1] > 0
+        out[0] = 1 if a == b else 0
+        out[1] = 1 if a != b else 0
+
+    out = cuda.to_device(np.zeros(2, dtype=np.int32))
+    inp = cuda.to_device(np.array([1, 0], dtype=np.int32))
+    k[1, 1](inp, out)
+    np.testing.assert_array_equal(out.copy_to_host(), [0, 1])
+
+    inp = cuda.to_device(np.array([1, 1], dtype=np.int32))
+    k[1, 1](inp, out)
+    np.testing.assert_array_equal(out.copy_to_host(), [1, 0])
+
+
+def test_boolean_ordering_comparisons():
+    """Booleans must compare as unsigned i1: True > False."""
+
+    @cuda.jit
+    def k(inp, out):
+        a = inp[0] > 0
+        b = inp[1] > 0
+        out[0] = 1 if a < b else 0
+        out[1] = 1 if a <= b else 0
+        out[2] = 1 if a > b else 0
+        out[3] = 1 if a >= b else 0
+
+    out = cuda.to_device(np.zeros(4, dtype=np.int32))
+    for lhs, rhs in [(1, 0), (0, 1), (1, 1), (0, 0)]:
+        inp = cuda.to_device(np.array([lhs, rhs], dtype=np.int32))
+        k[1, 1](inp, out)
+        a, b = bool(lhs), bool(rhs)
+        expected = [int(a < b), int(a <= b), int(a > b), int(a >= b)]
+        np.testing.assert_array_equal(out.copy_to_host(), expected)


### PR DESCRIPTION
Fixes #188.

Comparison operators reject Boolean operands; see the issue for the repro.

Changes in `lowering/math.py`:

- `==`, `!=`, `<`, `<=`, `>`, `>=` gain `(Boolean, Boolean)` signatures on the existing code generators, matching numba-cuda's registrations in `numba/cuda/cpython/numbers.py`.
- The predicate selection in `_bin_op_cg` treats Boolean operands as unsigned: booleans lower to signless i1, and a signed i1 comparison orders True (all-ones, -1) below False.

Tests: `tests/test_bool.py` gains equality and ordering tests over runtime boolean pairs; the ordering test checks all four True/False combinations against Python semantics. Both fail on main; both pass with this change. Full test suite run against a main baseline with no new failures, on an RTX 4070 SUPER, CUDA 12.

---
Written by Chris' bot, re-written repeatedly by Chris.
