### PR TITLE
Add demand-driven planner launch metadata

### DIFF
--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -37,9 +37,10 @@ Whole-function planning
 
 Extensions that need to inspect or transform a complete function before typing
 can register a :py:class:`~numba_cuda_mlir.extending.WholeFunctionPlanner`.
-Planners run once after inlineable device functions have been merged into the
-caller and before type inference. This makes calls introduced by device
-helpers visible without rerunning unrelated rewrite registries.
+Each planner runs once per compiler attempt after inlineable device functions
+have been merged into the caller and before type inference. This makes calls
+introduced by device helpers visible without rerunning unrelated rewrite
+registries.
 
 Implement ``run()`` and return ``True`` only when the planner changed
 ``state.func_ir``. Before the first planner and after each change,
@@ -62,11 +63,20 @@ should check ``self.is_device_function`` and decline device functions.
            return bool(modified)
 
 Registration order is preserved, and registering the same planner class more
-than once has no effect. The planner pass snapshots its registry before
-running, so planners registered after that snapshot, including from a running
-planner, start with the next compilation. Planners operate on untyped Numba
-IR; typing and MLIR lowering extensions remain responsible for the later
-compilation phases.
+than once has no effect. The planner pass snapshots its registry before each
+compiler attempt. A planner registered after that snapshot does not join the
+active attempt, but it can run in a later retry or compilation. Planners
+operate on untyped Numba IR; typing and MLIR lowering extensions remain
+responsible for the later compilation phases.
+
+A planner that needs the configured grid, block, dynamic shared memory, or
+cluster should call
+:py:func:`~numba_cuda_mlir.extending.require_launch_config`. The first generic
+compiler attempt requests a launch-qualified retry; the planner then runs
+again with normalized launch metadata. A retry reruns the complete ordered
+planner set, including planners that did not request the metadata. Planners
+must therefore be pure or idempotent across attempts and should avoid
+externally visible side effects.
 
 Register every planner before compiling a dispatcher that needs it.
 Registration does not invalidate an overload that the dispatcher has already
@@ -81,6 +91,8 @@ cache key. In-memory overload reuse is unchanged.
    :members: is_device_function, run
 
 .. autofunction:: numba_cuda_mlir.extending.register_planner
+
+.. autofunction:: numba_cuda_mlir.extending.require_launch_config
 
 Typing
 ------

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -65,18 +65,24 @@ should check ``self.is_device_function`` and decline device functions.
 Registration order is preserved, and registering the same planner class more
 than once has no effect. The planner pass snapshots its registry before each
 compiler attempt. A planner registered after that snapshot does not join the
-active attempt, but it can run in a later retry or compilation. Planners
+active attempt, but it can run in a later compilation. Planners
 operate on untyped Numba IR; typing and MLIR lowering extensions remain
 responsible for the later compilation phases.
 
 A planner that needs the configured grid, block, dynamic shared memory, or
 cluster should call
-:py:func:`~numba_cuda_mlir.extending.require_launch_config`. The first generic
-compiler attempt requests a launch-qualified retry; the planner then runs
-again with normalized launch metadata. A retry reruns the complete ordered
-planner set, including planners that did not request the metadata. Planners
-must therefore be pure or idempotent across attempts and should avoid
-externally visible side effects.
+:py:func:`~numba_cuda_mlir.extending.require_launch_config`. A configured
+kernel launch makes normalized launch metadata available to compiler state
+without specializing ordinary kernels up front. The first planner that calls
+``require_launch_config()`` promotes that metadata for the current compiler
+attempt; subsequent planning, typing, and lowering phases observe the same
+launch-qualified target options. The resulting overload is keyed by the
+normalized launch configuration, while planners that never request it keep a
+generic overload.
+
+Extensions that consume launch metadata during the earlier AST-transform phase
+must opt in with ``uses_launch_config = True`` so launch qualification is active
+before whole-function planning begins.
 
 Register every planner before compiling a dispatcher that needs it.
 Registration does not invalidate an overload that the dispatcher has already

--- a/src/numba_cuda_mlir/_launch_config.py
+++ b/src/numba_cuda_mlir/_launch_config.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal launch-configuration normalization shared by dispatch and planning."""
+
+_LAUNCH_CONFIG_TRACKER_METADATA_KEY = "launch_config_tracker"
+_LAUNCH_CONFIG_TRACKER_OPTION = "__launch_config_tracker__"
+
+
+class _LaunchConfigTracker:
+    """Lazily normalize and record launch metadata used by one compiler attempt."""
+
+    __slots__ = ("_available_launch_config", "_launch_config", "required")
+
+    def __init__(self, available_launch_config):
+        self._available_launch_config = available_launch_config
+        self._launch_config = None
+        self.required = False
+
+    def require(self):
+        if self._launch_config is None:
+            self._launch_config = _normalize_available_launch_config(self._available_launch_config)
+        self.required = True
+        return self._launch_config
+
+    @property
+    def launch_config(self):
+        return self._launch_config
+
+
+def _is_launch_config_key_tuple(value):
+    return (
+        isinstance(value, tuple)
+        and len(value) == 4
+        and all(isinstance(item, tuple) and len(item) == 2 for item in value)
+        and value[0][0] == "grid"
+        and value[1][0] == "block"
+        and value[2][0] == "sharedmem"
+        and value[3][0] == "cluster"
+    )
+
+
+def _launch_config_key(launch_config):
+    """Return the specialization key for a configure-produced launch config."""
+
+    if launch_config is None:
+        return None
+    block = launch_config.get("block")
+    if block is None:
+        raise ValueError("launch_config must contain a 'block' entry")
+    if not isinstance(block, tuple):
+        raise TypeError("launch_config 'block' must be a normalized tuple")
+    grid = launch_config.get("grid")
+    if grid is None:
+        raise ValueError("launch_config must contain a 'grid' entry")
+    if not isinstance(grid, tuple):
+        raise TypeError("launch_config 'grid' must be a normalized tuple")
+    cluster = launch_config.get("cluster")
+    if cluster is not None and not isinstance(cluster, tuple):
+        raise TypeError("launch_config 'cluster' must be a normalized tuple or None")
+    sharedmem = launch_config.get("sharedmem", 0)
+    if sharedmem is None:
+        sharedmem = 0
+    try:
+        sharedmem = int(sharedmem)
+    except (TypeError, ValueError):
+        raise TypeError("launch_config 'sharedmem' must be integer-convertible") from None
+    return (
+        ("grid", grid),
+        ("block", block),
+        ("sharedmem", sharedmem),
+        ("cluster", cluster),
+    )
+
+
+def _launch_config_dict_from_key(launch_config_key):
+    if not _is_launch_config_key_tuple(launch_config_key):
+        raise TypeError("launch_config_key must be a normalized launch-config key")
+    return {name: value for name, value in launch_config_key}
+
+
+def _normalize_available_launch_config(launch_config):
+    launch_config_key = _launch_config_key(launch_config)
+    if launch_config_key is None:
+        return None
+    return _launch_config_dict_from_key(launch_config_key)

--- a/src/numba_cuda_mlir/_whole_function_planners.py
+++ b/src/numba_cuda_mlir/_whole_function_planners.py
@@ -9,6 +9,10 @@ from numba_cuda_mlir.numba_cuda.core import postproc
 from numba_cuda_mlir.numba_cuda.core.ir_utils import build_definitions, simplify_CFG
 
 
+class _RequireLaunchConfig(RuntimeError):
+    """Request a launch-qualified compiler attempt."""
+
+
 class WholeFunctionPlanner:
     """Base class for whole-function extension planners.
 
@@ -89,6 +93,27 @@ class _WholeFunctionPlannerRegistry:
 _planner_registry = _WholeFunctionPlannerRegistry()
 
 
