### PR TITLE
Add post-inline whole-function planners

### DIFF
--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -68,6 +68,10 @@ planner, start with the next compilation. Planners operate on untyped Numba
 IR; typing and MLIR lowering extensions remain responsible for the later
 compilation phases.
 
+Persistent disk-cache load and save are bypassed while planners are
+registered because planner identity and implementation are not part of the
+cache key. In-memory overload reuse is unchanged.
+
 .. autoclass:: numba_cuda_mlir.extending.WholeFunctionPlanner
    :members: is_device_function, run
 

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -42,11 +42,11 @@ caller and before type inference. This makes calls introduced by device
 helpers visible without rerunning unrelated rewrite registries.
 
 Implement ``run()`` and return ``True`` only when the planner changed
-``state.func_ir``. After each change, Numba-CUDA-MLIR simplifies the control
-flow graph, refreshes postprocessing state and definitions, and verifies every
-block before invoking the next planner. Planners run for both kernels and
-device-function compilations; a planner that only applies to kernels should
-check ``self.is_device_function`` and decline device functions.
+``state.func_ir``. Before the first planner and after each change,
+Numba-CUDA-MLIR simplifies the control flow graph, refreshes postprocessing
+state and definitions, and verifies every block. Planners run for both kernels
+and device-function compilations; a planner that only applies to kernels
+should check ``self.is_device_function`` and decline device functions.
 
 .. code-block:: python
 

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -68,6 +68,11 @@ planner, start with the next compilation. Planners operate on untyped Numba
 IR; typing and MLIR lowering extensions remain responsible for the later
 compilation phases.
 
+Register every planner before compiling a dispatcher that needs it.
+Registration does not invalidate an overload that the dispatcher has already
+compiled and cached in memory; a planner registered later applies only when a
+new overload is compiled.
+
 Persistent disk-cache load and save are bypassed while planners are
 registered because planner identity and implementation are not part of the
 cache key. In-memory overload reuse is unchanged.

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -7,8 +7,11 @@
 Low-level extension API
 =======================
 
-The low-level API exposes Numba-CUDA-MLIR's two compilation phases directly:
+The low-level API exposes Numba-CUDA-MLIR's extension phases directly:
 
+* **Planning** — after device functions have been inlined and before type
+  inference, whole-function planners can inspect and transform the complete
+  untyped Numba IR.
 * **Typing** — running before code generation, type inference resolves each
   variable, attribute, and call to a type. Extension authors register new
   typing rules with the :py:mod:`~numba_cuda_mlir.numba_cuda.typing` template
@@ -17,17 +20,58 @@ The low-level API exposes Numba-CUDA-MLIR's two compilation phases directly:
   operation. Extension authors register lowering implementations with
   :py:attr:`~numba_cuda_mlir.extending.lowering_registry`.
 
-These are the same two phases that underpin the high-level API. The
-high-level decorators are convenience wrappers that arrange the typing and
-lowering for you; use the low-level API when you need to introduce a
-brand-new type, emit MLIR directly, or anything else that is difficult to
-express using the high-level API.
+Typing and lowering also underpin the high-level API. The high-level
+decorators are convenience wrappers that arrange those phases for you; use
+the low-level API when you need whole-function planning, a brand-new type,
+direct MLIR emission, or anything else that is difficult to express using the
+high-level API.
 
 The lowering half of this API differs significantly from Numba's. Numba's
 lowering callbacks receive an ``llvmlite.ir.IRBuilder`` and emit LLVM IR.
 Numba-CUDA-MLIR's lowering callbacks receive an MLIR builder
 (:py:class:`numba_cuda_mlir.mlir_lowering.MLIRLower`) and emit MLIR through
 the bindings in :py:mod:`numba_cuda_mlir._mlir`.
+
+Whole-function planning
+-----------------------
+
+Extensions that need to inspect or transform a complete function before typing
+can register a :py:class:`~numba_cuda_mlir.extending.WholeFunctionPlanner`.
+Planners run once after inlineable device functions have been merged into the
+caller and before type inference. This makes calls introduced by device
+helpers visible without rerunning unrelated rewrite registries.
+
+Implement ``run()`` and return ``True`` only when the planner changed
+``state.func_ir``. After each change, Numba-CUDA-MLIR simplifies the control
+flow graph, refreshes postprocessing state and definitions, and verifies every
+block before invoking the next planner. Planners run for both kernels and
+device-function compilations; a planner that only applies to kernels should
+check ``self.is_device_function`` and decline device functions.
+
+.. code-block:: python
+
+   from numba_cuda_mlir.extending import (
+       WholeFunctionPlanner,
+       register_planner,
+   )
+
+   @register_planner
+   class MyPlanner(WholeFunctionPlanner):
+       def run(self):
+           modified = rewrite_my_extension_calls(self.state.func_ir)
+           return bool(modified)
+
+Registration order is preserved, and registering the same planner class more
+than once has no effect. The planner pass snapshots its registry before
+running, so planners registered after that snapshot, including from a running
+planner, start with the next compilation. Planners operate on untyped Numba
+IR; typing and MLIR lowering extensions remain responsible for the later
+compilation phases.
+
+.. autoclass:: numba_cuda_mlir.extending.WholeFunctionPlanner
+   :members: is_device_function, run
+
+.. autofunction:: numba_cuda_mlir.extending.register_planner
 
 Typing
 ------

