### PR TITLE
Restrict SSA rewrite passes to blocks that define or use the variable

### DIFF
--- a/src/numba_cuda_mlir/numba_cuda/core/ssa.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/ssa.py
@@ -82,9 +82,7 @@ def _run_ssa(blocks):
         _logger.debug("Replaced assignments: %s", _lazy_pformat(defmap))
         # Fix up the RHS
         # Re-associate the variable uses with the reaching definition
-        blocks = _fix_ssa_vars(
-            blocks, varname, defmap, cfg, df_plus, cache_list_vars, use_labels
-        )
+        blocks = _fix_ssa_vars(blocks, varname, defmap, cfg, df_plus, cache_list_vars, use_labels)
 
     # Post-condition checks.
     # CFG invariant
@@ -102,9 +100,7 @@ def _fix_ssa_vars(blocks, varname, defmap, cfg, df_plus, cache_list_vars, use_la
     states["phimap"] = phimap = defaultdict(list)
     states["cfg"] = cfg
     states["phi_locations"] = _compute_phi_locations(df_plus, defmap)
-    newblocks = _run_block_rewrite(
-        blocks, states, _FixSSAVars(cache_list_vars), use_labels
-    )
+    newblocks = _run_block_rewrite(blocks, states, _FixSSAVars(cache_list_vars), use_labels)
     # insert phi nodes
     for label, philist in phimap.items():
         curblk = newblocks[label]

--- a/src/numba_cuda_mlir/numba_cuda/core/ssa.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/ssa.py
@@ -58,7 +58,7 @@ def _run_ssa(blocks):
     cfg = compute_cfg_from_blocks(blocks)
     df_plus = _iterated_domfronts(cfg)
     # Find SSA violators
-    violators = _find_defs_violators(blocks, cfg)
+    violators, defs, uses = _find_defs_violators(blocks, cfg)
     # Make cache for .list_vars()
     cache_list_vars = _CacheListVars()
 
@@ -68,13 +68,23 @@ def _run_ssa(blocks):
             "Fix SSA violator on var %s",
             varname,
         )
+        # Only blocks that define or use the variable are visited;
+        # other blocks pass through by reference. The label sets stay
+        # valid across both passes: renames touch only this variable
+        # and phi nodes introduce fresh names. The fix pass uses the
+        # union of use and def blocks, otherwise the RHS of an
+        # assignment to itself (e.g. ``x = x + 1``) is excluded.
+        def_labels = {label for _assign, label in defs[varname]}
+        use_labels = uses[varname] | def_labels
         # Fix up the LHS
         # Put fresh variables for all assignments to the variable
-        blocks, defmap = _fresh_vars(blocks, varname)
+        blocks, defmap = _fresh_vars(blocks, varname, def_labels)
         _logger.debug("Replaced assignments: %s", _lazy_pformat(defmap))
         # Fix up the RHS
         # Re-associate the variable uses with the reaching definition
-        blocks = _fix_ssa_vars(blocks, varname, defmap, cfg, df_plus, cache_list_vars)
+        blocks = _fix_ssa_vars(
+            blocks, varname, defmap, cfg, df_plus, cache_list_vars, use_labels
+        )
 
     # Post-condition checks.
     # CFG invariant
@@ -84,7 +94,7 @@ def _run_ssa(blocks):
     return blocks
 
 
-def _fix_ssa_vars(blocks, varname, defmap, cfg, df_plus, cache_list_vars):
+def _fix_ssa_vars(blocks, varname, defmap, cfg, df_plus, cache_list_vars, use_labels):
     """Rewrite all uses to ``varname`` given the definition map"""
     states = _make_states(blocks)
     states["varname"] = varname
@@ -92,12 +102,18 @@ def _fix_ssa_vars(blocks, varname, defmap, cfg, df_plus, cache_list_vars):
     states["phimap"] = phimap = defaultdict(list)
     states["cfg"] = cfg
     states["phi_locations"] = _compute_phi_locations(df_plus, defmap)
-    newblocks = _run_block_rewrite(blocks, states, _FixSSAVars(cache_list_vars))
+    newblocks = _run_block_rewrite(
+        blocks, states, _FixSSAVars(cache_list_vars), use_labels
+    )
     # insert phi nodes
     for label, philist in phimap.items():
         curblk = newblocks[label]
-        # Prepend PHI nodes to the block
-        curblk.body = philist + curblk.body
+        # Prepend PHI nodes to the block. Build a fresh block rather
+        # than mutating in place: phi locations include pass-through
+        # blocks, and input block objects must never be mutated.
+        newblk = ir.Block(scope=curblk.scope, loc=curblk.loc)
+        newblk.body = philist + curblk.body
+        newblocks[label] = newblk
     return newblocks
 
 
@@ -130,12 +146,12 @@ def _compute_phi_locations(iterated_df, defmap):
     return phi_locations
 
 
