### PR TITLE
Fix Windows miscompilation of floating-point constant vectors

### DIFF
--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -15,6 +15,7 @@
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
+#include <cstring>
 #include <fstream>
 
 #define DEBUG_TYPE "llvm70-target"
@@ -913,18 +914,36 @@ llvm::Error MLIRToLLVM70::translateConstantOp(Operation *op) {
     if (!vecTy)
       return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                      "DenseElementsAttr on non-vector type");
-    LLVMTypeRef elemLLVMTy = convertType(vecTy.getElementType());
+    Type elemTy = vecTy.getElementType();
+    LLVMTypeRef elemLLVMTy = convertType(elemTy);
     SmallVector<LLVMValueRef> elems;
-    if (vecTy.getElementType().isIntOrIndex()) {
+    if (elemTy.isIntOrIndex()) {
       for (auto val : denseAttr.getValues<APInt>())
         elems.push_back(b.constInt(elemLLVMTy, toUInt64(val),
                                    val.isNegative()));
-    } else if (isBF16(vecTy.getElementType())) {
-      for (auto val : denseAttr.getValues<APFloat>())
-        elems.push_back(constBF16(b, val));
     } else {
-      for (auto val : denseAttr.getValues<APFloat>())
-        elems.push_back(b.constReal(elemLLVMTy, val.convertToDouble()));
+      // Reconstruct floating-point elements from their raw bit patterns instead
+      // of using DenseElementsAttr::getValues<APFloat>(). When this bridge and
+      // the MLIR Python bindings embed distinct LLVM copies (e.g. on Windows,
+      // where duplicate symbols are not interposed as they are with ELF),
+      // APFloat's fltSemantics singletons live at different addresses across the
+      // module boundary and the float element iterator silently yields zero.
+      // Raw byte access carries the correct IEEE encoding, so we read the bits
+      // and materialize the constant via an integer bitcast. bf16 is stored as
+      // i16, so it needs no bitcast.
+      unsigned bitWidth = elemTy.getIntOrFloatBitWidth();
+      unsigned byteWidth = bitWidth / 8;
+      ArrayRef<char> raw = denseAttr.getRawData();
+      bool splat = denseAttr.isSplat();
+      LLVMTypeRef intElemTy = b.intTy(bitWidth);
+      for (int64_t i = 0, e = vecTy.getNumElements(); i < e; ++i) {
+        uint64_t bits = 0;
+        std::memcpy(&bits, raw.data() + (splat ? 0 : i * byteWidth), byteWidth);
+        LLVMValueRef intConst = b.constInt(intElemTy, bits, /*signExt=*/false);
+        elems.push_back(isBF16(elemTy)
+                            ? intConst
+                            : b.constBitCast(intConst, elemLLVMTy));
+      }
     }
     mapValue(result, b.constVector(elems.data(), elems.size()));
     return llvm::Error::success();

--- a/tests/numba_cuda_tests/cudapy/test_vector_type.py
+++ b/tests/numba_cuda_tests/cudapy/test_vector_type.py
@@ -9,11 +9,7 @@ and should not be imported by user, user should only import the
 corresponding vector type from `cuda` module in kernel to use them.
 """
 
-from functools import wraps
-import sys
-
 import numpy as np
-import pytest
 
 from numba_cuda_mlir.testing import NumbaCUDATestCase
 
@@ -34,31 +30,6 @@ class _VectorTypeTestInfo:
 
 def _vector_types():
     return [_VectorTypeTestInfo(vec_type) for vec_type in _cuda_vector_types]
-
-
-def _is_windows_llvm70_vector_path():
-    if sys.platform != "win32":
-        return False
-    from numba_cuda_mlir import tools
-
-    return tools.get_gpu_compute_capability(tuple) < (10, 0)
-
-
-def _xfail_windows_llvm70_vector_path(reason):
-    def decorator(fn):
-        @wraps(fn)
-        def wrapper(*args, **kwargs):
-            if not _is_windows_llvm70_vector_path():
-                return fn(*args, **kwargs)
-            try:
-                fn(*args, **kwargs)
-            except AssertionError:
-                pytest.xfail(reason)
-            pytest.fail(f"XPASS(strict): {reason}")
-
-        return wrapper
-
-    return decorator
 
 
 def make_kernel(vtype):
@@ -303,9 +274,6 @@ class TestCudaVectorType(NumbaCUDATestCase):
             kernel[1, 1](arr)
             np.testing.assert_almost_equal(arr, np.array(range(vty.num_elements)))
 
-    @_xfail_windows_llvm70_vector_path(
-        "Fancy vector construction currently only fails on Windows LLVM 7 path"
-    )
     def test_fancy_creation_readout(self):
         for vty in _vector_types():
             kernel = make_fancy_creation_kernel(vty)
@@ -522,9 +490,6 @@ class TestCudaVectorType(NumbaCUDATestCase):
         for alias, vec_type in vector_types_by_alias.items():
             self.assertEqual(id(getattr(cuda, vec_type.name)), id(getattr(cuda, alias)))
 
-    @_xfail_windows_llvm70_vector_path(
-        "Vector local array readback currently fails on Windows LLVM 7 path"
-    )
     def test_vector_local_array(self):
         """Tests that vector types can be used as dtype for cuda.local.array"""
 
@@ -541,9 +506,6 @@ class TestCudaVectorType(NumbaCUDATestCase):
         kernel[1, 1](out)
         np.testing.assert_array_equal(out, np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
 
-    @_xfail_windows_llvm70_vector_path(
-        "Vector shared array readback currently fails on Windows LLVM 7 path"
-    )
     def test_vector_shared_array(self):
         """Tests that vector types can be used as dtype for cuda.shared.array"""
 

--- a/tests/test_vector_types.py
+++ b/tests/test_vector_types.py
@@ -616,3 +616,130 @@ def test_cuda_vector_fancy_creation():
         1.0,  # f4_6: (f1_1, f1_1, f1_1, f1_1)
     ]
     np.testing.assert_allclose(res, expected)
+
+
+# ---------------------------------------------------------------------------
+# Regression: compile-time-constant vector stores.
+#
+# Storing a compile-time-constant floating-point vector into a vector-typed
+# array (the `dense<>` constant path) was miscompiled to an all-zero result on
+# Windows. The bridge and the MLIR Python bindings embed distinct LLVM copies,
+# and without ELF-style symbol interposition APFloat's fltSemantics singletons
+# differ across the module boundary, so the dense float element iterator
+# silently yielded zero. Integer constant vectors and runtime-built floating
+# vectors were unaffected. See LLVM70Target.cpp::translateConstantOp.
+# ---------------------------------------------------------------------------
+
+
+def _store_constant_vector_kernel(vec_type, values):
+    """Build a kernel that stores a constant `vec_type` into a vector view."""
+    if len(values) == 1:
+        (e0,) = values
+
+        @cuda.jit
+        def kernel(out):
+            out.view(vec_type)[0] = vec_type(e0)
+
+    elif len(values) == 2:
+        e0, e1 = values
+
+        @cuda.jit
+        def kernel(out):
+            out.view(vec_type)[0] = vec_type(e0, e1)
+
+    elif len(values) == 3:
+        e0, e1, e2 = values
+
+        @cuda.jit
+        def kernel(out):
+            out.view(vec_type)[0] = vec_type(e0, e1, e2)
+
+    else:
+        e0, e1, e2, e3 = values
+
+        @cuda.jit
+        def kernel(out):
+            out.view(vec_type)[0] = vec_type(e0, e1, e2, e3)
+
+    return kernel
+
+
+_CONSTANT_VECTOR_CASES = [
+    (cuda.float16x2, np.float16, (1.0, 2.0)),
+    (cuda.float16x4, np.float16, (1.0, 2.0, 3.0, 4.0)),
+    (cuda.float32x2, np.float32, (1.0, 2.0)),
+    (cuda.float32x3, np.float32, (1.0, 2.0, 3.0)),
+    (cuda.float32x4, np.float32, (1.0, 2.0, 3.0, 4.0)),
+    (cuda.float64x2, np.float64, (1.0, 2.0)),
+    (cuda.float64x3, np.float64, (1.0, 2.0, 3.0)),
+    (cuda.float64x4, np.float64, (1.0, 2.0, 3.0, 4.0)),
+    # Integer constant vectors were never broken; kept as controls.
+    (cuda.int32x2, np.int32, (5, 6)),
+    (cuda.int32x4, np.int32, (5, 6, 7, 8)),
+]
+
+
+@pytest.mark.parametrize(
+    "vec_type,dtype,values",
+    _CONSTANT_VECTOR_CASES,
+    ids=[case[0].name for case in _CONSTANT_VECTOR_CASES],
+)
+def test_constant_vector_store(vec_type, dtype, values):
+    """A compile-time-constant vector must survive the store round-trip."""
+    kernel = _store_constant_vector_kernel(vec_type, values)
+
+    out = np.zeros(len(values), dtype=dtype)
+    kernel[1, 1](out)
+    cuda.synchronize()
+
+    np.testing.assert_allclose(out.tolist(), values)
+
+
+@pytest.mark.parametrize(
+    "vec_type,dtype,values",
+    [
+        (cuda.float32x2, np.float32, (1.0, 2.0)),
+        (cuda.float64x2, np.float64, (3.0, 4.0)),
+    ],
+    ids=["float32x2", "float64x2"],
+)
+def test_runtime_vector_store_matches_constant(vec_type, dtype, values):
+    """Control: a runtime-built float vector store must also round-trip.
+
+    This exercises the insertelement path (as opposed to the dense<> constant
+    path) and guards against a regression in either construction route.
+    """
+    a, b = values
+
+    @cuda.jit
+    def kernel(out, x, y):
+        out.view(vec_type)[0] = vec_type(x, y)
+
+    out = np.zeros(len(values), dtype=dtype)
+    kernel[1, 1](out, dtype(a), dtype(b))
+    cuda.synchronize()
+
+    np.testing.assert_allclose(out.tolist(), values)
+
+
+def test_constant_vector_store_not_zeroed_in_ptx():
+    """The generated PTX must not collapse the FP constant vector to zero.
+
+    A PTX-level check that pins the exact failure mode (`0f00000000` for every
+    lane) independently of GPU execution.
+    """
+    e0, e1 = 1.0, 2.0
+
+    @cuda.jit
+    def kernel(out):
+        out.view(cuda.float32x2)[0] = cuda.float32x2(e0, e1)
+
+    out = np.zeros(2, dtype=np.float32)
+    kernel[1, 1](out)
+
+    (ptx,) = kernel.inspect_ptx().values()
+    if isinstance(ptx, bytes):
+        ptx = ptx.decode()
+    # 1.0f and 2.0f encode as 0f3F800000 and 0f40000000 respectively.
+    assert "0f3F800000" in ptx
+    assert "0f40000000" in ptx


### PR DESCRIPTION
# Fix Windows miscompilation of floating-point constant vectors

## Summary

On Windows, storing a **compile-time-constant floating-point vector** (e.g.
`float32x2(1.0, 2.0)`) into a vector-typed array produced an all-zero result.
This fixes the miscompilation in the LLVM-7 bridge and adds regression tests.
The same code path works correctly on Linux, so this was a platform-specific
codegen bug, not a logic error in the kernels.

## Symptom

```python
@cuda.jit
def kernel(out):
    out.view(cuda.float32x2)[0] = cuda.float32x2(1.0, 2.0)
```

Produced PTX with every lane zeroed
(`mov.f32 %f1, 0f00000000; st.global.v2.f32 [...], {%f1, %f1}`) instead of
`1.0, 2.0`. This surfaced as failing `nvmath-python` tests
(`test_underlying_abstraction_storage_interop` for `complex64` / `complex128`,
which are backed by `float32x2` / `float64x2`).

Unaffected (and used as controls): integer constant vectors, runtime-built
float vectors (`insertelement` path), and scalar float constants.

## Root cause

`MLIRToLLVM70.dll` and the MLIR Python bindings (`MLIRPythonCAPI.dll`) each
embed their own copy of LLVM. On Linux, ELF symbol interposition collapses the
duplicate `llvm::APFloatBase` `fltSemantics` singletons to a single definition
at load time; **Windows has no such interposition**, so the two copies live at
different addresses. As a result, `DenseElementsAttr::getValues<APFloat>()` in
the bridge constructed `APFloat`s against a `fltSemantics` pointer it did not
recognize and silently yielded zero for every float element. The constant was
already `zeroinitializer` in the bridge's generated LLVM-7 IR, before libnvvm.

## Fix

In `LLVM70Target.cpp::translateConstantOp`, stop routing floating-point dense
constants through `getValues<APFloat>()`. Instead, read each element's **raw bit
pattern** (integer/byte access is unaffected by the semantics mismatch) and
materialize the constant via an integer→float `bitcast`. `bf16` is stored as
`i16`, so it needs no bitcast. The integer path is unchanged.

This is robust regardless of how the LLVM/MLIR linkage evolves; relying on
`APFloat` semantics-singleton identity across a module boundary is inherently
fragile.

## Tests

Added regression tests in `tests/test_vector_types.py` (the existing tests never
exercised the constant-vector *store* path):

- `test_constant_vector_store` — parametrized over `float16/32/64` × 2/3/4 lanes
  plus `int32` controls; verifies the constant survives the store round-trip.
- `test_runtime_vector_store_matches_constant` — control covering the runtime
  `insertelement` path.
- `test_constant_vector_store_not_zeroed_in_ptx` — pins the exact failure mode at
  the PTX level (`0f3F800000` / `0f40000000` must be present).

## Verification

- New tests: 13 passed; full `tests/test_vector_types.py`: 54 passed.
- Previously failing `nvmath-python` tests (`float32` / `float64` interop) now
  pass; full `numba_cuda_mlir` set: 8 passed, 6 xpassed, 0 failed (no
  regressions across int / complex / bf16).

## Follow-up (not in this MR)

The deeper root cause — two LLVM copies in one process — remains. Eliminating it
requires building the modern LLVM/MLIR as a single shared library that both the
bindings and the bridge import (`MLIRPythonCAPI.dll` currently doesn't export
`LLVMSupport` internals like `fltSemantics`), which is a CI/artifact-level
change. This MR's defensive fix hardens the bridge against that entire class of
ODR mismatch in the meantime.