--- a/src/numba_cuda_mlir/_whole_function_planners.py
+++ b/src/numba_cuda_mlir/_whole_function_planners.py
@@ -90,7 +90,11 @@ _planner_registry = _WholeFunctionPlannerRegistry()
 
 
 def register_planner(planner_cls):
-    """Register a whole-function planner class."""
+    """Register a whole-function planner class.
+
+    Register planners before compiling any dispatcher that needs them.
+    Registration does not invalidate existing in-memory overloads.
+    """
 
     return _planner_registry.register(planner_cls)
 

--- a/src/numba_cuda_mlir/_whole_function_planners.py
+++ b/src/numba_cuda_mlir/_whole_function_planners.py
@@ -54,11 +54,17 @@ class _WholeFunctionPlannerRegistry:
             return bool(self._planners)
 
     def apply(self, state) -> bool:
-        """Run each planner once, repairing IR after every mutation."""
+        """Run each planner once with coherent IR and repair every mutation."""
 
         modified = False
         with self._lock:
             planners = tuple(self._planners)
+        if planners:
+            # Inlining and CFG simplification can leave definitions and
+            # postprocessing analysis describing blocks that no longer exist.
+            # Repair once so the first inspection-only planner sees the same
+            # coherent IR promised to every planner after a mutation.
+            self._repair_ir(state.func_ir)
         for planner_cls in planners:
             result = planner_cls(state).run()
             if not isinstance(result, bool):

--- a/src/numba_cuda_mlir/_whole_function_planners.py
+++ b/src/numba_cuda_mlir/_whole_function_planners.py
@@ -48,6 +48,11 @@ class _WholeFunctionPlannerRegistry:
                 self._planners.append(planner_cls)
         return planner_cls
 
+    @property
+    def has_planners(self) -> bool:
+        with self._lock:
+            return bool(self._planners)
+
     def apply(self, state) -> bool:
         """Run each planner once, repairing IR after every mutation."""
 