-def _fresh_vars(blocks, varname):
+def _fresh_vars(blocks, varname, def_labels):
     """Rewrite to put fresh variable names"""
     states = _make_states(blocks)
     states["varname"] = varname
     states["defmap"] = defmap = defaultdict(list)
-    newblocks = _run_block_rewrite(blocks, states, _FreshVarHandler())
+    newblocks = _run_block_rewrite(blocks, states, _FreshVarHandler(), def_labels)
     return newblocks, defmap
 
 
@@ -148,8 +164,10 @@ def _find_defs_violators(blocks, cfg):
     """
     Returns
     -------
-    res : Set[str]
-        The SSA violators in a dictionary of variable names.
+    res : Tuple[Dict[str, None], Mapping, Mapping]
+        The SSA violators in a dictionary of variable names, the
+        per-variable definition map (name -> [(assign, label)]) and the
+        per-variable use-block map (name -> {label}).
     """
     defs = defaultdict(list)
     uses = defaultdict(set)
@@ -171,7 +189,7 @@ def _find_defs_violators(blocks, cfg):
                     violators[k] = None
                     break
     _logger.debug("SSA violators %s", _lazy_pformat(list(violators)))
-    return violators
+    return violators, defs, uses
 
 
 def _run_block_analysis(blocks, states, handler):
@@ -182,9 +200,15 @@ def _run_block_analysis(blocks, states, handler):
             pass
 
 
-def _run_block_rewrite(blocks, states, handler):
+def _run_block_rewrite(blocks, states, handler, relevant_labels=None):
     newblocks = {}
     for label, blk in blocks.items():
+        if relevant_labels is not None and label not in relevant_labels:
+            # The handler can only change statements that mention the
+            # variable being processed, so blocks without a def/use
+            # of it pass through unchanged.
+            newblocks[label] = blk
+            continue
         _logger.debug("==== SSA block rewrite pass on %s", label)
         newblk = ir.Block(scope=blk.scope, loc=blk.loc)
 

