### PR TITLE
Preserve numpy integer scalar argument width on lazy-JIT launch path

### DIFF
--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -53,6 +53,11 @@ PyTypeObject* g_cuda_core_Stream_type;
 
 PyTypeObject* g_enum_Enum_type;
 
+// numpy integer abstract base type; matches every signed/unsigned numpy
+// integer scalar (int8/16/32/64, uint8/16/32/64, including aliases such as
+// numpy.longlong).
+PyTypeObject* g_numpy_integer_type;
+
 constexpr uint8_t BYTE_BITWIDTH = 8;
 
 constexpr const char* ERROR_CODE_GLOBAL_NAME = "__numba_cuda_mlir_error_code";
@@ -456,6 +461,8 @@ enum class PythonArgKind {
     PyEnum,
     // numpy.datetime64 or numpy.timedelta64 scalar (stored as int64)
     NpDatetime,
+    // numpy signed/unsigned integer scalar (int8/16/32/64, uint8/16/32/64)
+    NpInteger,
 };
 
 enum class ParameterKind {
@@ -510,6 +517,22 @@ Result<std::pair<PythonArgKind, ParameterKind>> classify_arg(PyObject* arg) {
     if (type_name && strcmp(type_name, "numpy.float32") == 0)
         return {{PythonArgKind::NpFloat32, ParameterKind::Float}};
 
+    // numpy.datetime64 and numpy.timedelta64 scalars (stored as int64)
+    if (type_name && (strcmp(type_name, "numpy.datetime64") == 0
+                   || strcmp(type_name, "numpy.timedelta64") == 0))
+        return {{PythonArgKind::NpDatetime, ParameterKind::Integer}};
+
+    // numpy signed/unsigned integer scalars. These must be marshalled with
+    // their native width preserved, so the launcher classifies them directly
+    // instead of letting the Python side widen them to a Python int.
+    if (g_numpy_integer_type) {
+        int is_np_int = PyObject_IsInstance(arg, (PyObject*)g_numpy_integer_type);
+        if (is_np_int < 0)
+            return ErrorRaised;
+        if (is_np_int)
+            return {{PythonArgKind::NpInteger, ParameterKind::Integer}};
+    }
+
     // Check for numpy.complex64 before PyComplex_Check
     // numpy.complex64 is NOT a subclass of Python complex, but numpy.complex128 IS
     if (type_name && strcmp(type_name, "numpy.complex64") == 0)
@@ -535,11 +558,6 @@ Result<std::pair<PythonArgKind, ParameterKind>> classify_arg(PyObject* arg) {
         if (PyObject_HasAttrString(arg, "getPtr") && PyObject_HasAttrString(arg, "opaque"))
             return {{PythonArgKind::TMADescriptor, ParameterKind::Integer}};
     }
-
-    // numpy.datetime64 and numpy.timedelta64 scalars (stored as int64)
-    if (type_name && (strcmp(type_name, "numpy.datetime64") == 0
-                   || strcmp(type_name, "numpy.timedelta64") == 0))
-        return {{PythonArgKind::NpDatetime, ParameterKind::Integer}};
 
     // Check for numpy.void or record (scalar record/structured dtype) before __cuda_array_interface__
     // numpy.void has __array_interface__ but not __cuda_array_interface__
@@ -581,11 +599,22 @@ inline void fast_extract_py_long(PyObject* obj, CudaArg* out) {
     out->i64 = PyLong_AsLongLong(obj);
 }
 
+inline void fast_extract_np_integer(PyObject* obj, CudaArg* out) {
+    // Convert the numpy scalar to a real Python int, then reuse pylong_as,
+    // which reinterprets uint64 values above INT64_MAX as their bit pattern.
+    PyObject* as_int = PyNumber_Index(obj);
+    if (as_int) {
+        out->i64 = pylong_as<int64_t>(as_int);
+        Py_DECREF(as_int);
+    }
+}
+
 ScalarExtractor get_scalar_extractor(PythonArgKind kind) {
     switch (kind) {
     case PythonArgKind::NpFloat32:  return fast_extract_np_float32;
     case PythonArgKind::PyFloat:    return fast_extract_py_float;
     case PythonArgKind::PyLong:     return fast_extract_py_long;
+    case PythonArgKind::NpInteger:  return fast_extract_np_integer;
     default:                        return nullptr;
     }
 }
@@ -1020,6 +1049,25 @@ inline Status extract_py_long(PyObject* pyobj, bool is_constant, LaunchHelper& h
     return OK;
 }
 
+inline Status extract_np_integer(PyObject* pyobj, bool is_constant, LaunchHelper& helper) {
+    // Promote numpy integer scalar to PyLong, required for pylong_as's unsigned retry;
+    // pylong_as keeps the exact 64-bit pattern, so uint64 > INT64_MAX round-trips.
+    PyPtr as_int = steal(PyNumber_Index(pyobj));
+    if (!as_int) return ErrorRaised;
+
+    int64_t value = pylong_as<int64_t>(as_int.get());
+    if (PyErr_Occurred()) return ErrorRaised;
+
+    size_t start_idx = helper.cuargs.size();
+    helper.cuargs.push_back(cuda_arg_i64(value));
+    helper.arg_metadata.push_back({ArgMetadata::Kind::Scalar, start_idx, 0});
+
+    if (is_constant)
+        helper.constants.push_back(ConstantArg(value));
+
+    return OK;
+}
+
 inline Status extract_py_enum(PyObject* pyobj, bool is_constant, LaunchHelper& helper) {
     PyObject* value_attr = PyObject_GetAttrString(pyobj, "value");
     if (!value_attr) return ErrorRaised;
@@ -1367,6 +1415,9 @@ Status extract_cuda_args(PyObject* const* pyargs, size_t num_pyargs,
             break;
         case PythonArgKind::PyLong:
             if (!extract_py_long(pyobj, is_constant, helper)) return ErrorRaised;
+            break;
+        case PythonArgKind::NpInteger:
+            if (!extract_np_integer(pyobj, is_constant, helper)) return ErrorRaised;
             break;
         case PythonArgKind::PyEnum:
             if (!extract_py_enum(pyobj, is_constant, helper)) return ErrorRaised;
@@ -1808,6 +1859,8 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
         const ScalarExtractor* extractors = profile->fast_extractors.data();
         for (size_t i = 0; i < n; ++i) {
             extractors[i](pyargs[i], &base[i]);
+            // Fast extractors return void; propagate any exception they raised
+            if (PyErr_Occurred()) return ErrorRaised;
             helper->cuarg_pointers[i] = &base[i];
         }
         helper->constants.clear();
@@ -2358,6 +2411,16 @@ void try_get_enum_globals() {
     }
 }
 
+void try_get_numpy_globals() {
+    PyPtr numpy = try_import("numpy");
+    if (!numpy) return;
+
+    if (PyPtr numpy_integer = try_getattr(numpy, "integer")) {
+        if (PyType_Check(numpy_integer.get()))
+            g_numpy_integer_type = reinterpret_cast<PyTypeObject*>(numpy_integer.release());
+    }
+}
+
 } // anonymous namespace
 
 
@@ -2401,6 +2464,7 @@ Status kernel_init(PyObject* m) {
     try_get_numba_globals();
     try_get_cuda_core_globals();
     try_get_enum_globals();
+    try_get_numpy_globals();
 
     KernelDispatcher_type.tp_name = "numba_cuda_mlir._cext.KernelDispatcher";
     KernelDispatcher_type.tp_basicsize = sizeof(PythonWrapper<KernelDispatcher>);

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -467,7 +467,8 @@ class _ArgMarshaller:
             case np.datetime64() | np.timedelta64():
                 return arg
             case np.integer():
-                return int(arg)
+                # Keep as-is; C++ launcher handles np.integer directly.
+                return arg
             case np.float16():
                 # Keep as-is; C++ launcher handles f16 conversion
                 return arg

--- a/tests/test_debuginfo.py
+++ b/tests/test_debuginfo.py
@@ -777,7 +777,7 @@ def test_mlir_poly_scalar_var_runtime_debug():
 
 
 def test_mlir_di_bitwise_result_int32():
-    """Bitwise AND/OR/XOR on int32 operands must appear as int32 in DWARF (nvbug5936795)."""
+    """Bitwise AND/OR/XOR on int32 operands must appear as int32 in DWARF."""
 
     def k(out, a, b):
         result_and = a & b
@@ -799,6 +799,43 @@ def test_mlir_di_bitwise_result_int32():
         CHECK: di_local_variable<{{.*}}name = "result_and"{{.*}}type = #[[INT32]]
         CHECK: di_local_variable<{{.*}}name = "result_or"{{.*}}type = #[[INT32]]
         CHECK: di_local_variable<{{.*}}name = "result_xor"{{.*}}type = #[[INT32]]
+        """,
+        mlir,
+    )
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize(
+    "int_arg, expected_name, size_bits, encoding",
+    [
+        (np.int8, "int8", 8, "DW_ATE_signed"),
+        (np.int16, "int16", 16, "DW_ATE_signed"),
+        (np.int32, "int32", 32, "DW_ATE_signed"),
+        (np.int64, "int64", 64, "DW_ATE_signed"),
+        (np.uint8, "uint8", 8, "DW_ATE_unsigned"),
+        (np.uint16, "uint16", 16, "DW_ATE_unsigned"),
+        (np.uint32, "uint32", 32, "DW_ATE_unsigned"),
+        (np.uint64, "uint64", 64, "DW_ATE_unsigned"),
+    ],
+)
+def test_mlir_scalar_int_arg_type(int_arg, expected_name, size_bits, encoding):
+    """A numpy integer scalar arg keeps its width on the lazy JIT path."""
+
+    @cuda.jit(debug=True, opt=False)
+    def k(out, x):
+        out[0] = x
+
+    out = np.zeros(1, dtype=np.int64)
+    # Signature-less launch: the scalar's type is inferred from the value.
+    k[1, 1](out, int_arg(42))
+
+    (sig,) = k.overloads
+    mlir = k.inspect_mlir(sig)
+    testing.filecheck(
+        f"""
+        CHECK: di_basic_type<tag = DW_TAG_base_type, name = "{expected_name}"
+        CHECK-SAME: sizeInBits = {size_bits}
+        CHECK-SAME: encoding = {encoding}
         """,
         mlir,
     )


### PR DESCRIPTION
Scalar `int8`/`int16`/`int32` (and their unsigned counterparts) kernel arguments were reported as `int64` in CUBIN DWARF debug info when the kernel was compiled via the implicit / lazy-JIT path (a bare `@cuda.jit` with no explicit signature and no type annotations). 

The problem: the dispatcher was widening every numpy integer scalar to a 64-bit Python `int` before type inference, so `typeof()` saw `int64`, and the compiled parameter, together with its debug info, became `int64`.

After this change, numpy integer scalar arguments keep their native width through the lazy-JIT path, mirroring how `np.float16`/`np.float32` are already preserved. The DWARF now reports the correct `int8`/`int16`/`int32`/`int64` (and unsigned) base types. Python `int` arguments continue to map to `int64`, unchanged.