--- a/src/numba_cuda_mlir/_whole_function_planners.py
+++ b/src/numba_cuda_mlir/_whole_function_planners.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Whole-function extension planning after device-function inlining."""
+
+from threading import RLock
+
+from numba_cuda_mlir.numba_cuda.core import postproc
+from numba_cuda_mlir.numba_cuda.core.ir_utils import build_definitions, simplify_CFG
+
+
+class WholeFunctionPlanner:
+    """Base class for whole-function extension planners.
+
+    Planners run after device-function inlining and before type inference. They
+    may inspect and rewrite any block in ``state.func_ir`` and must return a
+    Boolean indicating whether they changed the IR.
+    """
+
+    def __init__(self, state):
+        self.state = state
+
+    @property
+    def is_device_function(self) -> bool:
+        """Whether the current compilation is for a device function."""
+
+        targetoptions = self.state.metadata.get("targetoptions", {})
+        return bool(targetoptions.get("device", False))
+
+    def run(self) -> bool:
+        """Inspect or rewrite the current function and report whether it changed."""
+
+        raise NotImplementedError
+
+
+class _WholeFunctionPlannerRegistry:
+    def __init__(self):
+        self._planners = []
+        self._lock = RLock()
+
+    def register(self, planner_cls):
+        """Register a planner class and return it for decorator use."""
+
+        if not isinstance(planner_cls, type) or not issubclass(planner_cls, WholeFunctionPlanner):
+            raise TypeError(f"{planner_cls!r} is not a WholeFunctionPlanner subclass")
+        with self._lock:
+            if planner_cls not in self._planners:
+                self._planners.append(planner_cls)
+        return planner_cls
+
+    def apply(self, state) -> bool:
+        """Run each planner once, repairing IR after every mutation."""
+
+        modified = False
+        with self._lock:
+            planners = tuple(self._planners)
+        for planner_cls in planners:
+            result = planner_cls(state).run()
+            if not isinstance(result, bool):
+                raise TypeError(
+                    f"{planner_cls.__name__}.run() must return bool, got {type(result)!r}"
+                )
+            if result:
+                self._repair_ir(state.func_ir)
+                modified = True
+        return modified
+
+    @staticmethod
+    def _repair_ir(func_ir) -> None:
+        func_ir.blocks = simplify_CFG(func_ir.blocks)
+        func_ir._reset_analysis_variables()
+        postproc.PostProcessor(func_ir).run()
+        func_ir._definitions = build_definitions(func_ir.blocks)
+        for block in func_ir.blocks.values():
+            block.verify()
+
+
+_planner_registry = _WholeFunctionPlannerRegistry()
+
+
+def register_planner(planner_cls):
+    """Register a whole-function planner class."""
+
+    return _planner_registry.register(planner_cls)
+
+
+__all__ = ["WholeFunctionPlanner", "register_planner"]

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -39,6 +39,7 @@ from numba_cuda_mlir.numba_cuda.core.descriptors import TargetDescriptor
 from numba_cuda_mlir.numba_cuda.core.compiler_lock import global_compiler_lock
 from numba_cuda_mlir.numba_cuda.dispatcher import Dispatcher
 from numba_cuda_mlir.numba_cuda.core.options import TargetOptions
+from numba_cuda_mlir._whole_function_planners import _planner_registry
 from numba_cuda_mlir.numba_cuda.core.target_extension import (
     CPU,
     target_registry,
@@ -2557,12 +2558,17 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             if active_launch_config is not None:
                 targetoptions["__launch_config__"] = dict(active_launch_config)
 
+        # A cached result bypasses compiler passes. Until planner identity and
+        # implementation are part of the persistent cache key, active planners
+        # must compile in-process so their transformations cannot be skipped.
+        use_disk_cache = active_launch_config_key is None and not _planner_registry.has_planners
+
         # Try to load from disk cache
         mlir_target.ensure_initialized()
         sig = typing.signature(types.none, *argtypes)
         # Launch-specialized compiles use an in-memory cache because the
         # generic in-memory and on-disk cache keys do not include launch metadata.
-        if active_launch_config_key is None:
+        if use_disk_cache:
             cres = self._cache.load_overload(sig, mlir_target.target_context)
             if cres is not None:
                 self._cache_hits[argtypes] += 1
@@ -2571,7 +2577,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 return _result(wrapped)
 
         # Cache miss - need to compile
-        if active_launch_config_key is None:
+        if use_disk_cache:
             self._cache_misses[argtypes] += 1
 
         # Compile using mlir_compiler_entry which handles annotations and AST transforms
@@ -2636,7 +2642,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             self.overloads[result.signature.args] = wrapped
 
         # Save to disk cache
-        if active_launch_config_key is None:
+        if use_disk_cache:
             self._cache.save_overload(sig, result)
 
         return _result(wrapped)
@@ -2665,18 +2671,21 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             return self.overloads[argtypes]
 
         self._resolve_target_options()
+        use_disk_cache = not _planner_registry.has_planners
 
         # Try to load from disk cache
         mlir_target.ensure_initialized()
-        cres = self._cache.load_overload(sig, mlir_target.target_context)
-        if cres is not None:
-            self._cache_hits[argtypes] += 1
-            wrapped = CompileResult(cres)
-            self.overloads[argtypes] = wrapped
-            return wrapped
+        if use_disk_cache:
+            cres = self._cache.load_overload(sig, mlir_target.target_context)
+            if cres is not None:
+                self._cache_hits[argtypes] += 1
+                wrapped = CompileResult(cres)
+                self.overloads[argtypes] = wrapped
+                return wrapped
 
         # Cache miss - need to compile
-        self._cache_misses[argtypes] += 1
+        if use_disk_cache:
+            self._cache_misses[argtypes] += 1
 
         if abi_info is not None:
             self.targetoptions["abi_info"] = abi_info
@@ -2700,7 +2709,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self._propagate_compile_callbacks(cres.metadata)
 
         # Save to cache
-        self._cache.save_overload(sig, cres)
+        if use_disk_cache:
+            self._cache.save_overload(sig, cres)
 
         # Wrap in CompileResult for compatibility attributes
         wrapped = CompileResult(cres)

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -2561,23 +2561,30 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         # A cached result bypasses compiler passes. Until planner identity and
         # implementation are part of the persistent cache key, active planners
         # must compile in-process so their transformations cannot be skipped.
-        use_disk_cache = active_launch_config_key is None and not _planner_registry.has_planners
+        disk_cache_eligible = active_launch_config_key is None
+        disk_cache_miss = False
 
-        # Try to load from disk cache
+        # Serialize cache-hit publication with planner registration. If an
+        # import during cache loading registers a planner reentrantly, discard
+        # that cached result and compile through the planner pass instead.
         mlir_target.ensure_initialized()
         sig = typing.signature(types.none, *argtypes)
         # Launch-specialized compiles use an in-memory cache because the
         # generic in-memory and on-disk cache keys do not include launch metadata.
-        if use_disk_cache:
-            cres = self._cache.load_overload(sig, mlir_target.target_context)
-            if cres is not None:
-                self._cache_hits[argtypes] += 1
-                wrapped = CompileResult(cres)
-                self.overloads[argtypes] = wrapped
-                return _result(wrapped)
+        if disk_cache_eligible:
+            with _planner_registry._lock:
+                if not _planner_registry._planners:
+                    cres = self._cache.load_overload(sig, mlir_target.target_context)
+                    if not _planner_registry._planners:
+                        if cres is not None:
+                            self._cache_hits[argtypes] += 1
+                            wrapped = CompileResult(cres)
+                            self.overloads[argtypes] = wrapped
+                            return _result(wrapped)
+                        disk_cache_miss = True
 
         # Cache miss - need to compile
-        if use_disk_cache:
+        if disk_cache_miss:
             self._cache_misses[argtypes] += 1
 
         # Compile using mlir_compiler_entry which handles annotations and AST transforms
@@ -2642,8 +2649,10 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             self.overloads[result.signature.args] = wrapped
 
         # Save to disk cache
-        if use_disk_cache:
-            self._cache.save_overload(sig, result)
+        if disk_cache_eligible:
+            with _planner_registry._lock:
+                if not _planner_registry._planners:
+                    self._cache.save_overload(sig, result)
 
         return _result(wrapped)
 
@@ -2671,20 +2680,23 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             return self.overloads[argtypes]
 
         self._resolve_target_options()
-        use_disk_cache = not _planner_registry.has_planners
+        disk_cache_miss = False
 
-        # Try to load from disk cache
+        # Publish cache hits atomically with respect to planner registration.
         mlir_target.ensure_initialized()
-        if use_disk_cache:
-            cres = self._cache.load_overload(sig, mlir_target.target_context)
-            if cres is not None:
-                self._cache_hits[argtypes] += 1
-                wrapped = CompileResult(cres)
-                self.overloads[argtypes] = wrapped
-                return wrapped
+        with _planner_registry._lock:
+            if not _planner_registry._planners:
+                cres = self._cache.load_overload(sig, mlir_target.target_context)
+                if not _planner_registry._planners:
+                    if cres is not None:
+                        self._cache_hits[argtypes] += 1
+                        wrapped = CompileResult(cres)
+                        self.overloads[argtypes] = wrapped
+                        return wrapped
+                    disk_cache_miss = True
 
         # Cache miss - need to compile
-        if use_disk_cache:
+        if disk_cache_miss:
             self._cache_misses[argtypes] += 1
 
         if abi_info is not None:
@@ -2709,8 +2721,9 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self._propagate_compile_callbacks(cres.metadata)
 
         # Save to cache
-        if use_disk_cache:
-            self._cache.save_overload(sig, cres)
+        with _planner_registry._lock:
+            if not _planner_registry._planners:
+                self._cache.save_overload(sig, cres)
 
         # Wrap in CompileResult for compatibility attributes
         wrapped = CompileResult(cres)

--- a/src/numba_cuda_mlir/extending/__init__.py
+++ b/src/numba_cuda_mlir/extending/__init__.py
@@ -25,6 +25,10 @@ from numba_cuda_mlir.models import mlir_data_manager
 
 from numba_cuda_mlir.lowering_registry import LoweringRegistry
 from numba_cuda_mlir.extending.argument_handler import ArgumentHandler
+from numba_cuda_mlir._whole_function_planners import (
+    WholeFunctionPlanner,
+    register_planner,
+)
 
 lowering_registry = LoweringRegistry()
 typing_registry = Registry()
@@ -34,12 +38,14 @@ register_model = functools.partial(register, mlir_data_manager)
 
 __all__ = [
     "ArgumentHandler",
+    "WholeFunctionPlanner",
     "intrinsic",
     "lowering_registry",
     "as_numba_type",
     "lower_builtin",
     "lower_cast",
     "refresh_registries",
+    "register_planner",
     "overload",
     "overload_attribute",
     "overload_method",

--- a/src/numba_cuda_mlir/mlir_compiler.py
+++ b/src/numba_cuda_mlir/mlir_compiler.py
@@ -50,6 +50,7 @@ from numba_cuda_mlir.numba_cuda.core.untyped_passes import (
 from numba_cuda_mlir.numbair_transforms import (
     NumbaCudaMlirLiteralUnroll,
     NumbaCudaMlirInlineInlinables,
+    PostInlineWholeFunctionPlanners,
 )
 
 import numba_cuda_mlir.mlir_lowering as lowering
@@ -223,6 +224,12 @@ def get_compiler_class(targetoptions: Dict[str, Any]):
                     modified_passes.append((NumbaCudaMlirLiteralUnroll, desc))
                 elif impl is InlineInlinables:
                     modified_passes.append((NumbaCudaMlirInlineInlinables, desc))
+                    modified_passes.append(
+                        (
+                            PostInlineWholeFunctionPlanners,
+                            "post-inline whole-function extension planners",
+                        )
+                    )
                 else:
                     modified_passes.append((impl, desc))
             pm.passes.extend(modified_passes)

--- a/src/numba_cuda_mlir/numbair_transforms/__init__.py
+++ b/src/numba_cuda_mlir/numbair_transforms/__init__.py
@@ -16,6 +16,7 @@ from numba_cuda_mlir.numba_cuda.core import untyped_passes as untyped_passes_mod
 from numba_cuda_mlir.numba_cuda.core.typed_passes import PartialTypeInference
 from numba_cuda_mlir.numba_cuda.core import ir
 from numba_cuda_mlir.numba_cuda.misc.special import literal_unroll
+from numba_cuda_mlir._whole_function_planners import _planner_registry
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
@@ -119,3 +120,16 @@ class NumbaCudaMlirInlineInlinables(InlineInlinables):
             if instr.opname in ("LOAD_GLOBAL", "LOAD_DEREF") and instr.argval == pyfunc.__name__:
                 return True
         return False
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class PostInlineWholeFunctionPlanners(FunctionPass):
+    """Run extension planners after device-function inlining."""
+
+    _name = "post_inline_whole_function_planners"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        return _planner_registry.apply(state)

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -216,7 +216,8 @@ class _InspectPostInlineStatePlanner(WholeFunctionPlanner):
             current = func_ir._definitions[name]
             assert len(current) == len(rebuilt)
             assert all(lhs is rhs for lhs, rhs in zip(current, rebuilt))
-        assert set(func_ir.block_entry_vars) == set(func_ir.blocks.values())
+        assert set(func_ir.variable_lifetime.cfg.nodes()) == set(func_ir.blocks)
+        assert set(func_ir.variable_lifetime.usedefs.usemap) == set(func_ir.blocks)
         type(self).kernel_runs += 1
         return False
 

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for post-inline whole-function extension planning."""
+
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from numba_cuda_mlir import compiler, cuda, types
+from numba_cuda_mlir._whole_function_planners import (
+    _WholeFunctionPlannerRegistry,
+    _planner_registry,
+)
+from numba_cuda_mlir.extending import WholeFunctionPlanner, register_planner
+from numba_cuda_mlir.numba_cuda.compiler import run_frontend
+from numba_cuda_mlir.numba_cuda.core import ir
+
+
+@pytest.fixture
+def isolated_global_planners():
+    with _planner_registry._lock:
+        original = list(_planner_registry._planners)
+        _planner_registry._planners.clear()
+        try:
+            yield
+        finally:
+            _planner_registry._planners[:] = original
+
+
+def test_planners_run_once_in_registration_order():
+    events = []
+    registry = _WholeFunctionPlannerRegistry()
+
+    class FirstPlanner(WholeFunctionPlanner):
+        def run(self):
+            events.append("first")
+            return False
+
+    class SecondPlanner(WholeFunctionPlanner):
+        def run(self):
+            events.append("second")
+            return False
+
+    assert registry.register(FirstPlanner) is FirstPlanner
+    assert registry.register(FirstPlanner) is FirstPlanner
+    assert registry.register(SecondPlanner) is SecondPlanner
+    assert registry.apply(SimpleNamespace()) is False
+    assert events == ["first", "second"]
+
+
+def test_registration_during_planning_applies_to_next_compilation():
+    events = []
+    registry = _WholeFunctionPlannerRegistry()
+
+    class LatePlanner(WholeFunctionPlanner):
+        def run(self):
+            events.append("late")
+            return False
+
+    class RegisteringPlanner(WholeFunctionPlanner):
+        def run(self):
+            events.append("register")
+            registry.register(LatePlanner)
+            return False
+
+    registry.register(RegisteringPlanner)
+    assert registry.apply(SimpleNamespace()) is False
+    assert events == ["register"]
+
+    assert registry.apply(SimpleNamespace()) is False
+    assert events == ["register", "register", "late"]
+
+
+def test_concurrent_duplicate_registration_is_idempotent():
+    registry = _WholeFunctionPlannerRegistry()
+
+    class Planner(WholeFunctionPlanner):
+        def run(self):
+            return False
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        registered = list(executor.map(registry.register, [Planner] * 64))
+
+    assert registered == [Planner] * 64
+    assert registry._planners == [Planner]
+
+
+def test_planner_registration_and_result_contracts():
+    registry = _WholeFunctionPlannerRegistry()
+
+    with pytest.raises(TypeError, match="WholeFunctionPlanner subclass"):
+        registry.register(object)
+
+    class InvalidResultPlanner(WholeFunctionPlanner):
+        def run(self):
+            return None
+
+    registry.register(InvalidResultPlanner)
+    with pytest.raises(TypeError, match=r"run\(\) must return bool"):
+        registry.apply(SimpleNamespace())
+
+
+def test_ir_is_repaired_between_modifying_planners():
+    events = []
+    observed_constants = []
+    registry = _WholeFunctionPlannerRegistry()
+
+    def add_one(value):
+        return value + 1
+
+    func_ir = run_frontend(add_one)
+
+    class ReplaceConstantPlanner(WholeFunctionPlanner):
+        replaced_var = None
+
+        def run(self):
+            events.append("replace")
+            for block in self.state.func_ir.blocks.values():
+                for index, inst in enumerate(block.body):
+                    if (
+                        isinstance(inst, ir.Assign)
+                        and isinstance(inst.value, ir.Const)
+                        and inst.value.value == 1
+                    ):
+                        block.body[index] = ir.Assign(ir.Const(2, inst.loc), inst.target, inst.loc)
+                        type(self).replaced_var = inst.target
+                        return True
+            raise AssertionError("test function did not contain the expected constant")
+
+    class ObserveDefinitionPlanner(WholeFunctionPlanner):
+        def run(self):
+            events.append("observe")
+            definition = self.state.func_ir.get_definition(ReplaceConstantPlanner.replaced_var)
+            observed_constants.append(definition.value)
+            return False
+
+    registry.register(ReplaceConstantPlanner)
+    registry.register(ObserveDefinitionPlanner)
+
+    assert registry.apply(SimpleNamespace(func_ir=func_ir)) is True
+    assert events == ["replace", "observe"]
+    assert observed_constants == [2]
+
+
+def _post_inline_marker(value):
+    return value
+
+
+class _MarkerPlanner(WholeFunctionPlanner):
+    kernel_runs = 0
+    device_runs = 0
+
+    def run(self):
+        if self.is_device_function:
+            type(self).device_runs += 1
+            return False
+
+        type(self).kernel_runs += 1
+        marker_vars = set()
+        for block in self.state.func_ir.blocks.values():
+            for inst in block.body:
+                if (
+                    isinstance(inst, ir.Assign)
+                    and isinstance(inst.value, ir.Global)
+                    and inst.value.value is _post_inline_marker
+                ):
+                    marker_vars.add(inst.target.name)
+
+        modified = False
+        for block in self.state.func_ir.blocks.values():
+            new_body = []
+            for inst in block.body:
+                if isinstance(inst, ir.Assign) and inst.target.name in marker_vars:
+                    new_body.append(ir.Assign(ir.Const(None, inst.loc), inst.target, inst.loc))
+                    modified = True
+                    continue
+                if isinstance(inst, ir.Assign):
+                    call = inst.value
+                    if (
+                        isinstance(call, ir.Expr)
+                        and call.op == "call"
+                        and isinstance(call.func, ir.Var)
+                        and call.func.name in marker_vars
+                    ):
+                        new_body.append(ir.Assign(call.args[0], inst.target, inst.loc))
+                        modified = True
+                        continue
+                new_body.append(inst)
+            block.body = new_body
+        return modified
+
+
+def test_planner_pass_runs_after_device_inlining_without_gpu(
+    isolated_global_planners,
+):
+    _MarkerPlanner.kernel_runs = 0
+    _MarkerPlanner.device_runs = 0
+    register_planner(_MarkerPlanner)
+
+    @cuda.jit(device=True, inline="always")
+    def device_func(value):
+        if value > 0:
+            return _post_inline_marker(value)
+        return value
+
+    def kernel(d_in, d_out):
+        d_out[0] = device_func(d_in[0])
+
+    compiler.compile(
+        kernel,
+        types.void(types.int32[::1], types.int32[::1]),
+        device=False,
+        abi="numba",
+        cc=(8, 0),
+    )
+
+    assert _MarkerPlanner.kernel_runs == 1
+    assert _MarkerPlanner.device_runs == 0
+
+
+def test_planner_runs_for_device_function_compilation_without_gpu(
+    isolated_global_planners,
+):
+    _MarkerPlanner.kernel_runs = 0
+    _MarkerPlanner.device_runs = 0
+    register_planner(_MarkerPlanner)
+
+    def device_func(value):
+        return value + 1
+
+    compiler.compile(
+        device_func,
+        types.int32(types.int32),
+        device=True,
+        abi="numba",
+        cc=(8, 0),
+    )
+
+    assert _MarkerPlanner.kernel_runs == 0
+    assert _MarkerPlanner.device_runs == 1
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_planner_sees_inline_device_function_body(isolated_global_planners):
+    _MarkerPlanner.kernel_runs = 0
+    _MarkerPlanner.device_runs = 0
+    register_planner(_MarkerPlanner)
+
+    @cuda.jit(device=True, inline="always")
+    def device_func(value):
+        if value > 0:
+            return _post_inline_marker(value)
+        return value
+
+    @cuda.jit
+    def kernel(d_in, d_out):
+        d_out[0] = device_func(d_in[0])
+
+    h_input = np.asarray([7], dtype=np.int32)
+    h_output = np.asarray([0], dtype=np.int32)
+    kernel[1, 1](h_input, h_output)
+
+    np.testing.assert_array_equal(h_output, h_input)
+    assert _MarkerPlanner.kernel_runs == 1
+    assert _MarkerPlanner.device_runs == 0

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -145,6 +145,51 @@ def test_ir_is_repaired_between_modifying_planners():
     assert observed_constants == [2]
 
 
