### PR TITLE
Query libnvvm for the NVVM IR version on the llvm70-translate path

### DIFF
--- a/cext/mlir-llvm70/include/llvm70/LibNVVMCompiler.h
+++ b/cext/mlir-llvm70/include/llvm70/LibNVVMCompiler.h
@@ -56,6 +56,11 @@ public:
   /// Get the program log (warnings, errors) from libnvvm.
   std::string getLog(nvvmProgram prog);
 
+  /// Query the NVVM IR and debug-metadata versions supported by the
+  /// loaded libnvvm (nvvmIRVersion).
+  llvm::Error getIRVersion(int &irMajor, int &irMinor, int &dbgMajor,
+                           int &dbgMinor);
+
 private:
   LibNVVMCompiler() = default;
   llvm::Error resolveSymbols();
@@ -74,6 +79,7 @@ private:
   nvvmResult (*fnGetCompiledResult)(nvvmProgram, char *) = nullptr;
   nvvmResult (*fnGetProgramLogSize)(nvvmProgram, size_t *) = nullptr;
   nvvmResult (*fnGetProgramLog)(nvvmProgram, char *) = nullptr;
+  nvvmResult (*fnIRVersion)(int *, int *, int *, int *) = nullptr;
 };
 
 } // namespace llvm70

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -47,6 +47,24 @@ llvm::Expected<std::string> llvm70::translateToNVVMIR(gpu::GPUModuleOp gpuMod,
 
 llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
                                                   const LLVM70Options &opts) {
+  // If the caller supplied no versions (debug pair 0.0), ask libnvvm;
+  // recent libnvvm rejects the zero debug version.
+  auto compilerOrErr = LibNVVMCompiler::create(opts.libnvvmPath);
+  if (!compilerOrErr)
+    return compilerOrErr.takeError();
+
+  LLVM70Options effectiveOpts = opts;
+  if (opts.nvvmDebugMajor == 0 && opts.nvvmDebugMinor == 0) {
+    int irMajor, irMinor, dbgMajor, dbgMinor;
+    if (auto err =
+            (*compilerOrErr)->getIRVersion(irMajor, irMinor, dbgMajor, dbgMinor))
+      return std::move(err);
+    effectiveOpts.nvvmIRMajor = irMajor;
+    effectiveOpts.nvvmIRMinor = irMinor;
+    effectiveOpts.nvvmDebugMajor = dbgMajor;
+    effectiveOpts.nvvmDebugMinor = dbgMinor;
+  }
+
   auto builderOrErr = LLVM70IRBuilder::create(opts.libLLVMPath);
   if (!builderOrErr)
     return builderOrErr.takeError();
@@ -57,7 +75,8 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
     builder->setDataLayout(opts.dataLayout.c_str());
 
   MLIRToLLVM70 translator(*builder);
-  if (auto err = translator.translate(gpuMod, opts.debugLevel, opts.genLTO, &opts))
+  if (auto err = translator.translate(gpuMod, opts.debugLevel, opts.genLTO,
+                                      &effectiveOpts))
     return std::move(err);
 
   LLVM_DEBUG({
@@ -92,12 +111,6 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
   }
 
   // Compile via libnvvm
-  auto compilerOrErr = LibNVVMCompiler::create(opts.libnvvmPath);
-  if (!compilerOrErr) {
-    builder->disposeMemoryBuffer(buf);
-    return compilerOrErr.takeError();
-  }
-
   std::string computeArch =
       "compute_" + opts.chip.substr(opts.chip.find_first_of("0123456789"));
   auto ptxOrErr =

--- a/cext/mlir-llvm70/lib/LibNVVMCompiler.cpp
+++ b/cext/mlir-llvm70/lib/LibNVVMCompiler.cpp
@@ -45,6 +45,16 @@ llvm::Error LibNVVMCompiler::resolveSymbols() {
   RESOLVE(fnGetCompiledResult, "nvvmGetCompiledResult");
   RESOLVE(fnGetProgramLogSize, "nvvmGetProgramLogSize");
   RESOLVE(fnGetProgramLog, "nvvmGetProgramLog");
+  RESOLVE(fnIRVersion, "nvvmIRVersion");
+  return llvm::Error::success();
+}
+
+llvm::Error LibNVVMCompiler::getIRVersion(int &irMajor, int &irMinor,
+                                          int &dbgMajor, int &dbgMinor) {
+  nvvmResult rc = fnIRVersion(&irMajor, &irMinor, &dbgMajor, &dbgMinor);
+  if (rc != NVVM_SUCCESS)
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "nvvmIRVersion failed (%d)", rc);
   return llvm::Error::success();
 }
 


### PR DESCRIPTION
Fixes #218.

`translateToPTX` left the four `nvvmir.version` fields at their defaults unless the caller set them, and recent libnvvm rejects the default 0.0 debug pair. It now asks libnvvm for its supported versions (`nvvmIRVersion`) and uses those when the caller supplied none. Callers that pass explicit versions are unchanged. The Python compile path already gets its versions the same way.

`LibNVVMCompiler` gains the `nvvmIRVersion` binding. The libnvvm load moves from just before compilation to before translation; every path through this function already required libnvvm.

**Verification:** (CUDA 13, Windows) 40 RUN lines in `cext/mlir-llvm70/test` go red->green; the `--dump-llvm`-only lines are unaffected.

Written by Chris' bot, rewritten repeatedly by Chris.
