### PR TITLE
Timeout tests at 30 min

### DIFF
--- a/.github/workflows/test-cudf-source-linux.yml
+++ b/.github/workflows/test-cudf-source-linux.yml
@@ -43,6 +43,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "${{ matrix.FLAVOR || 'linux' }}-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-${{ matrix.GPU_COUNT }}"
+    timeout-minutes: 30
     if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
     container:
       options: -u root --security-opt seccomp=unconfined --shm-size 16g

--- a/.github/workflows/test-expensive-linux.yml
+++ b/.github/workflows/test-expensive-linux.yml
@@ -43,6 +43,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "${{ matrix.FLAVOR || 'linux' }}-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-${{ matrix.GPU_COUNT }}"
+    timeout-minutes: 30
     if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
     container:
       options: -u root --security-opt seccomp=unconfined --shm-size 16g

--- a/.github/workflows/test-numbast-mlir-linux.yml
+++ b/.github/workflows/test-numbast-mlir-linux.yml
@@ -43,6 +43,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "${{ matrix.FLAVOR || 'linux' }}-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-${{ matrix.GPU_COUNT }}"
+    timeout-minutes: 30
     if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
     container:
       options: -u root --security-opt seccomp=unconfined --shm-size 16g

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -76,6 +76,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "${{ matrix.FLAVOR || 'linux' }}-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-${{ matrix.GPU_COUNT }}"
+    timeout-minutes: 30
     # The build stage could fail but we want the CI to keep moving.
     if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
     # Our self-hosted runners require a container

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -63,6 +63,7 @@ jobs:
       max-parallel: 5
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "windows-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-${{ matrix.GPU_COUNT }}"
+    timeout-minutes: 30
     if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
     steps:
       - name: Checkout ${{ github.event.repository.name }}


### PR DESCRIPTION
The CI occasionally stalls on network issues, this leads to jobs often taking 6+ hours that just need to be restarted. This PR adds a 30 min timeout to each of the test jobs, all of which should take < 15 min, so we can get these failures noticed faster.