+def test_active_planners_bypass_persistent_dispatch_cache(
+    isolated_global_planners,
+    monkeypatch,
+):
+    from numba_cuda_mlir import descriptor as descriptor_mod, mlir_compiler
+    from numba_cuda_mlir.numba_cuda import typing as cuda_typing
+
+    class Planner(WholeFunctionPlanner):
+        def run(self):
+            return False
+
+    class UnexpectedCache:
+        def load_overload(self, *args):
+            pytest.fail("active planners must not load persistent cache entries")
+
+        def save_overload(self, *args):
+            pytest.fail("active planners must not save persistent cache entries")
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"compiled", "func_name": "kernel"}
+
+    def kernel(value):
+        pass
+
+    register_planner(Planner)
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher._cache = UnexpectedCache()
+    monkeypatch.setattr(
+        mlir_compiler,
+        "mlir_compiler_entry",
+        lambda *args, **kwargs: CompilerResult(),
+    )
+    monkeypatch.setattr(
+        descriptor_mod._compile_arg_types,
+        "types",
+        (types.int32,),
+        raising=False,
+    )
+
+    assert dispatcher._compile_impl([1]) == (b"compiled", "kernel", False)
+    assert not dispatcher._cache_hits
+    assert not dispatcher._cache_misses
+
+
 def _post_inline_marker(value):
     return value
 

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -25,9 +25,10 @@ def isolated_global_planners():
     with _planner_registry._lock:
         original = list(_planner_registry._planners)
         _planner_registry._planners.clear()