+def require_launch_config(state) -> dict:
+    """Return normalized launch metadata or request a launch-qualified retry."""
+
+    metadata = getattr(state, "metadata", None)
+    if not isinstance(metadata, dict):
+        raise TypeError("compiler state metadata must be a dict")
+    targetoptions = metadata.get("targetoptions")
+    if not isinstance(targetoptions, dict):
+        raise TypeError("compiler state metadata must contain targetoptions")
+    launch_config = targetoptions.get("__launch_config__")
+    if (
+        not isinstance(launch_config, dict)
+        or "grid" not in launch_config
+        or "block" not in launch_config
+    ):
+        raise _RequireLaunchConfig(
+            "whole-function planner requires metadata from a configured kernel launch"
+        )
+    return launch_config
+
+
 def register_planner(planner_cls):
     """Register a whole-function planner class.
 
@@ -99,4 +124,4 @@ def register_planner(planner_cls):
     return _planner_registry.register(planner_cls)
 
 
-__all__ = ["WholeFunctionPlanner", "register_planner"]
+__all__ = ["WholeFunctionPlanner", "register_planner", "require_launch_config"]

--- a/src/numba_cuda_mlir/_whole_function_planners.py
+++ b/src/numba_cuda_mlir/_whole_function_planners.py
@@ -5,12 +5,16 @@
 
 from threading import RLock
 
+from numba_cuda_mlir._launch_config import (
+    _LAUNCH_CONFIG_TRACKER_METADATA_KEY,
+    _LaunchConfigTracker,
+)
 from numba_cuda_mlir.numba_cuda.core import postproc
 from numba_cuda_mlir.numba_cuda.core.ir_utils import build_definitions, simplify_CFG
 
 
 class _RequireLaunchConfig(RuntimeError):
-    """Request a launch-qualified compiler attempt."""
+    """Report that no configured launch metadata is available."""
 
 
 class WholeFunctionPlanner:
@@ -94,7 +98,7 @@ _planner_registry = _WholeFunctionPlannerRegistry()
 
 
 def require_launch_config(state) -> dict:
-    """Return normalized launch metadata or request a launch-qualified retry."""
+    """Return normalized launch metadata for the current compiler attempt."""
 
     metadata = getattr(state, "metadata", None)
     if not isinstance(metadata, dict):
@@ -108,9 +112,13 @@ def require_launch_config(state) -> dict:
         or "grid" not in launch_config
         or "block" not in launch_config
     ):
-        raise _RequireLaunchConfig(
-            "whole-function planner requires metadata from a configured kernel launch"
-        )
+        launch_config_tracker = metadata.get(_LAUNCH_CONFIG_TRACKER_METADATA_KEY)
+        if not isinstance(launch_config_tracker, _LaunchConfigTracker):
+            raise _RequireLaunchConfig(
+                "whole-function planner requires metadata from a configured kernel launch"
+            )
+        launch_config = launch_config_tracker.require()
+        targetoptions["__launch_config__"] = launch_config
     return launch_config
 
 

--- a/src/numba_cuda_mlir/compiler.py
+++ b/src/numba_cuda_mlir/compiler.py
@@ -274,6 +274,7 @@ def _compile_only(pyfunc, sig=None, targetoptions=None):
     """Compile to MLIR without running the optimization pipeline."""
     from numba_cuda_mlir.cuda import jit
     from numba_cuda_mlir import mlir_compiler
+    from numba_cuda_mlir._whole_function_planners import _RequireLaunchConfig
     from numba_cuda_mlir.numba_cuda.core import sigutils
 
     dispatcher = pyfunc
@@ -287,12 +288,18 @@ def _compile_only(pyfunc, sig=None, targetoptions=None):
         sig = to_numba_type(inspect.signature(pyfunc))
 
     argtypes, return_type = sigutils.normalize_signature(sig)
-    cres = mlir_compiler.compile_mlir(
-        dispatcher.py_func,
-        return_type,
-        argtypes,
-        targetoptions=dispatcher.targetoptions,
-    )
+    try:
+        cres = mlir_compiler.compile_mlir(
+            dispatcher.py_func,
+            return_type,
+            argtypes,
+            targetoptions=dispatcher.targetoptions,
+        )
+    except _RequireLaunchConfig:
+        raise RuntimeError(
+            "whole-function planner requires launch metadata; compile through a "
+            "configured kernel launch"
+        ) from None
     return CompileResult(cres)
 
 

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -1965,7 +1965,14 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             sigs = []
             launch_config_sigs = []
         else:
-            sigs = [cr.signature for cr in self.overloads.values()]
+            # Once a planner requests launch metadata, generic overloads are
+            # no longer reachable through dispatch. Rebuilding them would also
+            # rerun the active planner without a configured launch.
+            sigs = (
+                []
+                if self._requires_launch_config
+                else [cr.signature for cr in self.overloads.values()]
+            )
             launch_config_sigs = []
             if self._launch_config_enabled:
                 seen = set()

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -663,9 +663,19 @@ class _ArgMarshaller:
             active_launch_config_generation = self._launch_config_generation
             launcher = self._launcher
             dispatcher = self._dispatcher
+            snapshot_launch_config_is_stale = _extensions_use_launch_config(
+                self._extensions
+                if self._has_extension_snapshot
+                else getattr(dispatcher, "extensions", ())
+            ) and self._launch_config_generation != getattr(
+                dispatcher,
+                "_launch_config_generation",
+                self._launch_config_generation,
+            )
             if dispatcher is not None and (
                 _planner_registry.has_planners
                 or getattr(dispatcher, "_requires_launch_config", False)
+                or snapshot_launch_config_is_stale
             ):
                 (
                     active_kernel_dispatcher,

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -39,7 +39,10 @@ from numba_cuda_mlir.numba_cuda.core.descriptors import TargetDescriptor
 from numba_cuda_mlir.numba_cuda.core.compiler_lock import global_compiler_lock
 from numba_cuda_mlir.numba_cuda.dispatcher import Dispatcher
 from numba_cuda_mlir.numba_cuda.core.options import TargetOptions
-from numba_cuda_mlir._whole_function_planners import _planner_registry
+from numba_cuda_mlir._whole_function_planners import (
+    _RequireLaunchConfig,
+    _planner_registry,
+)
 from numba_cuda_mlir.numba_cuda.core.target_extension import (
     CPU,
     target_registry,
@@ -67,6 +70,7 @@ _DISPATCHER_STATE_ATTRS = (
     "_launch_config_overloads",
     "_launch_config_dispatchers",
     "_launch_config_generation",
+    "_requires_launch_config",
     "_launch_config_cache_misses",
     "_launch_config_cache_hits",
     "_launch_config_cache_notice_emitted",
@@ -401,6 +405,13 @@ def _launch_config_dict_from_key(launch_config_key):
     return {name: value for name, value in launch_config_key}
 
 
+def _normalize_available_launch_config(launch_config):
+    launch_config_key = _launch_config_key(launch_config)
+    if launch_config_key is None:
+        return None
+    return _launch_config_dict_from_key(launch_config_key)
+
+
 def _normalize_launch_sharedmem(sharedmem):
     if sharedmem is None:
         return 0
@@ -450,9 +461,11 @@ class _ArgMarshaller:
         extensions=None,
         dispatcher=None,
         launch_config=None,
+        available_launch_config=None,
         kernel_dispatcher=None,
         launch_config_generation=None,
         stream_ref=None,
+        launch_stream=None,
     ):
         self._launcher = launcher
         self._callbacks = []
@@ -463,9 +476,13 @@ class _ArgMarshaller:
         self._extensions = list(extensions) if extensions is not None else []
         self._dispatcher = dispatcher
         self._launch_config = launch_config
+        self._available_launch_config = (
+            launch_config if available_launch_config is None else available_launch_config
+        )
         self._kernel_dispatcher = kernel_dispatcher
         self._launch_config_generation = launch_config_generation
         self._stream_ref = stream_ref
+        self._launch_stream = launch_stream
         self._kernel_dispatcher_registered = False
         self._kernel_dispatcher_registration_lock = threading.Lock()
         self._sig_cache = {}  # {type_key: (argtypes, fast_ok)}
@@ -561,9 +578,10 @@ class _ArgMarshaller:
         extensions = (
             self._extensions if self._has_extension_snapshot else getattr(disp, "extensions", ())
         )
-        active_launch_config = (
-            self._launch_config if _extensions_use_launch_config(extensions) else None
+        uses_launch_config = _extensions_use_launch_config(extensions) or getattr(
+            disp, "_requires_launch_config", False
         )
+        active_launch_config = self._available_launch_config if uses_launch_config else None
         active_launch_config_key = _launch_config_key(active_launch_config)
         if active_launch_config_key is None:
             overload_argtypes = tuple(disp.overloads)
@@ -623,45 +641,100 @@ class _ArgMarshaller:
         # compile-time helpers.
         previous_types = getattr(_compile_arg_types, "types", _MISSING)
         previous_launch_config = getattr(_compile_arg_types, "launch_config", _MISSING)
+        previous_available_launch_config = getattr(
+            _compile_arg_types, "available_launch_config", _MISSING
+        )
         previous_extensions = getattr(_compile_arg_types, "extensions", _MISSING)
         try:
             _compile_arg_types.types = argtypes
-            if self._launch_config is not None:
-                _compile_arg_types.launch_config = self._launch_config
-            elif hasattr(_compile_arg_types, "launch_config"):
-                delattr(_compile_arg_types, "launch_config")
+            if self._available_launch_config is not None:
+                _compile_arg_types.available_launch_config = self._available_launch_config
+            elif hasattr(_compile_arg_types, "available_launch_config"):
+                delattr(_compile_arg_types, "available_launch_config")
             if self._has_extension_snapshot:
                 _compile_arg_types.extensions = self._extensions
             elif self._dispatcher is not None and hasattr(self._dispatcher, "extensions"):
                 _compile_arg_types.extensions = self._dispatcher.extensions
             elif hasattr(_compile_arg_types, "extensions"):
                 delattr(_compile_arg_types, "extensions")
+
+            active_launch_config = self._launch_config
+            active_kernel_dispatcher = self._kernel_dispatcher
+            active_launch_config_generation = self._launch_config_generation
+            launcher = self._launcher
+            dispatcher = self._dispatcher
+            if dispatcher is not None and (
+                _planner_registry.has_planners
+                or getattr(dispatcher, "_requires_launch_config", False)
+            ):
+                (
+                    active_kernel_dispatcher,
+                    active_launch_config_generation,
+                    active_launch_config,
+                ) = dispatcher._prepare_for_launch(
+                    tuple(launch_args),
+                    tuple(argtypes),
+                    self._available_launch_config,
+                    self._launch_config,
+                    self._kernel_dispatcher,
+                    self._launch_config_generation,
+                )
+                if (
+                    active_kernel_dispatcher is not self._kernel_dispatcher
+                    or active_launch_config != self._launch_config
+                ):
+                    # A generic compile after recompile() replaces the native
+                    # dispatcher without activating launch metadata. Rebuild
+                    # the launcher from the configure-time geometry while
+                    # keeping launch_config absent from compiler TLS.
+                    launcher_config = (
+                        active_launch_config
+                        if active_launch_config is not None
+                        else self._available_launch_config
+                    )
+                    launcher = LaunchConfiguration(
+                        active_kernel_dispatcher,
+                        launcher_config["grid"],
+                        launcher_config["block"],
+                        self._launch_stream,
+                        launcher_config["sharedmem"],
+                        launcher_config.get("cluster"),
+                    )
+                    with self._kernel_dispatcher_registration_lock:
+                        self._launcher = launcher
+                        self._launch_config = active_launch_config
+                        self._kernel_dispatcher = active_kernel_dispatcher
+                        self._launch_config_generation = active_launch_config_generation
+                        self._kernel_dispatcher_registered = False
+
+            if active_launch_config is not None:
+                _compile_arg_types.launch_config = active_launch_config
+            elif hasattr(_compile_arg_types, "launch_config"):
+                delattr(_compile_arg_types, "launch_config")
             if (
-                self._dispatcher is not None
-                and self._launch_config is not None
-                and self._kernel_dispatcher is not None
+                dispatcher is not None
+                and active_launch_config is not None
+                and active_kernel_dispatcher is not None
             ):
                 with self._kernel_dispatcher_registration_lock:
                     if self._kernel_dispatcher_registered and hasattr(
-                        self._dispatcher, "_is_kernel_dispatcher_registered"
+                        dispatcher, "_is_kernel_dispatcher_registered"
                     ):
                         self._kernel_dispatcher_registered = (
-                            self._dispatcher._is_kernel_dispatcher_registered(
-                                self._launch_config,
-                                self._kernel_dispatcher,
-                                self._launch_config_generation,
+                            dispatcher._is_kernel_dispatcher_registered(
+                                active_launch_config,
+                                active_kernel_dispatcher,
+                                active_launch_config_generation,
                             )
                         )
                     if not self._kernel_dispatcher_registered:
-                        self._kernel_dispatcher_registered = (
-                            self._dispatcher._remember_kernel_dispatcher(
-                                self._launch_config,
-                                self._kernel_dispatcher,
-                                self._launch_config_generation,
-                                replace_existing=False,
-                            )
+                        self._kernel_dispatcher_registered = dispatcher._remember_kernel_dispatcher(
+                            active_launch_config,
+                            active_kernel_dispatcher,
+                            active_launch_config_generation,
+                            replace_existing=False,
                         )
-            return self._launcher(*launch_args)
+            return launcher(*launch_args)
         except UserFacingInternalCompilerError as e:
             if os.environ.get("NUMBA_CUDA_MLIR_ICE_FULL_TB", "0").strip() == "1":
                 raise
@@ -679,6 +752,11 @@ class _ArgMarshaller:
                     delattr(_compile_arg_types, "launch_config")
             else:
                 _compile_arg_types.launch_config = previous_launch_config
+            if previous_available_launch_config is _MISSING:
+                if hasattr(_compile_arg_types, "available_launch_config"):
+                    delattr(_compile_arg_types, "available_launch_config")
+            else:
+                _compile_arg_types.available_launch_config = previous_available_launch_config
             if previous_extensions is _MISSING:
                 if hasattr(_compile_arg_types, "extensions"):
                     delattr(_compile_arg_types, "extensions")
@@ -1531,6 +1609,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self._launch_config_overloads = {}
         self._launch_config_dispatchers = collections.OrderedDict()
         self._launch_config_generation = 0
+        self._requires_launch_config = False
         self._c = self._new_kernel_dispatcher()
         self.extensions = targetoptions.get("extensions") or []
         self._specialized = False
@@ -1580,7 +1659,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
 
     @property
     def _launch_config_enabled(self):
-        return _extensions_use_launch_config(self.extensions)
+        return self._requires_launch_config or _extensions_use_launch_config(self.extensions)
+
+    def _mark_requires_launch_config(self):
+        with self._launch_config_lock:
+            self._requires_launch_config = True
 
     def _get_kernel_dispatcher(self, launch_config):
         dispatcher, _ = self._get_kernel_dispatcher_and_generation(launch_config)
@@ -1590,6 +1673,12 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self._ensure_dispatcher_state()
         if not self._launch_config_enabled:
             return self._c, None
+        return self._get_launch_config_dispatcher_and_generation(launch_config)
+
+    def _get_launch_config_dispatcher_and_generation(self, launch_config):
+        """Get a launch-keyed dispatcher independent of current extensions."""
+
+        self._ensure_dispatcher_state()
         launch_config_key = _launch_config_key(launch_config)
         if launch_config_key is None:
             return self._c, None
@@ -1673,6 +1762,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 self._launch_config_dispatchers = collections.OrderedDict()
             if not hasattr(self, "_launch_config_generation"):
                 self._launch_config_generation = 0
+            if not hasattr(self, "_requires_launch_config"):
+                self._requires_launch_config = False
             if not hasattr(self, "_launch_config_cache_misses"):
                 self._launch_config_cache_misses = collections.Counter()
             if not hasattr(self, "_launch_config_cache_hits"):
@@ -1832,6 +1923,12 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 warnings.warn(NumbaPerformanceWarning(msg))
 
         launch_config = None
+        available_launch_config = {
+            "grid": griddim,
+            "block": blockdim,
+            "sharedmem": configured_sharedmem,
+            "cluster": cluster,
+        }
         kernel_dispatcher = self._c
         launch_config_generation = None
         stream_ref = None
@@ -1840,12 +1937,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             stream_ref = stream
             launch_stream = int(stream.handle)
         if launch_config_enabled:
-            launch_config = {
-                "grid": griddim,
-                "block": blockdim,
-                "sharedmem": configured_sharedmem,
-                "cluster": cluster,
-            }
+            launch_config = available_launch_config
             (
                 kernel_dispatcher,
                 launch_config_generation,
@@ -1859,9 +1951,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             extensions=extensions,
             dispatcher=self,
             launch_config=launch_config,
+            available_launch_config=available_launch_config,
             kernel_dispatcher=kernel_dispatcher,
             launch_config_generation=launch_config_generation,
             stream_ref=stream_ref,
+            launch_stream=launch_stream,
         )
 
     def _reduce_states(self):
@@ -1892,11 +1986,20 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             can_compile=self._can_compile,
             sigs=sigs,
             launch_config_sigs=launch_config_sigs,
+            requires_launch_config=self._requires_launch_config,
         )
 
     @classmethod
     def _rebuild(
-        cls, uuid, py_func, locals, targetoptions, can_compile, sigs, launch_config_sigs=()
+        cls,
+        uuid,
+        py_func,
+        locals,
+        targetoptions,
+        can_compile,
+        sigs,
+        launch_config_sigs=(),
+        requires_launch_config=False,
     ):
         """Rebuild an MLIRDispatcher after serialization."""
         try:
@@ -1906,6 +2009,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self = cls(py_func, targetoptions=targetoptions)
         self.locals = locals
         self._set_uuid(uuid)
+        self._requires_launch_config = bool(requires_launch_config)
         for sig in sigs:
             self.compile(sig)
         for sig, launch_config_key in launch_config_sigs:
@@ -2360,6 +2464,70 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         tied = [sig_args for rate, sig_args in candidates if rate == best_rate]
         return tied, True
 
+    def _compile_result_for(self, argtypes, launch_config):
+        if launch_config is not None:
+            launch_config_key = _launch_config_key(launch_config)
+            with self._launch_config_lock:
+                return self._find_launch_config_overload_locked(argtypes, launch_config_key)
+        exact = self.overloads.get(argtypes)
+        if exact is not None:
+            return exact
+        for sig_args, cres in self.overloads.items():
+            if len(sig_args) == len(argtypes) and all(
+                self._can_reuse_overload(s, r) for s, r in zip(sig_args, argtypes)
+            ):
+                return cres
+        return None
+
+    @global_compiler_lock
+    def _prepare_for_launch(
+        self,
+        args,
+        argtypes,
+        available_launch_config,
+        configured_launch_config,
+        configured_kernel_dispatcher,
+        configured_launch_config_generation,
+    ):
+        def active_launch_config():
+            if self._requires_launch_config:
+                return _normalize_available_launch_config(available_launch_config)
+            return configured_launch_config
+
+        launch_config = active_launch_config()
+        if self._compile_result_for(argtypes, launch_config) is None:
+            self._compile_impl(list(args))
+            launch_config = active_launch_config()
+
+        if self._compile_result_for(argtypes, launch_config) is None:
+            raise RuntimeError(
+                "kernel precompilation completed without publishing a matching overload"
+            )
+
+        if launch_config is None:
+            return self._c, None, None
+        if not self._requires_launch_config and configured_launch_config is not None:
+            if self._is_kernel_dispatcher_registered(
+                configured_launch_config,
+                configured_kernel_dispatcher,
+                configured_launch_config_generation,
+            ):
+                return (
+                    configured_kernel_dispatcher,
+                    configured_launch_config_generation,
+                    configured_launch_config,
+                )
+            # A retained marshaller may outlive recompile() or removal of the
+            # extension that originally opted it into launch specialization.
+            # Its extension snapshot still requires a launch-keyed native
+            # dispatcher for the freshly compiled overload.
+            kernel_dispatcher, generation = self._get_launch_config_dispatcher_and_generation(
+                launch_config
+            )
+            return kernel_dispatcher, generation, launch_config
+        kernel_dispatcher, generation = self._get_kernel_dispatcher_and_generation(launch_config)
+        return kernel_dispatcher, generation, launch_config
+
     def _raise_ambiguous(self, argtypes, tied):
         sigs_str = "\n".join(f"{sig_args} -> none" for sig_args in tied)
         raise TypeError(f"Ambiguous overloading for {self.py_func!r} {argtypes}:\n{sigs_str}")
@@ -2467,8 +2635,21 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             active_extensions = self.extensions
         force_launch_config = getattr(_compile_arg_types, "force_launch_config", False)
         active_launch_config = None
-        if force_launch_config or _extensions_use_launch_config(active_extensions):
+        if (
+            force_launch_config
+            or self._requires_launch_config
+            or _extensions_use_launch_config(active_extensions)
+        ):
             active_launch_config = getattr(_compile_arg_types, "launch_config", None)
+            if active_launch_config is None:
+                active_launch_config = _normalize_available_launch_config(
+                    getattr(_compile_arg_types, "available_launch_config", None)
+                )
+        if self._requires_launch_config and active_launch_config is None:
+            raise RuntimeError(
+                "whole-function planner requires launch metadata; compile through a "
+                "configured kernel launch"
+            )
         active_launch_config_key = _launch_config_key(active_launch_config)
         active_launch_config_generation = None
         if active_launch_config_key is not None:
@@ -2588,13 +2769,29 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             self._cache_misses[argtypes] += 1
 
         # Compile using mlir_compiler_entry which handles annotations and AST transforms
-        with self._compile_profiler():
-            result = mlir_compiler.mlir_compiler_entry(
-                pyfunc=self.py_func,
-                func_args=list(args),
-                targetoptions=targetoptions,
-                override_argtypes=override_argtypes,
-            )
+        try:
+            with self._compile_profiler():
+                result = mlir_compiler.mlir_compiler_entry(
+                    pyfunc=self.py_func,
+                    func_args=list(args),
+                    targetoptions=targetoptions,
+                    override_argtypes=override_argtypes,
+                )
+        except _RequireLaunchConfig as exc:
+            if active_launch_config is not None:
+                raise RuntimeError(
+                    "whole-function planner requested launch metadata after a "
+                    "launch-qualified retry"
+                ) from exc
+            available_launch_config = getattr(_compile_arg_types, "available_launch_config", None)
+            if available_launch_config is None:
+                raise RuntimeError(
+                    "whole-function planner requires launch metadata, but compilation "
+                    "was not initiated by a configured kernel launch"
+                ) from exc
+            _normalize_available_launch_config(available_launch_config)
+            self._mark_requires_launch_config()
+            return self._compile_impl(args, launch_config_retry_budget)
         wrapped = CompileResult(result)
         emit_launch_config_cache_notice = False
         retry_launch_config_compile = False
@@ -2714,6 +2911,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 optimize(cres)
 
             cres.target_context.insert_user_function(cres.entry_point, cres.fndesc, [cres.library])
+        except _RequireLaunchConfig:
+            raise RuntimeError(
+                "whole-function planner requires launch metadata; compile through a "
+                "configured kernel launch"
+            ) from None
         finally:
             self._is_compiling = False
 
@@ -2770,6 +2972,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 )
 
             cres.target_context.insert_user_function(cres.entry_point, cres.fndesc, [cres.library])
+        except _RequireLaunchConfig:
+            raise RuntimeError(
+                "whole-function planner requires launch metadata; device-function "
+                "compilation has no configured kernel launch"
+            ) from None
         finally:
             self._is_compiling = False
 

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -2794,18 +2794,18 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     targetoptions=targetoptions,
                     override_argtypes=override_argtypes,
                 )
-        except _RequireLaunchConfig as exc:
+        except _RequireLaunchConfig:
             if active_launch_config is not None:
                 raise RuntimeError(
                     "whole-function planner requested launch metadata after a "
                     "launch-qualified retry"
-                ) from exc
+                ) from None
             available_launch_config = getattr(_compile_arg_types, "available_launch_config", None)
             if available_launch_config is None:
                 raise RuntimeError(
                     "whole-function planner requires launch metadata, but compilation "
                     "was not initiated by a configured kernel launch"
-                ) from exc
+                ) from None
             _normalize_available_launch_config(available_launch_config)
             self._mark_requires_launch_config()
             return self._compile_impl(args, launch_config_retry_budget)

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -43,6 +43,14 @@ from numba_cuda_mlir._whole_function_planners import (
     _RequireLaunchConfig,
     _planner_registry,
 )
+from numba_cuda_mlir._launch_config import (
+    _LAUNCH_CONFIG_TRACKER_OPTION,
+    _LaunchConfigTracker,
+    _is_launch_config_key_tuple,
+    _launch_config_dict_from_key,
+    _launch_config_key,
+    _normalize_available_launch_config,
+)
 from numba_cuda_mlir.numba_cuda.core.target_extension import (
     CPU,
     target_registry,
@@ -351,65 +359,8 @@ class LaunchConfigInspectableKey:
     launch_config_key: tuple
 
 
-def _is_launch_config_key_tuple(value):
-    return (
-        isinstance(value, tuple)
-        and len(value) == 4
-        and all(isinstance(item, tuple) and len(item) == 2 for item in value)
-        and value[0][0] == "grid"
-        and value[1][0] == "block"
-        and value[2][0] == "sharedmem"
-        and value[3][0] == "cluster"
-    )
-
-
 def _is_launch_config_dict(value):
     return isinstance(value, dict) and "grid" in value and "block" in value
-
-
-def _launch_config_key(launch_config):
-    """Return the specialization key for a configure-produced launch config."""
-    if launch_config is None:
-        return None
-    block = launch_config.get("block")
-    if block is None:
-        raise ValueError("launch_config must contain a 'block' entry")
-    if not isinstance(block, tuple):
-        raise TypeError("launch_config 'block' must be a normalized tuple")
-    grid = launch_config.get("grid")
-    if grid is None:
-        raise ValueError("launch_config must contain a 'grid' entry")
-    if not isinstance(grid, tuple):
-        raise TypeError("launch_config 'grid' must be a normalized tuple")
-    cluster = launch_config.get("cluster")
-    if cluster is not None and not isinstance(cluster, tuple):
-        raise TypeError("launch_config 'cluster' must be a normalized tuple or None")
-    sharedmem = launch_config.get("sharedmem", 0)
-    if sharedmem is None:
-        sharedmem = 0
-    try:
-        sharedmem = int(sharedmem)
-    except (TypeError, ValueError):
-        raise TypeError("launch_config 'sharedmem' must be integer-convertible") from None
-    return (
-        ("grid", grid),
-        ("block", block),
-        ("sharedmem", sharedmem),
-        ("cluster", cluster),
-    )
-
-
-def _launch_config_dict_from_key(launch_config_key):
-    if not _is_launch_config_key_tuple(launch_config_key):
-        raise TypeError("launch_config_key must be a normalized launch-config key")
-    return {name: value for name, value in launch_config_key}
-
-
-def _normalize_available_launch_config(launch_config):
-    launch_config_key = _launch_config_key(launch_config)
-    if launch_config_key is None:
-        return None
-    return _launch_config_dict_from_key(launch_config_key)
 
 
 def _normalize_launch_sharedmem(sharedmem):
@@ -2651,6 +2602,12 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         if not has_extension_snapshot:
             active_extensions = self.extensions
         force_launch_config = getattr(_compile_arg_types, "force_launch_config", False)
+        available_launch_config = getattr(_compile_arg_types, "available_launch_config", None)
+        launch_config_tracker = (
+            _LaunchConfigTracker(available_launch_config)
+            if available_launch_config is not None
+            else None
+        )
         active_launch_config = None
         if (
             force_launch_config
@@ -2659,9 +2616,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         ):
             active_launch_config = getattr(_compile_arg_types, "launch_config", None)
             if active_launch_config is None:
-                active_launch_config = _normalize_available_launch_config(
-                    getattr(_compile_arg_types, "available_launch_config", None)
-                )
+                active_launch_config = available_launch_config
+            active_launch_config = _normalize_available_launch_config(active_launch_config)
         if self._requires_launch_config and active_launch_config is None:
             raise RuntimeError(
                 "whole-function planner requires launch metadata; compile through a "
@@ -2669,7 +2625,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             )
         active_launch_config_key = _launch_config_key(active_launch_config)
         active_launch_config_generation = None
-        if active_launch_config_key is not None:
+        if active_launch_config_key is not None or launch_config_tracker is not None:
             with self._launch_config_lock:
                 active_launch_config_generation = self._launch_config_generation
 
@@ -2749,10 +2705,18 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
 
         self._resolve_target_options()
         targetoptions = self.targetoptions
-        if active_launch_config is not None or has_extension_snapshot:
+        if (
+            active_launch_config is not None
+            or launch_config_tracker is not None
+            or has_extension_snapshot
+        ):
             targetoptions = self.targetoptions.copy()
             if has_extension_snapshot:
                 targetoptions["extensions"] = active_extensions
+            if launch_config_tracker is not None:
+                # Transport launch metadata to compiler state without exposing
+                # it to AST transforms as active specialization metadata.
+                targetoptions[_LAUNCH_CONFIG_TRACKER_OPTION] = launch_config_tracker
             if active_launch_config is not None:
                 targetoptions["__launch_config__"] = dict(active_launch_config)
 
@@ -2795,20 +2759,21 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     override_argtypes=override_argtypes,
                 )
         except _RequireLaunchConfig:
-            if active_launch_config is not None:
-                raise RuntimeError(
-                    "whole-function planner requested launch metadata after a "
-                    "launch-qualified retry"
-                ) from None
-            available_launch_config = getattr(_compile_arg_types, "available_launch_config", None)
-            if available_launch_config is None:
-                raise RuntimeError(
-                    "whole-function planner requires launch metadata, but compilation "
-                    "was not initiated by a configured kernel launch"
-                ) from None
-            _normalize_available_launch_config(available_launch_config)
+            raise RuntimeError(
+                "whole-function planner requires launch metadata, but compilation "
+                "was not initiated by a configured kernel launch"
+            ) from None
+
+        if (
+            active_launch_config is None
+            and launch_config_tracker is not None
+            and launch_config_tracker.required
+        ):
+            active_launch_config = launch_config_tracker.launch_config
+            active_launch_config_key = _launch_config_key(active_launch_config)
             self._mark_requires_launch_config()
-            return self._compile_impl(args, launch_config_retry_budget)
+            disk_cache_eligible = False
+
         wrapped = CompileResult(result)
         emit_launch_config_cache_notice = False
         retry_launch_config_compile = False

--- a/src/numba_cuda_mlir/extending/__init__.py
+++ b/src/numba_cuda_mlir/extending/__init__.py
@@ -28,6 +28,7 @@ from numba_cuda_mlir.extending.argument_handler import ArgumentHandler
 from numba_cuda_mlir._whole_function_planners import (
     WholeFunctionPlanner,
     register_planner,
+    require_launch_config,
 )
 
 lowering_registry = LoweringRegistry()
@@ -46,6 +47,7 @@ __all__ = [
     "lower_cast",
     "refresh_registries",
     "register_planner",
+    "require_launch_config",
     "overload",
     "overload_attribute",
     "overload_method",

--- a/src/numba_cuda_mlir/mlir_compiler.py
+++ b/src/numba_cuda_mlir/mlir_compiler.py
@@ -55,6 +55,10 @@ from numba_cuda_mlir.numbair_transforms import (
 
 import numba_cuda_mlir.mlir_lowering as lowering
 import numba_cuda_mlir.mlir_optimization as opt
+from numba_cuda_mlir._launch_config import (
+    _LAUNCH_CONFIG_TRACKER_METADATA_KEY,
+    _LAUNCH_CONFIG_TRACKER_OPTION,
+)
 from numba_cuda_mlir.decorators import mlir_jit
 from numba_cuda_mlir.ast_transforms import apply_ast_transforms
 from numba_cuda_mlir.errors import (
@@ -208,7 +212,10 @@ class MLIRBackend(LoweringPass):
         return True
 
 
-def get_compiler_class(targetoptions: Dict[str, Any]):
+def get_compiler_class(
+    targetoptions: Dict[str, Any],
+    launch_config_tracker=None,
+):
     class MLIRCompiler(CompilerBase):
         def define_pipelines(self):
             dpb = DefaultPassBuilder
@@ -292,6 +299,8 @@ def get_compiler_class(targetoptions: Dict[str, Any]):
             super().__init__(typingctx, targetctx, library, args, return_type, flags, locals)
             # Attach options early so all passes can see them via state.metadata
             self.state.metadata["targetoptions"] = targetoptions
+            if launch_config_tracker is not None:
+                self.state.metadata[_LAUNCH_CONFIG_TRACKER_METADATA_KEY] = launch_config_tracker
 
     return MLIRCompiler
 
@@ -302,6 +311,7 @@ def compile_mlir(pyfunc, return_type, args, targetoptions: Dict[str, Any]):
     from numba_cuda_mlir.tools import resolve_gpu_target
 
     register_lowering()
+    launch_config_tracker = targetoptions.pop(_LAUNCH_CONFIG_TRACKER_OPTION, None)
     gpu_target = resolve_gpu_target(targetoptions)
     targetoptions["chip"] = gpu_target["chip"]
 
@@ -367,9 +377,10 @@ def compile_mlir(pyfunc, return_type, args, targetoptions: Dict[str, Any]):
             return_type=return_type,
             flags=flags,
             locals={},
-            pipeline_class=get_compiler_class(targetoptions),
+            pipeline_class=get_compiler_class(targetoptions, launch_config_tracker),
         )
 
+    cres.metadata.pop(_LAUNCH_CONFIG_TRACKER_METADATA_KEY, None)
     cres.metadata["targetoptions"] = targetoptions
     cres.metadata["gpu_target"] = gpu_target
     cres.metadata["transformed_source"] = transformed_source

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -324,6 +324,56 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
     assert not hasattr(descriptor_mod._compile_arg_types, "available_launch_config")
 
 
+def test_arg_marshaller_rebinds_for_retained_launch_extension_snapshot(monkeypatch):
+    configured_kernel_dispatcher = object()
+    refreshed_kernel_dispatcher = object()
+    launch_config = {
+        "grid": (2, 1, 1),
+        "block": (64, 1, 1),
+        "sharedmem": 256,
+        "cluster": None,
+    }
+    dispatcher = _Dispatcher()
+    dispatcher.extensions = []
+    dispatcher._launch_config_generation = 8
+    prepare_calls = []
+
+    def prepare_for_launch(*args):
+        prepare_calls.append(args)
+        return refreshed_kernel_dispatcher, 8, launch_config
+
+    dispatcher._prepare_for_launch = prepare_for_launch
+    monkeypatch.setattr(
+        descriptor_mod,
+        "LaunchConfiguration",
+        lambda *args: lambda: "refreshed",
+    )
+
+    marshaller = _ArgMarshaller(
+        lambda: pytest.fail("stale launcher should not run"),
+        extensions=[_LaunchConfigExtension()],
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+        available_launch_config=launch_config,
+        kernel_dispatcher=configured_kernel_dispatcher,
+        launch_config_generation=7,
+    )
+
+    assert marshaller() == "refreshed"
+    assert prepare_calls == [
+        (
+            (),
+            (),
+            launch_config,
+            launch_config,
+            configured_kernel_dispatcher,
+            7,
+        )
+    ]
+    assert marshaller._kernel_dispatcher is refreshed_kernel_dispatcher
+    assert marshaller._launch_config_generation == 8
+
+
 def test_arg_marshaller_refreshes_launch_config_dispatcher():
     dispatcher = _Dispatcher()
     launch_config = {

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -1893,6 +1893,52 @@ def test_reduce_rebuild_and_recompile_preserve_learned_launch_requirement():
     assert rebuilt._launch_config_enabled is True
 
 
+def test_reduce_omits_stale_generic_sigs_after_learned_launch_requirement(monkeypatch):
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    generic_result = _CompileResult((types.int32,))
+    launch_result = _CompileResult((types.float32,))
+    dispatcher.overloads[(types.int32,)] = generic_result
+    dispatcher._launch_config_overloads[((types.float32,), launch_key)] = launch_result
+    dispatcher._mark_requires_launch_config()
+    dispatcher.disable_compile()
+
+    compiled = []
+
+    def compile_launch_config_signature(self, sig, launch_config_key):
+        compiled.append((tuple(sig.args), launch_config_key))
+        self._launch_config_overloads[(tuple(sig.args), launch_config_key)] = _CompileResult(
+            tuple(sig.args)
+        )
+
+    monkeypatch.setattr(
+        descriptor_mod.MLIRDispatcher,
+        "_compile_launch_config_signature",
+        compile_launch_config_signature,
+    )
+
+    states = dispatcher._reduce_states()
+    states["uuid"] = str(uuid4())
+    rebuilt = descriptor_mod.MLIRDispatcher._rebuild(**states)
+
+    assert states["sigs"] == []
+    assert states["launch_config_sigs"] == [(launch_result.signature, launch_key)]
+    assert compiled == [((types.float32,), launch_key)]
+    assert rebuilt._requires_launch_config is True
+    assert rebuilt._can_compile is False
+    assert not rebuilt.overloads
+    assert ((types.float32,), launch_key) in rebuilt.launch_config_overloads
+
+
 def test_compile_launch_config_signature_forces_launch_rebuild_without_extensions(monkeypatch):
     from numba_cuda_mlir import mlir_compiler
 

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -1866,8 +1866,12 @@ def test_compile_impl_reports_unavailable_or_repeated_launch_request(monkeypatch
     descriptor_mod._compile_arg_types.types = (types.int32,)
     dispatcher = descriptor_mod.MLIRDispatcher(kernel)
 
-    with pytest.raises(RuntimeError, match="not initiated by a configured kernel launch"):
+    with pytest.raises(
+        RuntimeError, match="not initiated by a configured kernel launch"
+    ) as unavailable:
         dispatcher._compile_impl([1])
+    assert unavailable.value.__cause__ is None
+    assert unavailable.value.__suppress_context__ is True
 
     descriptor_mod._compile_arg_types.available_launch_config = {
         "grid": (1, 1, 1),
@@ -1875,7 +1879,32 @@ def test_compile_impl_reports_unavailable_or_repeated_launch_request(monkeypatch
         "sharedmem": 0,
         "cluster": None,
     }
-    with pytest.raises(RuntimeError, match="after a launch-qualified retry"):
+    with pytest.raises(RuntimeError, match="after a launch-qualified retry") as repeated:
+        dispatcher._compile_impl([1])
+    assert repeated.value.__cause__ is None
+    assert repeated.value.__suppress_context__ is True
+
+
+def test_compile_impl_preserves_invalid_launch_config_type_error(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    def request_launch_config(*args, **kwargs):
+        raise _RequireLaunchConfig("launch config required")
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", request_launch_config)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": "dynamic",
+        "cluster": None,
+    }
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+
+    with pytest.raises(TypeError, match="sharedmem.*integer-convertible"):
         dispatcher._compile_impl([1])
 
 

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -3,6 +3,7 @@
 """Tests for dispatcher launch metadata plumbing."""
 
 import threading
+from uuid import uuid4
 
 import pytest
 import numpy as np
@@ -11,6 +12,7 @@ from numba_cuda_mlir import descriptor as descriptor_mod
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.cuda.experimental import consteval, current_target_options
 from numba_cuda_mlir.descriptor import _ArgMarshaller
+from numba_cuda_mlir._whole_function_planners import _RequireLaunchConfig
 from numba_cuda_mlir.numba_cuda import types, typing as cuda_typing
 
 
@@ -186,6 +188,142 @@ def test_arg_marshaller_without_launch_config_clears_outer_thread_local_temporar
     assert descriptor_mod._compile_arg_types.launch_config is outer_launch_config
 
 
+def test_arg_marshaller_exposes_available_config_without_activating_it():
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": None,
+        "cluster": None,
+    }
+    observed = []
+
+    def launcher():
+        observed.append(
+            (
+                getattr(descriptor_mod._compile_arg_types, "launch_config", None),
+                getattr(
+                    descriptor_mod._compile_arg_types,
+                    "available_launch_config",
+                    None,
+                ),
+            )
+        )
+        return "launched"
+
+    marshaller = _ArgMarshaller(
+        launcher,
+        available_launch_config=launch_config,
+    )
+
+    assert marshaller() == "launched"
+    assert observed == [(None, launch_config)]
+    assert not hasattr(descriptor_mod._compile_arg_types, "launch_config")
+    assert not hasattr(descriptor_mod._compile_arg_types, "available_launch_config")
+
+
+def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
+    generic_kernel_dispatcher = object()
+    launch_kernel_dispatcher = object()
+    available_launch_config = {
+        "grid": (2, 1, 1),
+        "block": (64, 1, 1),
+        "sharedmem": None,
+        "cluster": (2, 1, 1),
+    }
+    active_launch_config = {**available_launch_config, "sharedmem": 256}
+    dispatcher = _Dispatcher()
+    dispatcher._requires_launch_config = True
+    prepare_calls = []
+    launches = []
+
+    def prepare_for_launch(
+        args,
+        argtypes,
+        launch_config,
+        configured_launch_config,
+        configured_kernel_dispatcher,
+        configured_launch_config_generation,
+    ):
+        prepare_calls.append(
+            (
+                args,
+                argtypes,
+                launch_config,
+                configured_launch_config,
+                configured_kernel_dispatcher,
+                configured_launch_config_generation,
+            )
+        )
+        return launch_kernel_dispatcher, 7, active_launch_config
+
+    def launch_configuration(
+        kernel_dispatcher,
+        griddim,
+        blockdim,
+        stream,
+        sharedmem,
+        cluster,
+    ):
+        launches.append(
+            (
+                kernel_dispatcher,
+                griddim,
+                blockdim,
+                stream,
+                sharedmem,
+                cluster,
+            )
+        )
+
+        def launch():
+            assert descriptor_mod._compile_arg_types.launch_config == active_launch_config
+            return "qualified"
+
+        return launch
+
+    dispatcher._prepare_for_launch = prepare_for_launch
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    marshaller = _ArgMarshaller(
+        lambda: pytest.fail("generic launcher should not run"),
+        dispatcher=dispatcher,
+        available_launch_config=available_launch_config,
+        kernel_dispatcher=generic_kernel_dispatcher,
+        launch_stream=123,
+    )
+
+    assert marshaller() == "qualified"
+    assert marshaller() == "qualified"
+    assert prepare_calls == [
+        ((), (), available_launch_config, None, generic_kernel_dispatcher, None),
+        (
+            (),
+            (),
+            available_launch_config,
+            active_launch_config,
+            launch_kernel_dispatcher,
+            7,
+        ),
+    ]
+    assert launches == [
+        (
+            launch_kernel_dispatcher,
+            (2, 1, 1),
+            (64, 1, 1),
+            123,
+            256,
+            (2, 1, 1),
+        )
+    ]
+    assert marshaller._launch_config == active_launch_config
+    assert marshaller._launch_config_generation == 7
+    assert dispatcher.remembered_dispatchers == [
+        (active_launch_config, launch_kernel_dispatcher, active_launch_config, 7)
+    ]
+    assert not hasattr(descriptor_mod._compile_arg_types, "launch_config")
+    assert not hasattr(descriptor_mod._compile_arg_types, "available_launch_config")
+
+
 def test_arg_marshaller_refreshes_launch_config_dispatcher():
     dispatcher = _Dispatcher()
     launch_config = {
@@ -314,6 +452,7 @@ def test_plain_configure_preserves_raw_sharedmem(monkeypatch):
 
     assert captured == ["dynamic"]
     assert marshaller._launch_config is None
+    assert marshaller._available_launch_config["sharedmem"] == "dynamic"
 
 
 def test_configure_cache_tracks_mutated_non_launch_extensions(monkeypatch):
@@ -336,6 +475,49 @@ def test_configure_cache_tracks_mutated_non_launch_extensions(monkeypatch):
     assert updated is not generic
     assert updated._extensions == [extension]
     assert updated._launch_config is None
+
+
+def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
+    def launch_configuration(kernel_dispatcher, *args):
+        return lambda *launch_args: None
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel,
+        targetoptions={"extensions": [_LaunchConfigExtension()]},
+    )
+    marshaller = dispatcher.configure(1, 32)
+    retained_launch_config = marshaller._launch_config
+    retained_kernel_dispatcher = marshaller._kernel_dispatcher
+    retained_generation = marshaller._launch_config_generation
+    observed_configs = []
+
+    def compile_result_for(argtypes, launch_config):
+        observed_configs.append(launch_config)
+        return object()
+
+    monkeypatch.setattr(dispatcher, "_compile_result_for", compile_result_for)
+    dispatcher.extensions.clear()
+
+    prepared = dispatcher._prepare_for_launch(
+        (),
+        (types.int32,),
+        marshaller._available_launch_config,
+        retained_launch_config,
+        retained_kernel_dispatcher,
+        retained_generation,
+    )
+
+    assert prepared == (
+        retained_kernel_dispatcher,
+        retained_generation,
+        retained_launch_config,
+    )
+    assert observed_configs == [retained_launch_config, retained_launch_config]
 
 
 def test_launch_config_configure_reports_invalid_sharedmem():
@@ -1570,6 +1752,83 @@ def test_compile_impl_discards_callbacks_from_duplicate_launch_compile(monkeypat
     assert losing_setup_callback not in dispatcher._module_setup_callbacks
 
 
+def test_compile_impl_retries_when_planner_requests_launch_config(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": None,
+        "cluster": None,
+    }
+    compile_calls = []
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"qualified", "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append(dict(targetoptions))
+        if "__launch_config__" not in targetoptions:
+            raise _RequireLaunchConfig("launch config required")
+        return CompilerResult()
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.available_launch_config = available_launch_config
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ):
+        result = dispatcher._compile_impl([1])
+
+    normalized_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(normalized_launch_config)
+    assert result == (b"qualified", "kernel", False)
+    assert len(compile_calls) == 2
+    assert "__launch_config__" not in compile_calls[0]
+    assert compile_calls[1]["__launch_config__"] == normalized_launch_config
+    assert dispatcher._requires_launch_config is True
+    assert not dispatcher.overloads
+    assert ((types.int32,), launch_key) in dispatcher._launch_config_overloads
+
+
+def test_compile_impl_reports_unavailable_or_repeated_launch_request(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    def request_launch_config(*args, **kwargs):
+        raise _RequireLaunchConfig("launch config required")
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", request_launch_config)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+
+    with pytest.raises(RuntimeError, match="not initiated by a configured kernel launch"):
+        dispatcher._compile_impl([1])
+
+    descriptor_mod._compile_arg_types.available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    with pytest.raises(RuntimeError, match="after a launch-qualified retry"):
+        dispatcher._compile_impl([1])
+
+
 def test_disabled_launch_config_reduce_rebuild_restores_launch_sigs(monkeypatch):
     def kernel(x):
         pass
@@ -1612,6 +1871,26 @@ def test_disabled_launch_config_reduce_rebuild_restores_launch_sigs(monkeypatch)
     assert compiled == [(sig_args, launch_key, True)]
     assert rebuilt._can_compile is False
     assert (sig_args, launch_key) in rebuilt.launch_config_overloads
+
+
+def test_reduce_rebuild_and_recompile_preserve_learned_launch_requirement():
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher._mark_requires_launch_config()
+
+    states = dispatcher._reduce_states()
+    states["uuid"] = str(uuid4())
+    rebuilt = descriptor_mod.MLIRDispatcher._rebuild(**states)
+
+    assert states["requires_launch_config"] is True
+    assert rebuilt._requires_launch_config is True
+    assert rebuilt._launch_config_enabled is True
+
+    rebuilt.recompile()
+    assert rebuilt._requires_launch_config is True
+    assert rebuilt._launch_config_enabled is True
 
 
 def test_compile_launch_config_signature_forces_launch_rebuild_without_extensions(monkeypatch):

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -12,6 +12,7 @@ from numba_cuda_mlir import descriptor as descriptor_mod
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.cuda.experimental import consteval, current_target_options
 from numba_cuda_mlir.descriptor import _ArgMarshaller
+from numba_cuda_mlir._launch_config import _LAUNCH_CONFIG_TRACKER_OPTION
 from numba_cuda_mlir._whole_function_planners import _RequireLaunchConfig
 from numba_cuda_mlir.numba_cuda import types, typing as cuda_typing
 
@@ -1802,7 +1803,7 @@ def test_compile_impl_discards_callbacks_from_duplicate_launch_compile(monkeypat
     assert losing_setup_callback not in dispatcher._module_setup_callbacks
 
 
-def test_compile_impl_retries_when_planner_requests_launch_config(monkeypatch):
+def test_compile_impl_promotes_available_launch_config_in_current_attempt(monkeypatch):
     from numba_cuda_mlir import mlir_compiler
 
     def kernel(x):
@@ -1823,8 +1824,8 @@ def test_compile_impl_retries_when_planner_requests_launch_config(monkeypatch):
 
     def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
         compile_calls.append(dict(targetoptions))
-        if "__launch_config__" not in targetoptions:
-            raise _RequireLaunchConfig("launch config required")
+        tracker = targetoptions.pop(_LAUNCH_CONFIG_TRACKER_OPTION)
+        targetoptions["__launch_config__"] = tracker.require()
         return CompilerResult()
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
@@ -1845,15 +1846,72 @@ def test_compile_impl_retries_when_planner_requests_launch_config(monkeypatch):
     }
     launch_key = descriptor_mod._launch_config_key(normalized_launch_config)
     assert result == (b"qualified", "kernel", False)
-    assert len(compile_calls) == 2
+    assert len(compile_calls) == 1
     assert "__launch_config__" not in compile_calls[0]
-    assert compile_calls[1]["__launch_config__"] == normalized_launch_config
+    tracker = compile_calls[0][_LAUNCH_CONFIG_TRACKER_OPTION]
+    assert tracker.required is True
+    assert tracker.launch_config == normalized_launch_config
     assert dispatcher._requires_launch_config is True
     assert not dispatcher.overloads
     assert ((types.int32,), launch_key) in dispatcher._launch_config_overloads
 
 
-def test_compile_impl_reports_unavailable_or_repeated_launch_request(monkeypatch):
+def test_compile_impl_retries_only_after_promoted_config_generation_changes(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    stale_setup_callback = lambda obj: None
+    accepted_setup_callback = lambda obj: None
+    compile_calls = []
+
+    class CompilerResult:
+        def __init__(self, cubin, setup_callback):
+            self.signature = cuda_typing.signature(types.none, types.int32)
+            self.metadata = {
+                "cubin": cubin,
+                "func_name": "kernel",
+                "setup_callbacks": [setup_callback],
+            }
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append(dict(targetoptions))
+        if len(compile_calls) == 1:
+            tracker = targetoptions.pop(_LAUNCH_CONFIG_TRACKER_OPTION)
+            targetoptions["__launch_config__"] = tracker.require()
+            with dispatcher._launch_config_lock:
+                dispatcher._launch_config_generation += 1
+            return CompilerResult(b"stale", stale_setup_callback)
+        assert targetoptions["__launch_config__"] == launch_config
+        return CompilerResult(b"accepted", accepted_setup_callback)
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.available_launch_config = launch_config
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ):
+        assert dispatcher._compile_impl([1]) == (b"accepted", "kernel", False)
+
+    assert len(compile_calls) == 2
+    assert "__launch_config__" not in compile_calls[0]
+    assert compile_calls[1]["__launch_config__"] == launch_config
+    assert dispatcher._requires_launch_config is True
+    assert stale_setup_callback not in dispatcher._module_setup_callbacks
+    assert accepted_setup_callback in dispatcher._module_setup_callbacks
+
+
+def test_compile_impl_reports_unavailable_launch_request(monkeypatch):
     from numba_cuda_mlir import mlir_compiler
 
     def kernel(x):
@@ -1873,17 +1931,6 @@ def test_compile_impl_reports_unavailable_or_repeated_launch_request(monkeypatch
     assert unavailable.value.__cause__ is None
     assert unavailable.value.__suppress_context__ is True
 
-    descriptor_mod._compile_arg_types.available_launch_config = {
-        "grid": (1, 1, 1),
-        "block": (32, 1, 1),
-        "sharedmem": 0,
-        "cluster": None,
-    }
-    with pytest.raises(RuntimeError, match="after a launch-qualified retry") as repeated:
-        dispatcher._compile_impl([1])
-    assert repeated.value.__cause__ is None
-    assert repeated.value.__suppress_context__ is True
-
 
 def test_compile_impl_preserves_invalid_launch_config_type_error(monkeypatch):
     from numba_cuda_mlir import mlir_compiler
@@ -1891,8 +1938,8 @@ def test_compile_impl_preserves_invalid_launch_config_type_error(monkeypatch):
     def kernel(x):
         pass
 
-    def request_launch_config(*args, **kwargs):
-        raise _RequireLaunchConfig("launch config required")
+    def request_launch_config(pyfunc, func_args, targetoptions, override_argtypes):
+        targetoptions[_LAUNCH_CONFIG_TRACKER_OPTION].require()
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", request_launch_config)
     descriptor_mod._compile_arg_types.types = (types.int32,)
@@ -1906,6 +1953,47 @@ def test_compile_impl_preserves_invalid_launch_config_type_error(monkeypatch):
 
     with pytest.raises(TypeError, match="sharedmem.*integer-convertible"):
         dispatcher._compile_impl([1])
+
+
+def test_compile_impl_ignores_opaque_available_launch_config_without_demand(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    compile_calls = []
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"generic", "func_name": "kernel"}
+
+    def compile_without_launch_demand(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append(dict(targetoptions))
+        return CompilerResult()
+
+    monkeypatch.setattr(
+        mlir_compiler,
+        "mlir_compiler_entry",
+        compile_without_launch_demand,
+    )
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": "dynamic",
+        "cluster": None,
+    }
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+
+    assert dispatcher._compile_impl([1]) == (b"generic", "kernel", False)
+    assert len(compile_calls) == 1
+    tracker = compile_calls[0][_LAUNCH_CONFIG_TRACKER_OPTION]
+    assert tracker.required is False
+    assert tracker._available_launch_config["sharedmem"] == "dynamic"
+    assert "__launch_config__" not in compile_calls[0]
+    assert dispatcher._requires_launch_config is False
+    assert dispatcher.overloads
+    assert not dispatcher._launch_config_overloads
 
 
 def test_disabled_launch_config_reduce_rebuild_restores_launch_sigs(monkeypatch):

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -14,10 +14,17 @@ from numba_cuda_mlir._whole_function_planners import (
     _WholeFunctionPlannerRegistry,
     _planner_registry,
 )
-from numba_cuda_mlir.extending import WholeFunctionPlanner, register_planner
+from numba_cuda_mlir.extending import (
+    WholeFunctionPlanner,
+    register_planner,
+    require_launch_config,
+)
 from numba_cuda_mlir.numba_cuda.compiler import run_frontend
 from numba_cuda_mlir.numba_cuda.core import ir
 from numba_cuda_mlir.numba_cuda.core.ir_utils import build_definitions
+
+
+_RECOMPILE_VALUE = 1
 
 
 @pytest.fixture
@@ -110,6 +117,30 @@ def test_planner_registration_and_result_contracts():
     registry.register(InvalidResultPlanner)
     with pytest.raises(TypeError, match=r"run\(\) must return bool"):
         registry.apply(_planner_state())
+
+
+def test_require_launch_config_contract():
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    state = SimpleNamespace(metadata={"targetoptions": {"__launch_config__": launch_config}})
+
+    assert require_launch_config(state) is launch_config
+
+    state.metadata["targetoptions"].pop("__launch_config__")
+    with pytest.raises(RuntimeError, match="configured kernel launch"):
+        require_launch_config(state)
+
+
+def test_require_launch_config_requires_compiler_metadata():
+    with pytest.raises(TypeError, match="metadata must be a dict"):
+        require_launch_config(SimpleNamespace())
+
+    with pytest.raises(TypeError, match="must contain targetoptions"):
+        require_launch_config(SimpleNamespace(metadata={}))
 
 
 def test_ir_is_repaired_between_modifying_planners():
@@ -248,6 +279,81 @@ def test_planner_registered_during_compile_prevents_persistent_cache_save(
     assert dispatcher._cache_misses[(types.int32,)] == 1
 
 
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_retained_generic_launcher_rebinds_after_recompile(isolated_global_planners):
+    global _RECOMPILE_VALUE
+
+    class HarmlessPlanner(WholeFunctionPlanner):
+        def run(self):
+            return False
+
+    @cuda.jit
+    def kernel(out):
+        out[0] = _RECOMPILE_VALUE
+
+    register_planner(HarmlessPlanner)
+    retained_launcher = kernel[1, 32]
+    out = np.zeros(1, dtype=np.int32)
+
+    try:
+        _RECOMPILE_VALUE = 1
+        retained_launcher(out)
+        _RECOMPILE_VALUE = 2
+        kernel.recompile()
+        retained_launcher(out)
+
+        assert out[0] == 2
+        assert retained_launcher._kernel_dispatcher is kernel._c
+        assert kernel._requires_launch_config is False
+    finally:
+        _RECOMPILE_VALUE = 1
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_retained_launch_launcher_rebinds_after_recompile(isolated_global_planners):
+    global _RECOMPILE_VALUE
+
+    from numba_cuda_mlir import descriptor as descriptor_mod
+
+    class HarmlessPlanner(WholeFunctionPlanner):
+        def run(self):
+            return False
+
+    class LaunchConfigExtension:
+        uses_launch_config = True
+
+        def prepare_args(self, ty, val, stream=None, retr=None):
+            return ty, val
+
+    @cuda.jit(extensions=[LaunchConfigExtension()])
+    def kernel(out):
+        out[0] = _RECOMPILE_VALUE
+
+    register_planner(HarmlessPlanner)
+    retained_launcher = kernel[1, 32]
+    out = np.zeros(1, dtype=np.int32)
+
+    try:
+        _RECOMPILE_VALUE = 1
+        retained_launcher(out)
+        retained_generation = retained_launcher._launch_config_generation
+        kernel.extensions.clear()
+        _RECOMPILE_VALUE = 2
+        kernel.recompile()
+        retained_launcher(out)
+
+        assert out[0] == 2
+        assert retained_launcher._launch_config_generation != retained_generation
+        assert kernel._is_kernel_dispatcher_registered(
+            retained_launcher._launch_config,
+            retained_launcher._kernel_dispatcher,
+            retained_launcher._launch_config_generation,
+        )
+        assert not hasattr(descriptor_mod._compile_arg_types, "launch_config")
+    finally:
+        _RECOMPILE_VALUE = 1
+
+
 def _post_inline_marker(value):
     return value
 
@@ -316,6 +422,27 @@ class _MarkerPlanner(WholeFunctionPlanner):
         return modified
 
 
+class _LaunchConfigPlanner(WholeFunctionPlanner):
+    attempts = 0
+    launch_configs = []
+
+    def run(self):
+        if self.is_device_function:
+            return False
+        type(self).attempts += 1
+        type(self).launch_configs.append(dict(require_launch_config(self.state)))
+        return False
+
+
+class _CountingPlanner(WholeFunctionPlanner):
+    attempts = 0
+
+    def run(self):
+        if not self.is_device_function:
+            type(self).attempts += 1
+        return False
+
+
 def test_planner_pass_runs_after_device_inlining_without_gpu(
     isolated_global_planners,
 ):
@@ -369,6 +496,28 @@ def test_planner_runs_for_device_function_compilation_without_gpu(
     assert _MarkerPlanner.device_runs == 1
 
 
+def test_direct_compile_reports_missing_configured_launch(isolated_global_planners):
+    _LaunchConfigPlanner.attempts = 0
+    _LaunchConfigPlanner.launch_configs = []
+    register_planner(_LaunchConfigPlanner)
+
+    def kernel(output):
+        output[0] = 1
+
+    with pytest.raises(RuntimeError, match="compile through a configured kernel launch") as exc:
+        compiler.compile(
+            kernel,
+            types.void(types.int32[::1]),
+            device=False,
+            abi="numba",
+            cc=(8, 0),
+        )
+
+    assert type(exc.value) is RuntimeError
+    assert exc.value.__cause__ is None
+    assert _LaunchConfigPlanner.attempts == 1
+
+
 @pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
 def test_planner_sees_inline_device_function_body(isolated_global_planners):
     _MarkerPlanner.kernel_runs = 0
@@ -392,3 +541,49 @@ def test_planner_sees_inline_device_function_body(isolated_global_planners):
     np.testing.assert_array_equal(h_output, h_input)
     assert _MarkerPlanner.kernel_runs == 1
     assert _MarkerPlanner.device_runs == 0
+    assert kernel._requires_launch_config is False
+    assert kernel.overloads
+    assert not kernel._launch_config_overloads
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_planner_can_request_distinct_launch_config_specializations(
+    isolated_global_planners,
+):
+    _CountingPlanner.attempts = 0
+    _LaunchConfigPlanner.attempts = 0
+    _LaunchConfigPlanner.launch_configs = []
+    register_planner(_CountingPlanner)
+    register_planner(_LaunchConfigPlanner)
+
+    @cuda.jit
+    def kernel(output):
+        output[0] = cuda.blockDim.x
+
+    launch32 = kernel[1, 32]
+    launch64 = kernel[1, 64]
+    output32 = np.zeros(1, dtype=np.int32)
+    output64 = np.zeros(1, dtype=np.int32)
+
+    launch32(output32)
+    launch64(output64)
+    launch32(output32)
+
+    assert output32[0] == 32
+    assert output64[0] == 64
+    assert _CountingPlanner.attempts == 3
+    assert _LaunchConfigPlanner.attempts == 3
+    assert [config["block"] for config in _LaunchConfigPlanner.launch_configs] == [
+        (32, 1, 1),
+        (64, 1, 1),
+    ]
+    assert kernel._requires_launch_config is True
+    assert not kernel.overloads
+    launch_blocks = {
+        dict(launch_config_key)["block"]
+        for _argtypes, launch_config_key in kernel._launch_config_overloads
+    }
+    assert launch_blocks == {(32, 1, 1), (64, 1, 1)}
+
+    configured_after_demand = kernel.configure(1, 32)
+    assert configured_after_demand._launch_config["block"] == (32, 1, 1)

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -14,6 +14,10 @@ from numba_cuda_mlir._whole_function_planners import (
     _WholeFunctionPlannerRegistry,
     _planner_registry,
 )
+from numba_cuda_mlir._launch_config import (
+    _LAUNCH_CONFIG_TRACKER_METADATA_KEY,
+    _LaunchConfigTracker,
+)
 from numba_cuda_mlir.extending import (
     WholeFunctionPlanner,
     register_planner,
@@ -131,6 +135,17 @@ def test_require_launch_config_contract():
     assert require_launch_config(state) is launch_config
 
     state.metadata["targetoptions"].pop("__launch_config__")
+    tracker = _LaunchConfigTracker(launch_config)
+    state.metadata[_LAUNCH_CONFIG_TRACKER_METADATA_KEY] = tracker
+    promoted = require_launch_config(state)
+    assert promoted == launch_config
+    assert promoted is state.metadata["targetoptions"]["__launch_config__"]
+    assert promoted is not launch_config
+    assert tracker.required is True
+    assert require_launch_config(state) is promoted
+
+    state.metadata.pop(_LAUNCH_CONFIG_TRACKER_METADATA_KEY)
+    state.metadata["targetoptions"].pop("__launch_config__")
     with pytest.raises(RuntimeError, match="configured kernel launch"):
         require_launch_config(state)
 
@@ -141,6 +156,43 @@ def test_require_launch_config_requires_compiler_metadata():
 
     with pytest.raises(TypeError, match="must contain targetoptions"):
         require_launch_config(SimpleNamespace(metadata={}))
+
+
+def test_launch_config_promotion_is_visible_to_later_planners_in_same_attempt():
+    available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": None,
+        "cluster": None,
+    }
+    tracker = _LaunchConfigTracker(available_launch_config)
+    state = _planner_state()
+    state.metadata = {
+        "targetoptions": {},
+        _LAUNCH_CONFIG_TRACKER_METADATA_KEY: tracker,
+    }
+    registry = _WholeFunctionPlannerRegistry()
+    promoted = []
+    observed = []
+
+    class RequiringPlanner(WholeFunctionPlanner):
+        def run(self):
+            promoted.append(require_launch_config(self.state))
+            return False
+
+    class ObservingPlanner(WholeFunctionPlanner):
+        def run(self):
+            observed.append(self.state.metadata["targetoptions"]["__launch_config__"])
+            return False
+
+    registry.register(RequiringPlanner)
+    registry.register(ObservingPlanner)
+
+    assert registry.apply(state) is False
+    assert len(promoted) == 1
+    assert observed == promoted
+    assert promoted[0]["sharedmem"] == 0
+    assert tracker.required is True
 
 
 def test_ir_is_repaired_between_modifying_planners():
@@ -549,10 +601,26 @@ def test_planner_sees_inline_device_function_body(isolated_global_planners):
 @pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
 def test_planner_can_request_distinct_launch_config_specializations(
     isolated_global_planners,
+    monkeypatch,
 ):
+    from numba_cuda_mlir import mlir_compiler
+
     _CountingPlanner.attempts = 0
     _LaunchConfigPlanner.attempts = 0
     _LaunchConfigPlanner.launch_configs = []
+    ast_targetoptions = []
+    apply_ast_transforms = mlir_compiler.apply_ast_transforms
+
+    def observe_ast_targetoptions(pyfunc, targetoptions, args):
+        ast_targetoptions.append(dict(targetoptions))
+        assert "__launch_config_tracker__" not in targetoptions
+        return apply_ast_transforms(pyfunc, targetoptions, args)
+
+    monkeypatch.setattr(
+        mlir_compiler,
+        "apply_ast_transforms",
+        observe_ast_targetoptions,
+    )
     register_planner(_CountingPlanner)
     register_planner(_LaunchConfigPlanner)
 
@@ -571,8 +639,11 @@ def test_planner_can_request_distinct_launch_config_specializations(
 
     assert output32[0] == 32
     assert output64[0] == 64
-    assert _CountingPlanner.attempts == 3
-    assert _LaunchConfigPlanner.attempts == 3
+    assert _CountingPlanner.attempts == 2
+    assert _LaunchConfigPlanner.attempts == 2
+    assert len(ast_targetoptions) == 2
+    assert "__launch_config__" not in ast_targetoptions[0]
+    assert ast_targetoptions[1]["__launch_config__"]["block"] == (64, 1, 1)
     assert [config["block"] for config in _LaunchConfigPlanner.launch_configs] == [
         (32, 1, 1),
         (64, 1, 1),


### PR DESCRIPTION
## Stack dependency

Builds on current `main` at `6cb630e` (which contains #202, merged as
`335d7a9`). The #203 delta is five commits:

- `1233da4` Add demand-driven planner launch metadata
- `e37e11e` Skip stale generic planner overloads on rebuild
- `a3ec7cf` Refresh stale retained launchers
- `596b161` Hide internal launch retry exceptions
- `85f03e2` Promote planner launch metadata in one attempt

Exact range: `6cb630e..85f03e2`.

## Overview

Let a post-inline whole-function planner request normalized launch metadata
only when the current kernel actually needs it.

- Export `require_launch_config(state)` for planners.
- Carry the configured launch as an attempt-local, lazily normalized candidate
  that is hidden from earlier AST transforms.
- Promote normalized grid, block, shared-memory, and cluster facts into the
  current compiler state when the first planner requests them.
- Let later planners, typing, and lowering observe those facts in the same
  compiler attempt; launch demand does not replay the planner pipeline.
- Keep ordinary kernels generic. Only dispatchers that learn the requirement
  publish launch-keyed overloads and native launchers.
- Preserve stream and launch geometry when rebinding retained launchers,
  including after `recompile()` and extension removal.
- Preserve learned launch sensitivity through serialization and rebuild, while
  omitting stale generic overloads that are no longer reachable.
- Keep the existing bounded retry only for concurrent launch-configuration
  generation invalidation; it is not used to discover planner demand.
- Retain eager `uses_launch_config = True` opt-in for extensions that genuinely
  consume launch facts during the earlier AST-transform phase.

This is the launch-qualification contract needed to move
`cuda.coop.numba_mlir` group planning onto #202 without making every kernel
launch-specialized.

## Why this is needed

A normal dispatcher specializes by argument types. These launches have the
same Python signature, but they do not describe the same cooperative group:

```python
import cuda.coop.numba_mlir as coop
from numba_cuda_mlir import cuda

@cuda.jit
def block_sum(values, block_total):
    tid = cuda.threadIdx.x
    block = coop.this_block()
    total = coop.reduce(block, values[tid])
    if block.rank() == 0:
        block_total[0] = total

block_sum[1, 128](values_128, total_128)
block_sum[1, 256](values_256, total_256)
```

`this_block()` intentionally leaves the extent out of the kernel source. CCCL
must recover the configured block size to resolve the group, select the matching
provider specialization, and make `rank()`, `count()`, and the collective agree
with the actual launch. Reusing one generic overload for both launches could
bake stale launch facts into the second kernel.

Making every CUDA kernel launch-qualified would avoid that correctness problem
at too high a cost: kernels that never inspect launch geometry would acquire
separate overloads for every grid, block, dynamic-shared-memory, or cluster
configuration. This PR makes launch sensitivity demand-driven.

## Concrete extension use

The `cuda.coop.numba_mlir` group-hierarchy consumer follows this shape:

```python
from numba_cuda_mlir.extending import (
    WholeFunctionPlanner,
    register_planner,
    require_launch_config,
)

@register_planner
class CoopGroupHierarchyPlanner(WholeFunctionPlanner):
    def run(self) -> bool:
        # Ordinary kernels stay generic even though this planner is registered.
        if not has_group_markers(self.state.func_ir):
            return False

        launch = require_launch_config(self.state)
        return _GroupCallPlanner(self.state, launch).run()
```

The marker check is significant: the planner requests launch metadata only
after finding an operation whose lowering depends on it.
`require_launch_config()` lazily normalizes the configured `grid`, `block`,
`sharedmem`, and `cluster`, inserts those facts into the attempt's target
options, and returns them. A later planner in the same registry sees the same
active configuration without rerunning either planner.

The successful result is cached by argument types plus launch configuration.
Repeating the same launch reuses it; changing the launch compiles the distinct
specialization correctness requires. Plain kernels retain type-keyed overloads,
including when a configured launch contains an opaque raw shared-memory value
that no planner requests.

Provider choice remains a compile-time rewrite. Link inputs continue through
the existing LTO-IR path from #155, with no device-side provider dispatch, so
the selected implementation remains available for final-link inlining.

Persistent disk caching is deliberately bypassed while planners are active
because planner identity and launch metadata are not yet represented in that
cache key.

## Validation

- Exact local head: `85f03e212e27a6901e50403f8f55bae6c893af9e`.
- Focused descriptor/planner suite from an exact-source overlay: 78 passed on
  SM120 and 78 passed on SM75.
- Regressions cover same-attempt visibility across two planners, one compiler
  entry for first launch demand, generic no-demand compilation with opaque raw
  shared memory, demanded-value diagnostics, generation invalidation,
  serialization/rebuild, and retained-launcher behavior.
- Changed-file pre-commit for all seven changed files and `git diff --check`:
  passed.
- Fresh exact-head GitHub Actions:
  [run 30375302801](https://github.com/NVIDIA/numba-cuda-mlir/actions/runs/30375302801)
  completed green with 124 successful jobs and 4 expected skips; the complete
  PR rollup is 128 passed, 4 skipped, and zero failed or pending.

Dynamic shared-memory minimum propagation is the follow-on in #238.

Co-authored-by: Codex 5.6 Sol Ultra Fast