--- a/tests/test_ssa_restricted_sweeps.py
+++ b/tests/test_ssa_restricted_sweeps.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression pins for SSA reconstruction with restricted sweeps.
+
+The SSA rewrite passes visit only blocks that define or use the
+variable being processed; the test compares them against unrestricted
+sweeps (``relevant_labels=None``), which rewrite every block exactly
+as the pre-restriction implementation did.
+
+The hand-built IR includes the shape that makes the restriction
+subtle: an assignment with the same variable on both sides
+(``x = x + x``). ``_GatherDefsHandler`` drops every mention of a
+variable in a statement that assigns it, so such a block appears in
+the def map but not the use map — the use-fixup pass must visit the
+union of use and def blocks or the self-referential operand silently
+keeps the unversioned name.
+"""
+
+import operator
+
+import numpy as np
+from numba_cuda_mlir import cuda
+from numba_cuda_mlir.numba_cuda.core import ir
+from numba_cuda_mlir.numba_cuda.core import ssa as ssa_mod
+
+
+def _build_self_use_blocks():
+    """CFG with an SSA violator whose only non-terminal mention in
+    the loop block is ``x = x + x``:
+
+        0:  x = 0.0; cond = True; jump 8
+        8:  x = x + x; branch cond ? 8 : 16
+        16: return x
+    """
+    loc = ir.Loc("test_ssa", 1)
+    scope = ir.Scope(parent=None, loc=loc)
+    x = scope.define("x", loc)
+    cond = scope.define("cond", loc)
+
+    b0 = ir.Block(scope, loc)
+    b0.body = [
+        ir.Assign(ir.Const(0.0, loc), x, loc),
+        ir.Assign(ir.Const(True, loc), cond, loc),
+        ir.Jump(8, loc),
+    ]
+    b8 = ir.Block(scope, loc)
+    b8.body = [
+        ir.Assign(
+            ir.Expr.binop(operator.add, x, x, loc),
+            x,
+            loc,
+        ),
+        ir.Branch(cond, 8, 16, loc),
+    ]
+    b16 = ir.Block(scope, loc)
+    b16.body = [ir.Return(x, loc)]
+    return {0: b0, 8: b8, 16: b16}
+
+
+def _build_diamond_blocks():
+    """Diamond with a pass-through join: x is assigned in both arms
+    and used two blocks later, so the phi for x lands in a block that
+    neither defines nor uses it.
+
+        0:  cond = True; branch cond ? 8 : 16
+        8:  x = 1.0; jump 24
+        16: x = 2.0; jump 24
+        24: jump 32                 (pass-through phi location)
+        32: return x
+    """
+    loc = ir.Loc("test_ssa", 2)
+    scope = ir.Scope(parent=None, loc=loc)
+    x = scope.define("x", loc)
+    cond = scope.define("cond", loc)
+
+    b0 = ir.Block(scope, loc)
+    b0.body = [
+        ir.Assign(ir.Const(True, loc), cond, loc),
+        ir.Branch(cond, 8, 16, loc),
+    ]
+    b8 = ir.Block(scope, loc)
+    b8.body = [
+        ir.Assign(ir.Const(1.0, loc), x, loc),
+        ir.Jump(24, loc),
+    ]
+    b16 = ir.Block(scope, loc)
+    b16.body = [
+        ir.Assign(ir.Const(2.0, loc), x, loc),
+        ir.Jump(24, loc),
+    ]
+    b24 = ir.Block(scope, loc)
+    b24.body = [ir.Jump(32, loc)]
+    b32 = ir.Block(scope, loc)
+    b32.body = [ir.Return(x, loc)]
+    return {0: b0, 8: b8, 16: b16, 24: b24, 32: b32}
+
+
+def _reference_run_ssa(blocks):
+    """The production driver with the block restriction disabled:
+    every rewrite pass visits every block, as the pre-restriction
+    implementation did."""
+    if not blocks:
+        return {}
+    cfg = ssa_mod.compute_cfg_from_blocks(blocks)
+    df_plus = ssa_mod._iterated_domfronts(cfg)
+    violators, defs, uses = ssa_mod._find_defs_violators(blocks, cfg)
+    cache_list_vars = ssa_mod._CacheListVars()
+    for varname in violators:
+        blocks, defmap = ssa_mod._fresh_vars(blocks, varname, None)
+        blocks = ssa_mod._fix_ssa_vars(blocks, varname, defmap, cfg, df_plus, cache_list_vars, None)
+    return blocks
+
+
+def _dump(blocks):
+    return [(label, [str(stmt) for stmt in blk.body]) for label, blk in sorted(blocks.items())]
+
+
+def _assert_restricted_matches_unrestricted(builder):
+    # Build twice so each run gets its own scope and the SSA version
+    # counters start identically.
+    got = _dump(ssa_mod._run_ssa(builder()))
+    expected = _dump(_reference_run_ssa(builder()))
+    assert got == expected
+
+
+def test_self_use_assignment():
+    _assert_restricted_matches_unrestricted(_build_self_use_blocks)
+
+
+def test_phi_in_passthrough_block():
+    _assert_restricted_matches_unrestricted(_build_diamond_blocks)
+
+
+def test_phi_insertion_does_not_mutate_input_blocks():
+    # Restricted sweeps pass untouched blocks through by reference,
+    # so the phi-insertion step must build a fresh block: prepending
+    # in place would push the phi into the caller's IR as well.
+    blocks = _build_diamond_blocks()
+    input_bodies = {label: list(blk.body) for label, blk in blocks.items()}
+    ssa_mod._run_ssa(blocks)
+    for label, blk in blocks.items():
+        assert blk.body == input_bodies[label], f"input block {label} was mutated in place"
+
+
+def test_end_to_end_accumulators():
+    # End-to-end sanity: two SSA violators rewritten one after the
+    # other in a compiled kernel produce correct values.
+    @cuda.jit
+    def k(inp, out):
+        s = 0.0
+        p = 1.0
+        for i in range(inp.shape[0]):
+            s = s + inp[i]
+            p = p * inp[i]
+        out[0] = s
+        out[1] = p
+
+    inp = np.array([1.0, 2.0, 3.0, 4.0])
+    out = cuda.to_device(np.zeros(2))
+    k[1, 1](cuda.to_device(inp), out)
+    got = out.copy_to_host()
+    assert got[0] == 10.0
+    assert got[1] == 24.0


### PR DESCRIPTION

Part of #196: 38.08s to 21.76s on the repro (1.75x), 2.0x on our production kernel.

Each SSA-violating variable rewrites every block twice (fresh-name pass and use-fixup pass), making reconstruction O(violators x blocks). This change collects each variable's def and use blocks up front and passes every other block through by reference.

Two decisions in `numba_cuda/core/ssa.py` are worth review:

- The fix pass uses the union of use and def blocks, otherwise the RHS of an assignment to itself (e.g. `x = x + 1`) is excluded — the uses map omits it, and visiting use blocks alone miscompiles accumulator patterns.
- Phi insertion builds a fresh block instead of mutating in place, since phi locations can be pass-through blocks.

Tests: `tests/test_ssa_restricted_sweeps.py` pins both details with hand-built IR (a true self-use assignment, and a phi landing in a pass-through block with the input blocks asserted unchanged), compares the restricted rewrite against the same driver with the restriction disabled, and runs an end-to-end accumulator kernel. Full test suite run against a main baseline with no new failures, on an RTX 4070 SUPER, CUDA 12.

---
Written by Chris' bot, re-written repeatedly by Chris.