-        try:
-            yield
-        finally:
+    try:
+        yield
+    finally:
+        with _planner_registry._lock:
             _planner_registry._planners[:] = original
 
 
@@ -196,6 +197,55 @@ def test_active_planners_bypass_persistent_dispatch_cache(
     assert dispatcher._compile_impl([1]) == (b"compiled", "kernel", False)
     assert not dispatcher._cache_hits
     assert not dispatcher._cache_misses
+
+
+def test_planner_registered_during_compile_prevents_persistent_cache_save(
+    isolated_global_planners,
+    monkeypatch,
+):
+    from numba_cuda_mlir import descriptor as descriptor_mod, mlir_compiler
+    from numba_cuda_mlir.numba_cuda import typing as cuda_typing
+
+    class Planner(WholeFunctionPlanner):
+        def run(self):
+            return False
+
+    class TrackingCache:
+        load_calls = 0
+        save_calls = 0
+
+        def load_overload(self, *args):
+            self.load_calls += 1
+            return None
+
+        def save_overload(self, *args):
+            self.save_calls += 1
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"compiled", "func_name": "kernel"}
+
+    def kernel(value):
+        pass
+
+    def compile_and_register(*args, **kwargs):
+        register_planner(Planner)
+        return CompilerResult()
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher._cache = TrackingCache()
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", compile_and_register)
+    monkeypatch.setattr(
+        descriptor_mod._compile_arg_types,
+        "types",
+        (types.int32,),
+        raising=False,
+    )
+
+    assert dispatcher._compile_impl([1]) == (b"compiled", "kernel", False)
+    assert dispatcher._cache.load_calls == 1
+    assert dispatcher._cache.save_calls == 0
+    assert dispatcher._cache_misses[(types.int32,)] == 1
 
 
 def _post_inline_marker(value):

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -17,6 +17,7 @@ from numba_cuda_mlir._whole_function_planners import (
 from numba_cuda_mlir.extending import WholeFunctionPlanner, register_planner
 from numba_cuda_mlir.numba_cuda.compiler import run_frontend
 from numba_cuda_mlir.numba_cuda.core import ir
+from numba_cuda_mlir.numba_cuda.core.ir_utils import build_definitions
 
 
 @pytest.fixture
@@ -28,6 +29,13 @@ def isolated_global_planners():
             yield
         finally:
             _planner_registry._planners[:] = original
+
+
+def _planner_state():
+    def empty():
+        pass
+
+    return SimpleNamespace(func_ir=run_frontend(empty))
 
 
 def test_planners_run_once_in_registration_order():
@@ -47,7 +55,7 @@ def test_planners_run_once_in_registration_order():
     assert registry.register(FirstPlanner) is FirstPlanner
     assert registry.register(FirstPlanner) is FirstPlanner
     assert registry.register(SecondPlanner) is SecondPlanner
-    assert registry.apply(SimpleNamespace()) is False
+    assert registry.apply(_planner_state()) is False
     assert events == ["first", "second"]
 
 
@@ -67,10 +75,10 @@ def test_registration_during_planning_applies_to_next_compilation():
             return False
 
     registry.register(RegisteringPlanner)
-    assert registry.apply(SimpleNamespace()) is False
+    assert registry.apply(_planner_state()) is False
     assert events == ["register"]
 
-    assert registry.apply(SimpleNamespace()) is False
+    assert registry.apply(_planner_state()) is False
     assert events == ["register", "register", "late"]
 
 
@@ -100,7 +108,7 @@ def test_planner_registration_and_result_contracts():
 
     registry.register(InvalidResultPlanner)
     with pytest.raises(TypeError, match=r"run\(\) must return bool"):
-        registry.apply(SimpleNamespace())
+        registry.apply(_planner_state())
 
 
 def test_ir_is_repaired_between_modifying_planners():
@@ -194,6 +202,25 @@ def _post_inline_marker(value):
     return value
 
 
+class _InspectPostInlineStatePlanner(WholeFunctionPlanner):
+    kernel_runs = 0
+
+    def run(self):
+        if self.is_device_function:
+            return False
+
+        func_ir = self.state.func_ir
+        rebuilt_definitions = build_definitions(func_ir.blocks)
+        assert set(func_ir._definitions) == set(rebuilt_definitions)
+        for name, rebuilt in rebuilt_definitions.items():
+            current = func_ir._definitions[name]
+            assert len(current) == len(rebuilt)
+            assert all(lhs is rhs for lhs, rhs in zip(current, rebuilt))
+        assert set(func_ir.block_entry_vars) == set(func_ir.blocks.values())
+        type(self).kernel_runs += 1
+        return False
+
+
 class _MarkerPlanner(WholeFunctionPlanner):
     kernel_runs = 0
     device_runs = 0
@@ -241,8 +268,10 @@ class _MarkerPlanner(WholeFunctionPlanner):
 def test_planner_pass_runs_after_device_inlining_without_gpu(
     isolated_global_planners,
 ):
+    _InspectPostInlineStatePlanner.kernel_runs = 0
     _MarkerPlanner.kernel_runs = 0
     _MarkerPlanner.device_runs = 0
+    register_planner(_InspectPostInlineStatePlanner)
     register_planner(_MarkerPlanner)
 
     @cuda.jit(device=True, inline="always")
@@ -262,6 +291,7 @@ def test_planner_pass_runs_after_device_inlining_without_gpu(
         cc=(8, 0),
     )
 
+    assert _InspectPostInlineStatePlanner.kernel_runs == 1
     assert _MarkerPlanner.kernel_runs == 1
     assert _MarkerPlanner.device_runs == 0
 


### PR DESCRIPTION
## Overview

Add an opt-in whole-function planner extension point immediately after device-function inlining and before type inference.

- Export `WholeFunctionPlanner` and `register_planner` from `numba_cuda_mlir.extending`.
- Run registered planners in deterministic order using a thread-safe per-pass snapshot.
- Repair post-inline CFG and analysis state before the first planner, then repair again after each planner that mutates IR so every planner sees a coherent function.
- Expose kernel-versus-device-function classification through `is_device_function`.
- Bypass persistent cache load/save while planners are registered so cached code cannot skip planner transformations.
- Serialize persistent-cache hit publication and save decisions with planner registration, while leaving compilation itself unlocked so planners can register for the next compilation.
- Document the public contract and API.

This provides the post-inline visibility needed by extensions without rerunning every before-inference rewrite.

## Validation

- Fresh-head planner/dispatcher suite: 60 passed on SM120.
- Fresh-head changed-file pre-commit and git diff checks passed.
- Exact-head GitHub Actions run [30037569855](https://github.com/NVIDIA/numba-cuda-mlir/actions/runs/30037569855) completed green at `b3449050d23c9b0238e496b4ad164f6cee63181a`: 124 successful jobs, 4 skipped, zero failed or pending.
- Focused inline, extending, LTO, and compile-device regressions: 48 passed.
- Full Sphinx HTML build succeeded without warnings.

Closes #62.

Co-authored-by: Codex 5.6 Sol Ultra Fast