### PR TITLE
Restore selective fastmath support via per-op MLIR fastmath attributes

### DIFF
--- a/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
@@ -248,12 +248,6 @@ public:
   size_t getBufferSize(LLVMMemoryBufferRef buf);
   void disposeMemoryBuffer(LLVMMemoryBufferRef buf);
 
-  /// Replace the current module with one parsed from textual IR (in the same
-  /// context). Used to round-trip fast-math flag injection, which the old C
-  /// API cannot express directly. Only valid once construction is complete;
-  /// existing LLVMValueRefs into the old module become invalid.
-  llvm::Error replaceModuleWithParsedIR(llvm::StringRef ir);
-
 private:
   LLVM70IRBuilder() = default;
   llvm::Error resolveSymbols();
@@ -307,10 +301,6 @@ private:
   LLVM_FN(unsigned, fnCountParams, LLVMValueRef)
   LLVM_FN(void, fnSetValueName2, LLVMValueRef, const char *, size_t)
   LLVM_FN(LLVMValueRef, fnIsAInstruction, LLVMValueRef)
-  LLVM_FN(LLVMMemoryBufferRef, fnCreateMemoryBufferWithMemoryRangeCopy,
-          const char *, size_t, const char *)
-  LLVM_FN(LLVMBool, fnParseIRInContext, LLVMContextRef, LLVMMemoryBufferRef,
-          LLVMModuleRef *, char **)
 
   // Basic blocks
   LLVM_FN(LLVMBasicBlockRef, fnAppendBB, LLVMContextRef, LLVMValueRef,

--- a/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
@@ -67,6 +67,7 @@ public:
   LLVMValueRef getParam(LLVMValueRef fn, unsigned idx);
   unsigned countParams(LLVMValueRef fn);
   void setValueName(LLVMValueRef val, const char *name);
+  bool isInstruction(LLVMValueRef val);
 
   // --- Basic blocks ---
   LLVMBasicBlockRef appendBB(LLVMValueRef fn, const char *name);
@@ -247,6 +248,12 @@ public:
   size_t getBufferSize(LLVMMemoryBufferRef buf);
   void disposeMemoryBuffer(LLVMMemoryBufferRef buf);
 
+  /// Replace the current module with one parsed from textual IR (in the same
+  /// context). Used to round-trip fast-math flag injection, which the old C
+  /// API cannot express directly. Only valid once construction is complete;
+  /// existing LLVMValueRefs into the old module become invalid.
+  llvm::Error replaceModuleWithParsedIR(llvm::StringRef ir);
+
 private:
   LLVM70IRBuilder() = default;
   llvm::Error resolveSymbols();
@@ -299,6 +306,11 @@ private:
   LLVM_FN(LLVMValueRef, fnGetParam, LLVMValueRef, unsigned)
   LLVM_FN(unsigned, fnCountParams, LLVMValueRef)
   LLVM_FN(void, fnSetValueName2, LLVMValueRef, const char *, size_t)
+  LLVM_FN(LLVMValueRef, fnIsAInstruction, LLVMValueRef)
+  LLVM_FN(LLVMMemoryBufferRef, fnCreateMemoryBufferWithMemoryRangeCopy,
+          const char *, size_t, const char *)
+  LLVM_FN(LLVMBool, fnParseIRInContext, LLVMContextRef, LLVMMemoryBufferRef,
+          LLVMModuleRef *, char **)
 
   // Basic blocks
   LLVM_FN(LLVMBasicBlockRef, fnAppendBB, LLVMContextRef, LLVMValueRef,

--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -50,6 +50,8 @@ struct LLVM70Options {
   int nvvmDebugMinor = 0;
   /// Extra .bc files to link (libdevice, runtime BCs)
   llvm::SmallVector<std::string> linkLibs;
+  /// Extra nvvmCompileProgram options (e.g. "-prec-div=0" for fastmath)
+  llvm::SmallVector<std::string> nvvmOptions;
 };
 
 /// Translate a gpu.module (containing LLVM dialect ops) to PTX.
@@ -73,8 +75,21 @@ public:
                         bool omitDebugInfoVersionFlag = false,
                         const LLVM70Options *opts = nullptr);
 
+  /// True when at least one instruction was tagged with a fast-math marker
+  /// name (see tagFastmath). The module's printed IR must then have the
+  /// flag keywords injected before serialization.
+  bool hasFastmathMarkers() const { return fmfTagged; }
+
 private:
   LLVM70IRBuilder &b;
+
+  // Fast-math flag transfer state. The LLVM 7 C API has no way to set
+  // per-instruction fast-math flags, so flagged instructions are given a
+  // marker value name (__fmf.<mask>_<counter>) and the flag keywords are
+  // injected into the printed textual IR afterwards.
+  unsigned fmfCounter = 0;
+  bool fmfTagged = false;
+  void tagFastmath(mlir::Operation *op, LLVMValueRef inst);
 
   // MLIR Value → old LLVMValueRef
   llvm::DenseMap<mlir::Value, LLVMValueRef> valueMap;

--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -76,8 +76,8 @@ public:
                         const LLVM70Options *opts = nullptr);
 
   /// True when at least one instruction was tagged with a fast-math marker
-  /// name (see tagFastmath). The module's printed IR must then have the
-  /// flag keywords injected before serialization.
+  /// name (see tagFastmath). The printed IR must then have the flag
+  /// keywords injected before it reaches libnvvm.
   bool hasFastmathMarkers() const { return fmfTagged; }
 
 private:

--- a/cext/mlir-llvm70/include/llvm70/LibNVVMCompiler.h
+++ b/cext/mlir-llvm70/include/llvm70/LibNVVMCompiler.h
@@ -48,10 +48,13 @@ public:
   /// Compile bitcode buffer(s) to PTX (or LTOIR when \p genLTO is true) for
   /// the given SM architecture.  \p arch is e.g. "compute_80".  \p modules is
   /// a list of (buffer, size) pairs — each may be LLVM bitcode or text IR.
+  /// \p extraOptions are additional nvvmCompileProgram options
+  /// (e.g. "-prec-div=0").
   llvm::Expected<std::string>
   compile(llvm::StringRef arch,
           llvm::ArrayRef<std::pair<const char *, size_t>> modules,
-          unsigned optLevel = 2, bool genLTO = false);
+          unsigned optLevel = 2, bool genLTO = false,
+          llvm::ArrayRef<std::string> extraOptions = {});
 
   /// Get the program log (warnings, errors) from libnvvm.
   std::string getLog(nvvmProgram prog);

--- a/cext/mlir-llvm70/lib/CAPI.cpp
+++ b/cext/mlir-llvm70/lib/CAPI.cpp
@@ -44,7 +44,13 @@ int llvm70_translate_gpu_module_from_op(
     int gen_lto, int opt_level, int gen_lineinfo,
     int nvvm_ir_major, int nvvm_ir_minor, int nvvm_debug_major,
     int nvvm_debug_minor,
-    char **out, size_t *out_len, char **err_out) {
+    char **out, size_t *out_len, char **err_out,
+    // Deliberately last: a caller built against this signature can invoke a
+    // library that predates it (the older callee ignores the trailing
+    // argument), and the output pointers never shift. The reverse pairing,
+    // an older caller against this library, remains undefined, as with any
+    // C signature change.
+    const char *nvvm_options) {
 
   *out = nullptr;
   *out_len = 0;
@@ -86,6 +92,20 @@ int llvm70_translate_gpu_module_from_op(
   opts.nvvmIRMinor = nvvm_ir_minor;
   opts.nvvmDebugMajor = nvvm_debug_major;
   opts.nvvmDebugMinor = nvvm_debug_minor;
+
+  // Space-separated extra nvvmCompileProgram options (e.g. "-prec-div=0").
+  if (nvvm_options && nvvm_options[0]) {
+    const char *p = nvvm_options;
+    while (*p) {
+      while (*p == ' ')
+        ++p;
+      const char *start = p;
+      while (*p && *p != ' ')
+        ++p;
+      if (p > start)
+        opts.nvvmOptions.emplace_back(start, p - start);
+    }
+  }
 
   // Intercept llvm::report_fatal_error so it throws an exception instead of
   // aborting the host process (e.g. bf16 rejection, unsupported types).

--- a/cext/mlir-llvm70/lib/CAPI.cpp
+++ b/cext/mlir-llvm70/lib/CAPI.cpp
@@ -45,11 +45,8 @@ int llvm70_translate_gpu_module_from_op(
     int nvvm_ir_major, int nvvm_ir_minor, int nvvm_debug_major,
     int nvvm_debug_minor,
     char **out, size_t *out_len, char **err_out,
-    // Deliberately last: a caller built against this signature can invoke a
-    // library that predates it (the older callee ignores the trailing
-    // argument), and the output pointers never shift. The reverse pairing,
-    // an older caller against this library, remains undefined, as with any
-    // C signature change.
+    // Deliberately last: an older library ignores a trailing argument, so
+    // the output pointers never shift.
     const char *nvvm_options) {
 
   *out = nullptr;

--- a/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
@@ -88,6 +88,10 @@ llvm::Error LLVM70IRBuilder::resolveSymbols() {
   RESOLVE(fnGetParam, "LLVMGetParam");
   RESOLVE(fnCountParams, "LLVMCountParams");
   RESOLVE(fnSetValueName2, "LLVMSetValueName2");
+  RESOLVE(fnIsAInstruction, "LLVMIsAInstruction");
+  RESOLVE(fnCreateMemoryBufferWithMemoryRangeCopy,
+          "LLVMCreateMemoryBufferWithMemoryRangeCopy");
+  RESOLVE(fnParseIRInContext, "LLVMParseIRInContext");
 
   // Basic blocks
   RESOLVE(fnAppendBB, "LLVMAppendBasicBlockInContext");
@@ -294,6 +298,10 @@ LLVMValueRef LLVM70IRBuilder::getParam(LLVMValueRef fn, unsigned idx) {
 unsigned LLVM70IRBuilder::countParams(LLVMValueRef fn) {
   return fnCountParams(fn);
 }
+bool LLVM70IRBuilder::isInstruction(LLVMValueRef v) {
+  return fnIsAInstruction(v) != nullptr;
+}
+
 void LLVM70IRBuilder::setValueName(LLVMValueRef v, const char *name) {
   fnSetValueName2(v, name, strlen(name));
 }
@@ -726,6 +734,32 @@ LLVMValueRef LLVM70IRBuilder::insertDbgValue(LLVMValueRef val,
                                              LLVMMetadataRef debugLoc) {
   return fnDIBuilderInsertDbgValueAtEnd(diBuilder, val, varInfo, expr,
                                         debugLoc, getInsertBlock());
+}
+
+llvm::Error LLVM70IRBuilder::replaceModuleWithParsedIR(llvm::StringRef ir) {
+  // The DIBuilder references the old module; dispose it first (debug info
+  // has already been finalized by the time this is called).
+  if (diBuilder && fnDisposeDIBuilder) {
+    fnDisposeDIBuilder(diBuilder);
+    diBuilder = nullptr;
+  }
+  LLVMMemoryBufferRef buf = fnCreateMemoryBufferWithMemoryRangeCopy(
+      ir.data(), ir.size(), "fastmath_ir");
+  LLVMModuleRef newModule = nullptr;
+  char *errMsg = nullptr;
+  // LLVMParseIRInContext consumes the memory buffer regardless of outcome.
+  if (fnParseIRInContext(ctx, buf, &newModule, &errMsg)) {
+    std::string msg = errMsg ? errMsg : "unknown parse error";
+    if (errMsg)
+      fnDisposeMessage(errMsg);
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "re-parsing IR with fast-math flags "
+                                   "failed: %s",
+                                   msg.c_str());
+  }
+  fnDisposeModule(module);
+  module = newModule;
+  return llvm::Error::success();
 }
 
 // Bitcode

--- a/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
@@ -89,9 +89,6 @@ llvm::Error LLVM70IRBuilder::resolveSymbols() {
   RESOLVE(fnCountParams, "LLVMCountParams");
   RESOLVE(fnSetValueName2, "LLVMSetValueName2");
   RESOLVE(fnIsAInstruction, "LLVMIsAInstruction");
-  RESOLVE(fnCreateMemoryBufferWithMemoryRangeCopy,
-          "LLVMCreateMemoryBufferWithMemoryRangeCopy");
-  RESOLVE(fnParseIRInContext, "LLVMParseIRInContext");
 
   // Basic blocks
   RESOLVE(fnAppendBB, "LLVMAppendBasicBlockInContext");
@@ -734,32 +731,6 @@ LLVMValueRef LLVM70IRBuilder::insertDbgValue(LLVMValueRef val,
                                              LLVMMetadataRef debugLoc) {
   return fnDIBuilderInsertDbgValueAtEnd(diBuilder, val, varInfo, expr,
                                         debugLoc, getInsertBlock());
-}
-
-llvm::Error LLVM70IRBuilder::replaceModuleWithParsedIR(llvm::StringRef ir) {
-  // The DIBuilder references the old module; dispose it first (debug info
-  // has already been finalized by the time this is called).
-  if (diBuilder && fnDisposeDIBuilder) {
-    fnDisposeDIBuilder(diBuilder);
-    diBuilder = nullptr;
-  }
-  LLVMMemoryBufferRef buf = fnCreateMemoryBufferWithMemoryRangeCopy(
-      ir.data(), ir.size(), "fastmath_ir");
-  LLVMModuleRef newModule = nullptr;
-  char *errMsg = nullptr;
-  // LLVMParseIRInContext consumes the memory buffer regardless of outcome.
-  if (fnParseIRInContext(ctx, buf, &newModule, &errMsg)) {
-    std::string msg = errMsg ? errMsg : "unknown parse error";
-    if (errMsg)
-      fnDisposeMessage(errMsg);
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "re-parsing IR with fast-math flags "
-                                   "failed: %s",
-                                   msg.c_str());
-  }
-  fnDisposeModule(module);
-  module = newModule;
-  return llvm::Error::success();
 }
 
 // Bitcode

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -29,8 +29,8 @@ using namespace mlir;
 // The LLVM 7 C API cannot set per-instruction fast-math flags. Flagged
 // instructions are named __fmf.<mask>_<counter> during translation; the
 // printed module gets the keywords inserted at each marked instruction
-// and is re-parsed. Python identifiers cannot contain '.', so the marker
-// cannot collide with a user value name.
+// and goes to libnvvm as text. Python identifiers cannot contain '.', so
+// the marker cannot collide with a user value name.
 //===----------------------------------------------------------------------===//
 
 // Keyword string (each keyword preceded by a space) for an
@@ -165,11 +165,9 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
                  << builder->printModuleToString() << "\n";
   });
 
-  // Serialize the kernel module. Recorded fast-math flags only exist as
-  // value-name markers; materialize them as keywords on the printed IR
-  // and hand libnvvm the text, which its parser accepts alongside
-  // emission kind 3 by name. Stock LLVM 7 cannot re-parse that kind, and
-  // every substitute it can parse changes the debug output downstream.
+  // With fast-math markers, submit the keyword-injected text; libnvvm's
+  // parser accepts it, including emission kind 3, which LLVM 7 cannot
+  // re-parse without changing the debug output.
   std::string textIR;
   LLVMMemoryBufferRef buf = nullptr;
   const char *modData;

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -85,12 +85,12 @@ static void appendLineWithFlags(llvm::StringRef line, std::string &out) {
 }
 
 // The compile unit uses emission kind 3 (DebugDirectivesOnly, named in
-// LLVM 8+); LLVM 7 prints it empty, which its own parser rejects.
-// Downgrade that one case to LineTablesOnly for the round-trip. Only
-// metadata lines (leading '!') are rewritten.
-static void fixupUnparseableEmissionKind(std::string &ir) {
+// LLVM 8+); LLVM 7 prints it empty. libnvvm's parser accepts the name,
+// so spell it back in. Only metadata lines (leading '!') are rewritten.
+static void spellOutEmissionKind(std::string &ir) {
   static constexpr llvm::StringLiteral kEmpty = "emissionKind: ,";
-  static constexpr llvm::StringLiteral kFixed = "emissionKind: LineTablesOnly,";
+  static constexpr llvm::StringLiteral kFixed =
+      "emissionKind: DebugDirectivesOnly,";
   size_t pos = 0;
   while ((pos = ir.find(kEmpty.data(), pos)) != std::string::npos) {
     size_t bol = ir.rfind('\n', pos);
@@ -165,29 +165,37 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
                  << builder->printModuleToString() << "\n";
   });
 
-  // Materialize any recorded fast-math flags via the text round-trip.
+  // Serialize the kernel module. Recorded fast-math flags only exist as
+  // value-name markers; materialize them as keywords on the printed IR
+  // and hand libnvvm the text, which its parser accepts alongside
+  // emission kind 3 by name. Stock LLVM 7 cannot re-parse that kind, and
+  // every substitute it can parse changes the debug output downstream.
+  std::string textIR;
+  LLVMMemoryBufferRef buf = nullptr;
+  const char *modData;
+  size_t modSize;
   if (translator.hasFastmathMarkers()) {
-    std::string textIR = injectFastmathFlags(builder->printModuleToString());
-    fixupUnparseableEmissionKind(textIR);
-    if (auto err = builder->replaceModuleWithParsedIR(textIR))
-      return std::move(err);
+    textIR = injectFastmathFlags(builder->printModuleToString());
+    spellOutEmissionKind(textIR);
+    modData = textIR.data();
+    modSize = textIR.size();
+  } else {
+    buf = builder->writeBitcodeToMemoryBuffer();
+    modData = builder->getBufferStart(buf);
+    modSize = builder->getBufferSize(buf);
   }
 
-  // Serialize to bitcode
-  LLVMMemoryBufferRef buf = builder->writeBitcodeToMemoryBuffer();
-  const char *bcData = builder->getBufferStart(buf);
-  size_t bcSize = builder->getBufferSize(buf);
-
-  // Collect modules: our bitcode + any link libraries
+  // Collect modules: the kernel module + any link libraries
   llvm::SmallVector<std::pair<const char *, size_t>> modules;
-  modules.push_back({bcData, bcSize});
+  modules.push_back({modData, modSize});
 
   // Read link libraries (libdevice, runtime BCs)
   llvm::SmallVector<std::string> libBuffers;
   for (const auto &libPath : opts.linkLibs) {
     std::ifstream file(libPath, std::ios::binary | std::ios::ate);
     if (!file.is_open()) {
-      builder->disposeMemoryBuffer(buf);
+      if (buf)
+        builder->disposeMemoryBuffer(buf);
       return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                      "cannot open link library: %s",
                                      libPath.c_str());
@@ -212,7 +220,8 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
                       ->compile(computeArch, modules, opts.optLevel,
                                 opts.genLTO, opts.nvvmOptions);
 
-  builder->disposeMemoryBuffer(buf);
+  if (buf)
+    builder->disposeMemoryBuffer(buf);
   return ptxOrErr;
 }
 

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -24,6 +24,113 @@ using namespace llvm70;
 using namespace mlir;
 
 //===----------------------------------------------------------------------===//
+// Fast-math flag injection
+//
+// The LLVM 7 C API cannot set per-instruction fast-math flags. Flagged
+// instructions are named __fmf.<mask>_<counter> during translation; the
+// module is then printed to text, the flag keywords are inserted after
+// each marked instruction's opcode, and the result is re-parsed with the
+// same LLVM 7 runtime before bitcode serialization. The '.' cannot occur
+// in a Python identifier, LLVM 7 prints it unquoted (unlike '$'), and
+// numba's SSA renaming only ever appends ".<digits>", which cannot form
+// the "__fmf.<digits>_<digits>" shape — so the marker cannot collide
+// with a user-visible value name.
+//===----------------------------------------------------------------------===//
+
+// Keyword string (each keyword preceded by a space) for an
+// mlir::LLVM::FastmathFlags bitmask: nnan=1, ninf=2, nsz=4, arcp=8,
+// contract=16, afn=32, reassoc=64.
+static std::string fastmathKeywords(unsigned mask) {
+  if ((mask & 127u) == 127u)
+    return " fast";
+  static constexpr std::pair<unsigned, const char *> kBits[] = {
+      {1u, "nnan"},      {2u, "ninf"}, {4u, "nsz"},     {8u, "arcp"},
+      {16u, "contract"}, {32u, "afn"}, {64u, "reassoc"}};
+  std::string s;
+  for (auto [bit, kw] : kBits)
+    if (mask & bit) {
+      s += ' ';
+      s += kw;
+    }
+  return s;
+}
+
+// If `line` defines a marked value (%__fmf.<mask>_<n> = <opcode> ...), append
+// it to `out` with the flag keywords inserted after the opcode ("tail call"
+// inserts after "call"); otherwise append it unchanged.
+static void appendLineWithFlags(llvm::StringRef line, std::string &out) {
+  llvm::StringRef work = line.ltrim(" \t");
+  unsigned mask = 0, counter = 0;
+  size_t insertPos = 0;
+  bool matched = false;
+  if (work.consume_front("%__fmf.") && !work.consumeInteger(10, mask) &&
+      work.consume_front("_") && !work.consumeInteger(10, counter) &&
+      work.consume_front(" = ")) {
+    llvm::StringRef opcode = work.split(' ').first;
+    if (opcode == "tail") {
+      llvm::StringRef afterTail = work.drop_front(opcode.size()).ltrim(' ');
+      llvm::StringRef second = afterTail.split(' ').first;
+      if (second == "call") {
+        insertPos = (afterTail.data() + second.size()) - line.data();
+        matched = true;
+      }
+    } else {
+      insertPos = (work.data() + opcode.size()) - line.data();
+      matched = true;
+    }
+  }
+  if (!matched || mask == 0) {
+    out.append(line.data(), line.size());
+    return;
+  }
+  out.append(line.data(), insertPos);
+  out += fastmathKeywords(mask & 127u);
+  out.append(line.data() + insertPos, line.size() - insertPos);
+}
+
+// The debug compile unit is created with emission kind 3
+// (DebugDirectivesOnly), an extension of NVIDIA's LLVM 7 fork. A stock
+// LLVM 7 runtime has no name for it and prints "emissionKind: " (empty),
+// which no parser accepts, so the fast-math reparse would fail whenever
+// debug info is present. Downgrade exactly that unparseable case to
+// LineTablesOnly, which both stock and NVIDIA LLVM 7 round-trip. Only
+// metadata definition lines (leading '!') are rewritten, so the pattern
+// occurring inside a program's string constant is left alone.
+static void fixupUnparseableEmissionKind(std::string &ir) {
+  static constexpr llvm::StringLiteral kEmpty = "emissionKind: ,";
+  static constexpr llvm::StringLiteral kFixed = "emissionKind: LineTablesOnly,";
+  size_t pos = 0;
+  while ((pos = ir.find(kEmpty.data(), pos)) != std::string::npos) {
+    size_t bol = ir.rfind('\n', pos);
+    bol = (bol == std::string::npos) ? 0 : bol + 1;
+    if (ir[bol] != '!') {
+      pos += kEmpty.size();
+      continue;
+    }
+    ir.replace(pos, kEmpty.size(), kFixed.data());
+    pos += kFixed.size();
+  }
+}
+
+// Exercised end-to-end through translateToNVVMIR / translateToPTX by
+// test/fastmath_flags.mlir.
+static std::string injectFastmathFlags(llvm::StringRef ir) {
+  std::string out;
+  out.reserve(ir.size() + 1024);
+  size_t start = 0;
+  while (start <= ir.size()) {
+    size_t eol = ir.find('\n', start);
+    bool last = (eol == llvm::StringRef::npos);
+    appendLineWithFlags(ir.slice(start, last ? ir.size() : eol), out);
+    if (last)
+      break;
+    out += '\n';
+    start = eol + 1;
+  }
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
 // Public entry points
 //===----------------------------------------------------------------------===//
 
@@ -42,7 +149,10 @@ llvm::Expected<std::string> llvm70::translateToNVVMIR(gpu::GPUModuleOp gpuMod,
   if (auto err = translator.translate(gpuMod, opts.debugLevel, opts.genLTO, &opts))
     return std::move(err);
 
-  return builder->printModuleToString();
+  std::string ir = builder->printModuleToString();
+  if (translator.hasFastmathMarkers())
+    ir = injectFastmathFlags(ir);
+  return ir;
 }
 
 llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
@@ -64,6 +174,17 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
     llvm::dbgs() << "=== Generated NVVM IR ===\n"
                  << builder->printModuleToString() << "\n";
   });
+
+  // Fast-math flags cannot be set through the old C API. When any were
+  // recorded, round-trip the module through text: print, inject the flag
+  // keywords at the marked instructions, and re-parse with the same LLVM 7
+  // runtime before serializing to bitcode.
+  if (translator.hasFastmathMarkers()) {
+    std::string textIR = injectFastmathFlags(builder->printModuleToString());
+    fixupUnparseableEmissionKind(textIR);
+    if (auto err = builder->replaceModuleWithParsedIR(textIR))
+      return std::move(err);
+  }
 
   // Serialize to bitcode
   LLVMMemoryBufferRef buf = builder->writeBitcodeToMemoryBuffer();
@@ -100,8 +221,9 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
 
   std::string computeArch =
       "compute_" + opts.chip.substr(opts.chip.find_first_of("0123456789"));
-  auto ptxOrErr =
-      (*compilerOrErr)->compile(computeArch, modules, opts.optLevel, opts.genLTO);
+  auto ptxOrErr = (*compilerOrErr)
+                      ->compile(computeArch, modules, opts.optLevel,
+                                opts.genLTO, opts.nvvmOptions);
 
   builder->disposeMemoryBuffer(buf);
   return ptxOrErr;
@@ -854,6 +976,7 @@ llvm::Error MLIRToLLVM70::translateCallOp(Operation *op) {
   }
 
   LLVMValueRef result = b.buildCall(callee, args.data(), args.size(), "");
+  tagFastmath(op, result);
 
   if (callOp.getNumResults() > 0)
     mapValue(callOp->getResult(0), result);
@@ -994,6 +1117,34 @@ llvm::Error MLIRToLLVM70::translateAddressOfOp(Operation *op) {
   return llvm::Error::success();
 }
 
+// Record the fast-math flags of `op` (if any) on the freshly built
+// instruction `inst` by giving it a marker value name. The flags are
+// materialized later by injectFastmathFlags on the printed IR.
+void MLIRToLLVM70::tagFastmath(Operation *op, LLVMValueRef inst) {
+  if (!inst || !b.isInstruction(inst))
+    return;
+  auto iface = dyn_cast<LLVM::FastmathFlagsInterface>(op);
+  if (!iface)
+    return;
+  unsigned mask = static_cast<unsigned>(iface.getFastmathAttr().getValue());
+  if (!mask)
+    return;
+  // LLVM permits fast-math flags on calls with a floating-point scalar or
+  // vector return type; this translator only ever builds scalar FP calls,
+  // so only those are tagged.
+  if (isa<LLVM::CallOp>(op)) {
+    if (op->getNumResults() != 1)
+      return;
+    Type resTy = op->getResult(0).getType();
+    if (!(resTy.isF16() || resTy.isF32() || resTy.isF64() || isBF16(resTy)))
+      return;
+  }
+  std::string name =
+      ("__fmf." + llvm::Twine(mask) + "_" + llvm::Twine(fmfCounter++)).str();
+  b.setValueName(inst, name.c_str());
+  fmfTagged = true;
+}
+
 llvm::Error MLIRToLLVM70::translateArithOp(Operation *op) {
   LLVMValueRef result = nullptr;
 
@@ -1004,6 +1155,7 @@ llvm::Error MLIRToLLVM70::translateArithOp(Operation *op) {
     if (bf)
       operand = bf16ToF32(operand);
     result = b.buildFNeg(operand, "");
+    tagFastmath(op, result);
     if (bf)
       result = f32ToBf16(result);
     mapValue(fneg.getResult(), result);
@@ -1061,6 +1213,7 @@ llvm::Error MLIRToLLVM70::translateArithOp(Operation *op) {
                                    "unhandled arith op: %s",
                                    op->getName().getStringRef().str().c_str());
 
+  tagFastmath(op, result);
   if (bf)
     result = f32ToBf16(result);
 
@@ -1175,6 +1328,7 @@ llvm::Error MLIRToLLVM70::translateFCmpOp(Operation *op) {
     rhsVal = bf16ToF32(rhsVal);
   }
   auto result = b.buildFCmp(lp, lhsVal, rhsVal, "");
+  tagFastmath(op, result);
   mapValue(fcmpOp.getResult(), result);
   return llvm::Error::success();
 }
@@ -1569,6 +1723,7 @@ llvm::Error MLIRToLLVM70::translateUnaryFloatIntrinsic(Operation *op,
   LLVMValueRef arg = lookupValue(in);
   if (bf) arg = bf16ToF32(arg);
   LLVMValueRef result = b.buildCall(fn, &arg, 1, "");
+  tagFastmath(op, result);
   if (bf) result = f32ToBf16(result);
   mapValue(res, result);
   return llvm::Error::success();
@@ -1618,6 +1773,7 @@ llvm::Error MLIRToLLVM70::translateBinaryFloatIntrinsic(Operation *op,
   LLVMValueRef args[2] = {lookupValue(lhs), lookupValue(rhs)};
   if (bf) { args[0] = bf16ToF32(args[0]); args[1] = bf16ToF32(args[1]); }
   LLVMValueRef result = b.buildCall(fn, args, 2, "");
+  tagFastmath(op, result);
   if (bf) result = f32ToBf16(result);
   mapValue(res, result);
   return llvm::Error::success();
@@ -1647,6 +1803,7 @@ llvm::Error MLIRToLLVM70::translateMinimumMaximumOp(Operation *op,
   if (bf) { a = bf16ToF32(a); bv = bf16ToF32(bv); }
   LLVMValueRef args[2] = {a, bv};
   LLVMValueRef mmnResult = b.buildCall(fn, args, 2, "");
+  tagFastmath(op, mmnResult);
   LLVMValueRef isNaN = b.buildFCmp(LLVMRealUNO, a, bv, "");
   LLVMValueRef nanVal = b.buildFAdd(a, bv, "");
   LLVMValueRef result = b.buildSelect(isNaN, nanVal, mmnResult, "");

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -89,13 +89,13 @@ static void appendLineWithFlags(llvm::StringRef line, std::string &out) {
 }
 
 // The debug compile unit is created with emission kind 3
-// (DebugDirectivesOnly), an extension of NVIDIA's LLVM 7 fork. A stock
-// LLVM 7 runtime has no name for it and prints "emissionKind: " (empty),
-// which no parser accepts, so the fast-math reparse would fail whenever
-// debug info is present. Downgrade exactly that unparseable case to
-// LineTablesOnly, which both stock and NVIDIA LLVM 7 round-trip. Only
-// metadata definition lines (leading '!') are rewritten, so the pattern
-// occurring inside a program's string constant is left alone.
+// (DebugDirectivesOnly, which libnvvm honors but whose name only entered
+// LLVM at version 8). LLVM 7 has no name for it: its printer emits
+// "emissionKind: " (empty), which its own parser rejects, so the
+// fast-math reparse would fail whenever debug info is present. Downgrade
+// exactly that unparseable case to LineTablesOnly for the round-trip.
+// Only metadata definition lines (leading '!') are rewritten, so the
+// pattern occurring inside a program's string constant is left alone.
 static void fixupUnparseableEmissionKind(std::string &ir) {
   static constexpr llvm::StringLiteral kEmpty = "emissionKind: ,";
   static constexpr llvm::StringLiteral kFixed = "emissionKind: LineTablesOnly,";

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -28,13 +28,9 @@ using namespace mlir;
 //
 // The LLVM 7 C API cannot set per-instruction fast-math flags. Flagged
 // instructions are named __fmf.<mask>_<counter> during translation; the
-// module is then printed to text, the flag keywords are inserted after
-// each marked instruction's opcode, and the result is re-parsed with the
-// same LLVM 7 runtime before bitcode serialization. The '.' cannot occur
-// in a Python identifier, LLVM 7 prints it unquoted (unlike '$'), and
-// numba's SSA renaming only ever appends ".<digits>", which cannot form
-// the "__fmf.<digits>_<digits>" shape — so the marker cannot collide
-// with a user-visible value name.
+// printed module gets the keywords inserted at each marked instruction
+// and is re-parsed. Python identifiers cannot contain '.', so the marker
+// cannot collide with a user value name.
 //===----------------------------------------------------------------------===//
 
 // Keyword string (each keyword preceded by a space) for an
@@ -88,14 +84,10 @@ static void appendLineWithFlags(llvm::StringRef line, std::string &out) {
   out.append(line.data() + insertPos, line.size() - insertPos);
 }
 
-// The debug compile unit is created with emission kind 3
-// (DebugDirectivesOnly, which libnvvm honors but whose name only entered
-// LLVM at version 8). LLVM 7 has no name for it: its printer emits
-// "emissionKind: " (empty), which its own parser rejects, so the
-// fast-math reparse would fail whenever debug info is present. Downgrade
-// exactly that unparseable case to LineTablesOnly for the round-trip.
-// Only metadata definition lines (leading '!') are rewritten, so the
-// pattern occurring inside a program's string constant is left alone.
+// The compile unit uses emission kind 3 (DebugDirectivesOnly, named in
+// LLVM 8+); LLVM 7 prints it empty, which its own parser rejects.
+// Downgrade that one case to LineTablesOnly for the round-trip. Only
+// metadata lines (leading '!') are rewritten.
 static void fixupUnparseableEmissionKind(std::string &ir) {
   static constexpr llvm::StringLiteral kEmpty = "emissionKind: ,";
   static constexpr llvm::StringLiteral kFixed = "emissionKind: LineTablesOnly,";
@@ -112,8 +104,6 @@ static void fixupUnparseableEmissionKind(std::string &ir) {
   }
 }
 
-// Exercised end-to-end through translateToNVVMIR / translateToPTX by
-// test/fastmath_flags.mlir.
 static std::string injectFastmathFlags(llvm::StringRef ir) {
   std::string out;
   out.reserve(ir.size() + 1024);
@@ -175,10 +165,7 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
                  << builder->printModuleToString() << "\n";
   });
 
-  // Fast-math flags cannot be set through the old C API. When any were
-  // recorded, round-trip the module through text: print, inject the flag
-  // keywords at the marked instructions, and re-parse with the same LLVM 7
-  // runtime before serializing to bitcode.
+  // Materialize any recorded fast-math flags via the text round-trip.
   if (translator.hasFastmathMarkers()) {
     std::string textIR = injectFastmathFlags(builder->printModuleToString());
     fixupUnparseableEmissionKind(textIR);
@@ -1117,9 +1104,8 @@ llvm::Error MLIRToLLVM70::translateAddressOfOp(Operation *op) {
   return llvm::Error::success();
 }
 
-// Record the fast-math flags of `op` (if any) on the freshly built
-// instruction `inst` by giving it a marker value name. The flags are
-// materialized later by injectFastmathFlags on the printed IR.
+// Give an instruction with fast-math flags a marker value name;
+// injectFastmathFlags materializes the keywords on the printed IR.
 void MLIRToLLVM70::tagFastmath(Operation *op, LLVMValueRef inst) {
   if (!inst || !b.isInstruction(inst))
     return;
@@ -1129,9 +1115,7 @@ void MLIRToLLVM70::tagFastmath(Operation *op, LLVMValueRef inst) {
   unsigned mask = static_cast<unsigned>(iface.getFastmathAttr().getValue());
   if (!mask)
     return;
-  // LLVM permits fast-math flags on calls with a floating-point scalar or
-  // vector return type; this translator only ever builds scalar FP calls,
-  // so only those are tagged.
+  // Fast-math flags are only valid on calls returning floating point.
   if (isa<LLVM::CallOp>(op)) {
     if (op->getNumResults() != 1)
       return;

--- a/cext/mlir-llvm70/lib/LibNVVMCompiler.cpp
+++ b/cext/mlir-llvm70/lib/LibNVVMCompiler.cpp
@@ -53,7 +53,8 @@ llvm::Error LibNVVMCompiler::resolveSymbols() {
 llvm::Expected<std::string> LibNVVMCompiler::compile(
     llvm::StringRef arch,
     llvm::ArrayRef<std::pair<const char *, size_t>> modules,
-    unsigned optLevel, bool genLTO) {
+    unsigned optLevel, bool genLTO,
+    llvm::ArrayRef<std::string> extraOptions) {
   nvvmProgram prog = nullptr;
   nvvmResult rc = fnCreateProgram(&prog);
   if (rc != NVVM_SUCCESS)
@@ -82,6 +83,8 @@ llvm::Expected<std::string> LibNVVMCompiler::compile(
   opts.push_back(optOpt.c_str());
   if (genLTO)
     opts.push_back("-gen-lto");
+  for (const std::string &opt : extraOptions)
+    opts.push_back(opt.c_str());
   rc = fnCompileProgram(prog, opts.size(), opts.data());
   if (rc != NVVM_SUCCESS) {
     std::string log = getLog(prog);

--- a/cext/mlir-llvm70/test/fastmath_flags.mlir
+++ b/cext/mlir-llvm70/test/fastmath_flags.mlir
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// RUN: llvm70-translate %s --dump-llvm 2>&1 >/dev/null | FileCheck --check-prefix=CHECK-IR %s
+// RUN: llvm70-translate %s --dump-ptx 2>&1 >/dev/null | FileCheck --check-prefix=CHECK-PTX %s
+
+// Per-instruction fast-math flags cannot be set through the LLVM 7 C API;
+// the translator transfers them by naming flagged instructions with a
+// __fmf.<mask>_<n> marker and injecting the keywords into the printed IR.
+// Check that full and selective flag sets survive translation and that
+// unflagged instructions stay clean.
+
+module {
+  gpu.module @kernels [#nvvm_llvm70.target<chip = "sm_75">] {
+    llvm.func @flags(%a: f32, %b: f32, %out: !llvm.ptr<1>) attributes {gpu.kernel} {
+      %full = llvm.fmul %a, %b {fastmathFlags = #llvm.fastmath<fast>} : f32
+      %some = llvm.fadd %full, %b {fastmathFlags = #llvm.fastmath<nnan, arcp>} : f32
+      %div = llvm.fdiv %some, %a {fastmathFlags = #llvm.fastmath<arcp>} : f32
+      %none = llvm.fsub %div, %b : f32
+      %tid = nvvm.read.ptx.sreg.tid.x : i32
+      %idx = llvm.sext %tid : i32 to i64
+      %ptr = llvm.getelementptr %out[%idx] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f32
+      llvm.store %none, %ptr : f32, !llvm.ptr<1>
+      llvm.return
+    }
+  }
+}
+
+// CHECK-IR: define ptx_kernel void @flags
+// CHECK-IR: fmul fast float
+// CHECK-IR: fadd nnan arcp float
+// CHECK-IR: fdiv arcp float
+// CHECK-IR: fsub float
+
+// CHECK-PTX: .visible .entry flags

--- a/src/numba_cuda_mlir/decorators.py
+++ b/src/numba_cuda_mlir/decorators.py
@@ -536,8 +536,7 @@ def verify_target_options(kws: dict[str, Any]) -> dict[str, Any]:
     # Handle compatibility mappings
     if targetoptions.get("fast_math") is not None:
         targetoptions["fastmath"] = targetoptions["fast_math"]
-    # Normalize bool/set/dict to FastMathOptions so downstream consumers see
-    # a single representation with well-defined truthiness and flag set.
+    # Normalize to FastMathOptions so downstream consumers see one representation.
     targetoptions["fastmath"] = FastMathOptions(targetoptions.get("fastmath", False))
     if targetoptions.get("opt") is not None:
         targetoptions["opt_level"] = 3 if targetoptions["opt"] else 0

--- a/src/numba_cuda_mlir/decorators.py
+++ b/src/numba_cuda_mlir/decorators.py
@@ -6,6 +6,7 @@ from numba_cuda_mlir import typing
 from io import StringIO
 from numba_cuda_mlir.numba_cuda.core import sigutils
 from numba_cuda_mlir.numba_cuda import types as numba_types
+from numba_cuda_mlir.numba_cuda.core.options import FastMathOptions
 from numba_cuda_mlir.numba_cuda.core.typeinfer import register_dispatcher
 from numba_cuda_mlir.numba_cuda.decorators import jit as numba_cuda_jit
 import inspect
@@ -77,6 +78,16 @@ def _verify_shared_memory_carveout(value: Any, targetoptions: dict[str, Any]) ->
             raise ValueError("Carveout must be between -1 and 100")
         return None
     raise TypeError(f"shared_memory_carveout must be str or int, got {type(value).__name__}")
+
+
+def _verify_fastmath(value: Any, targetoptions: dict[str, Any]) -> str | None:
+    if value is None:
+        return None
+    try:
+        FastMathOptions(value)
+    except ValueError as e:
+        return str(e)
+    return None
 
 
 def _verify_launch_bounds(value: Any, targetoptions: dict[str, Any]) -> str | None:
@@ -213,9 +224,15 @@ def _get_schema() -> tuple[MLIRJITOption, ...]:
         ),
         MLIRJITOption(
             name="fastmath",
-            types=bool,
+            types=(bool, set, dict, FastMathOptions),
             default_value=False,
-            help="Use faster approximations for floating-point arithmetic",
+            help=(
+                "Use faster approximations for floating-point arithmetic. "
+                "True enables all fast-math flags; a set or dict may select "
+                "individual LLVM flags from {'fast', 'nnan', 'ninf', 'nsz', "
+                "'arcp', 'contract', 'afn', 'reassoc'}"
+            ),
+            extra_verification=_verify_fastmath,
         ),
         MLIRJITOption(
             name="device",
@@ -264,10 +281,11 @@ def _get_schema() -> tuple[MLIRJITOption, ...]:
         ),
         MLIRJITOption(
             name="fast_math",
-            types=(bool, type(None)),
+            types=(bool, set, dict, FastMathOptions, type(None)),
             default_value=None,
             help="Alias for fastmath",
             hidden=True,
+            extra_verification=_verify_fastmath,
         ),
         MLIRJITOption(
             name="opt",
@@ -518,6 +536,9 @@ def verify_target_options(kws: dict[str, Any]) -> dict[str, Any]:
     # Handle compatibility mappings
     if targetoptions.get("fast_math") is not None:
         targetoptions["fastmath"] = targetoptions["fast_math"]
+    # Normalize bool/set/dict to FastMathOptions so downstream consumers see
+    # a single representation with well-defined truthiness and flag set.
+    targetoptions["fastmath"] = FastMathOptions(targetoptions.get("fastmath", False))
     if targetoptions.get("opt") is not None:
         targetoptions["opt_level"] = 3 if targetoptions["opt"] else 0
 

--- a/src/numba_cuda_mlir/fastmath.py
+++ b/src/numba_cuda_mlir/fastmath.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Selective fastmath support.
+
+The ``fastmath`` target option accepts, like numba-cuda, either a bool or a
+set/dict of individual LLVM fast-math flags ({'fast', 'nnan', 'ninf', 'nsz',
+'arcp', 'contract', 'afn', 'reassoc'}).  The flags are applied per-operation
+as ``#arith.fastmath<...>`` attributes on every arith/math dialect op that
+implements the ArithFastMathInterface.  The conversion passes in the standard
+pipeline (convert-arith-to-llvm, convert-gpu-to-nvvm, convert-math-to-nvvm)
+translate these into LLVM fast-math flags, which libnvvm honours
+per-instruction (e.g. ``arcp`` selects ``div.approx`` for f32 division).
+
+Two effects have no per-instruction encoding and are handled separately:
+
+- The module-level libnvvm/ptxas knobs (``-ftz``, ``-fma``, ``-prec-div``,
+  ``-prec-sqrt``) are derived from the flag set by
+  :func:`nvvm_fastmath_options`.
+- f32 ``math.tanh`` is rewritten to ``tanh.approx.f32`` by
+  :func:`rewrite_approx_tanh`; this must happen while the op is still a
+  ``math.tanh``, because ``convert-math-to-nvvm`` lowers it to a plain
+  libdevice call and drops the fastmath attribute in the process.
+"""
+
+import inspect
+from functools import cache
+
+from numba_cuda_mlir._mlir import ir
+from numba_cuda_mlir.numba_cuda.core.options import FastMathOptions
+
+# Canonical flag order used by the MLIR arith fastmath attribute printer.
+_FLAG_ORDER = ("reassoc", "nnan", "ninf", "nsz", "arcp", "contract", "afn")
+
+
+def parse_fastmath(value) -> FastMathOptions:
+    """Normalize a user-facing fastmath value (bool | set | dict |
+    FastMathOptions) into FastMathOptions, validating flag names."""
+    return FastMathOptions(value)
+
+
+def nvvm_fastmath_options(fastmath) -> dict:
+    """Map a fastmath flag set to the module-level libnvvm/ptxas knobs it
+    implies.
+
+    Returns a dict with keys ``ftz``, ``fma``, ``prec_div`` and
+    ``prec_sqrt``; a key is absent when the flag set does not speak to that
+    knob (callers leave the toolchain default in place).
+
+    Each knob is enabled only by the flag that requests the corresponding
+    relaxation: ``arcp`` (approximate reciprocal/division) implies
+    ``prec_div=False``; ``afn`` (approximate functions) implies
+    ``prec_sqrt=False``; ``contract`` implies ``fma=True``; denormal
+    flushing has no per-instruction fast-math flag, so ``ftz=True`` is
+    implied only by full ``fast``.  ``fastmath=True`` (i.e. ``{'fast'}``)
+    enables all four, matching numba-cuda's ``nvvm.compile_ir`` gating for
+    the bool form.
+    """
+    flags = parse_fastmath(fastmath).flags
+    opts = {}
+    if "fast" in flags:
+        opts["ftz"] = True
+    if flags & {"contract", "fast"}:
+        opts["fma"] = True
+    if flags & {"arcp", "fast"}:
+        opts["prec_div"] = False
+    if flags & {"afn", "fast"}:
+        opts["prec_sqrt"] = False
+    return opts
+
+
+@cache
+def _fastmath_capable_op_names() -> frozenset:
+    """Names of arith/math dialect operations that carry a ``fastmath``
+    attribute (i.e. implement ArithFastMathInterface), discovered from the
+    generated Python bindings so the set tracks the bundled MLIR version."""
+    from numba_cuda_mlir._mlir.dialects import _arith_ops_gen, _math_ops_gen
+
+    names = set()
+    for mod in (_arith_ops_gen, _math_ops_gen):
+        for cls in vars(mod).values():
+            if (
+                inspect.isclass(cls)
+                and hasattr(cls, "OPERATION_NAME")
+                and isinstance(inspect.getattr_static(cls, "fastmath", None), property)
+            ):
+                names.add(cls.OPERATION_NAME)
+    return frozenset(names)
+
+
+def fastmath_attr(flags: set) -> ir.Attribute:
+    """Build an ``#arith.fastmath<...>`` attribute for the given flag set.
+    Must be called with an active MLIR context."""
+    if "fast" in flags:
+        mnemonic = "fast"
+    else:
+        mnemonic = ",".join(f for f in _FLAG_ORDER if f in flags)
+    assert mnemonic, f"no valid fastmath flags in {flags}"
+    return ir.Attribute.parse(f"#arith.fastmath<{mnemonic}>")
+
+
+def _chip_number(chip) -> int:
+    """sm_89 -> 89; 0 when unknown."""
+    if not chip:
+        return 0
+    digits = "".join(c for c in str(chip) if c.isdigit())
+    return int(digits) if digits else 0
+
+
+def apply_fastmath_to_function(func_op, fastmath) -> None:
+    """Stamp the fastmath attribute onto every fastmath-capable op nested in
+    ``func_op``.
+
+    Called once per lowered function, before device callees are considered:
+    callee functions are compiled separately with their own target options and
+    cloned into the caller's module already stamped, so walking only the
+    caller's func op scopes the flags exactly like numba-cuda's
+    per-instruction fast-math flags.
+    """
+    flags = parse_fastmath(fastmath).flags
+    if not flags:
+        return
+
+    attr = fastmath_attr(flags)
+    capable = _fastmath_capable_op_names()
+
+    def _stamp(op):
+        if op.name in capable:
+            op.attributes["fastmath"] = attr
+        return ir.WalkResult.ADVANCE
+
+    func_op.operation.walk(_stamp)
+
+
+def rewrite_approx_tanh(func_op, fastmath, chip=None) -> None:
+    """Replace f32 ``math.tanh`` with the hardware ``tanh.approx.f32``
+    instruction when the flags permit approximate functions (``afn`` or
+    ``fast``) and the target is sm_75+, as numba-cuda does.
+
+    This runs at stamping time rather than with the pre-codegen rewrites
+    (see optimization/__init__.py) because ``convert-math-to-nvvm`` lowers
+    ``math.tanh`` to a plain ``__nv_tanhf`` libdevice call and discards the
+    fastmath attribute, so after conversion there is nothing left to key
+    the rewrite on.
+    """
+    from numba_cuda_mlir._mlir.dialects import llvm
+
+    flags = parse_fastmath(fastmath).flags
+    if not (flags & {"afn", "fast"}) or _chip_number(chip) < 75:
+        return
+
+    tanh_ops = []
+
+    def _collect(op):
+        if op.name == "math.tanh" and isinstance(op.results[0].type, ir.F32Type):
+            tanh_ops.append(op)
+        return ir.WalkResult.ADVANCE
+
+    func_op.operation.walk(_collect)
+
+    for op in tanh_ops:
+        with ir.InsertionPoint(op), op.location:
+            result = llvm.inline_asm(
+                op.results[0].type,
+                [op.operands[0]],
+                "tanh.approx.f32 $0, $1;",
+                "=f,f",
+            )
+        op.results[0].replace_all_uses_with(result)
+        op.erase()

--- a/src/numba_cuda_mlir/fastmath.py
+++ b/src/numba_cuda_mlir/fastmath.py
@@ -3,30 +3,14 @@
 
 """Selective fastmath support.
 
-The ``fastmath`` target option accepts, like numba-cuda, either a bool or a
-set/dict of individual LLVM fast-math flags ({'fast', 'nnan', 'ninf', 'nsz',
-'arcp', 'contract', 'afn', 'reassoc'}).  The flags are applied per-operation
-as ``#arith.fastmath<...>`` attributes on every arith/math dialect op that
-implements the ArithFastMathInterface.  The conversion passes in the standard
-pipeline (convert-arith-to-llvm, convert-gpu-to-nvvm, convert-math-to-nvvm)
-translate these into LLVM fast-math flags, which reach libnvvm
-per-instruction (via the LLVM70 marker-name transfer on sm < 100).
-
-Three effects are handled separately because the per-instruction flags
-alone do not produce them:
-
-- The module-level libnvvm/ptxas knobs (``-ftz``, ``-fma``, ``-prec-div``,
-  ``-prec-sqrt``) have no per-instruction encoding and are derived from
-  the flag set by :func:`nvvm_fastmath_options`.
-- f32 division under ``arcp``/``fast`` is rewritten to
-  ``__nv_fast_fdividef`` at pre-codegen (see
-  ``optimization._rewrite_fast_divisions``): libnvvm never selects
-  ``div.approx`` from instruction flags or ``-prec-div=0`` alone, so the
-  substitution numba-cuda makes is reproduced here.
-- f32 ``math.tanh`` is rewritten to ``tanh.approx.f32`` by
-  :func:`rewrite_approx_tanh`; this must happen while the op is still a
-  ``math.tanh``, because ``convert-math-to-nvvm`` lowers it to a plain
-  libdevice call and drops the fastmath attribute in the process.
+``fastmath`` accepts a bool or a set/dict of LLVM fast-math flags, applied
+per-operation as ``#arith.fastmath<...>`` attributes and carried through
+the conversion passes to libnvvm. Three effects need separate handling:
+the module-level libnvvm/ptxas knobs (:func:`nvvm_fastmath_options`), the
+f32 division rewrite to ``__nv_fast_fdividef`` (libnvvm does not select
+``div.approx`` from instruction flags), and the f32 tanh rewrite
+(:func:`rewrite_approx_tanh`), which must run before convert-math-to-nvvm
+drops the attribute.
 """
 
 import inspect
@@ -46,21 +30,11 @@ def parse_fastmath(value) -> FastMathOptions:
 
 
 def nvvm_fastmath_options(fastmath) -> dict:
-    """Map a fastmath flag set to the module-level libnvvm/ptxas knobs it
-    implies.
+    """Map a fastmath flag set to the libnvvm/ptxas knobs it implies.
 
-    Returns a dict with keys ``ftz``, ``fma``, ``prec_div`` and
-    ``prec_sqrt``; a key is absent when the flag set does not speak to that
-    knob (callers leave the toolchain default in place).
-
-    Each knob is enabled only by the flag that requests the corresponding
-    relaxation: ``arcp`` (approximate reciprocal/division) implies
-    ``prec_div=False``; ``afn`` (approximate functions) implies
-    ``prec_sqrt=False``; ``contract`` implies ``fma=True``; denormal
-    flushing has no per-instruction fast-math flag, so ``ftz=True`` is
-    implied only by full ``fast``.  ``fastmath=True`` (i.e. ``{'fast'}``)
-    enables all four, matching numba-cuda's ``nvvm.compile_ir`` gating for
-    the bool form.
+    A key is absent when the flags do not speak to that knob (the caller
+    keeps the toolchain default). ftz has no per-instruction flag, so
+    only full ``fast`` enables it.
     """
     flags = parse_fastmath(fastmath).flags
     opts = {}
@@ -114,14 +88,9 @@ def _chip_number(chip) -> int:
 
 
 def apply_fastmath_to_function(func_op, fastmath) -> None:
-    """Stamp the fastmath attribute onto every fastmath-capable op nested in
-    ``func_op``.
-
-    Called once per lowered function, before device callees are considered:
-    callee functions are compiled separately with their own target options and
-    cloned into the caller's module already stamped, so walking only the
-    caller's func op scopes the flags exactly like numba-cuda's
-    per-instruction fast-math flags.
+    """Stamp the fastmath attribute onto every fastmath-capable op nested
+    in ``func_op``. Device callees are cloned in already stamped under
+    their own options, so flags scope per function.
     """
     flags = parse_fastmath(fastmath).flags
     if not flags:
@@ -139,15 +108,9 @@ def apply_fastmath_to_function(func_op, fastmath) -> None:
 
 
 def rewrite_approx_tanh(func_op, fastmath, chip=None) -> None:
-    """Replace f32 ``math.tanh`` with the hardware ``tanh.approx.f32``
-    instruction when the flags permit approximate functions (``afn`` or
-    ``fast``) and the target is sm_75+, as numba-cuda does.
-
-    This runs at stamping time rather than with the pre-codegen rewrites
-    (see optimization/__init__.py) because ``convert-math-to-nvvm`` lowers
-    ``math.tanh`` to a plain ``__nv_tanhf`` libdevice call and discards the
-    fastmath attribute, so after conversion there is nothing left to key
-    the rewrite on.
+    """Replace f32 ``math.tanh`` with ``tanh.approx.f32`` under ``afn`` or
+    ``fast`` on sm_75+, as numba-cuda does. Must run before
+    convert-math-to-nvvm, which drops the fastmath attribute.
     """
     from numba_cuda_mlir._mlir.dialects import llvm
 

--- a/src/numba_cuda_mlir/fastmath.py
+++ b/src/numba_cuda_mlir/fastmath.py
@@ -9,14 +9,20 @@ set/dict of individual LLVM fast-math flags ({'fast', 'nnan', 'ninf', 'nsz',
 as ``#arith.fastmath<...>`` attributes on every arith/math dialect op that
 implements the ArithFastMathInterface.  The conversion passes in the standard
 pipeline (convert-arith-to-llvm, convert-gpu-to-nvvm, convert-math-to-nvvm)
-translate these into LLVM fast-math flags, which libnvvm honours
-per-instruction (e.g. ``arcp`` selects ``div.approx`` for f32 division).
+translate these into LLVM fast-math flags, which reach libnvvm
+per-instruction (via the LLVM70 marker-name transfer on sm < 100).
 
-Two effects have no per-instruction encoding and are handled separately:
+Three effects are handled separately because the per-instruction flags
+alone do not produce them:
 
 - The module-level libnvvm/ptxas knobs (``-ftz``, ``-fma``, ``-prec-div``,
-  ``-prec-sqrt``) are derived from the flag set by
-  :func:`nvvm_fastmath_options`.
+  ``-prec-sqrt``) have no per-instruction encoding and are derived from
+  the flag set by :func:`nvvm_fastmath_options`.
+- f32 division under ``arcp``/``fast`` is rewritten to
+  ``__nv_fast_fdividef`` at pre-codegen (see
+  ``optimization._rewrite_fast_divisions``): libnvvm never selects
+  ``div.approx`` from instruction flags or ``-prec-div=0`` alone, so the
+  substitution numba-cuda makes is reproduced here.
 - f32 ``math.tanh`` is rewritten to ``tanh.approx.f32`` by
   :func:`rewrite_approx_tanh`; this must happen while the op is still a
   ``math.tanh``, because ``convert-math-to-nvvm`` lowers it to a plain

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -349,6 +349,7 @@ class MLIRLower(object):
                 self._mlir_module = ir.Module.create()
                 self.setup_func_op()
                 self.lower_function_body()
+                self._apply_fastmath_flags()
                 self.lower_capi_thunks()
                 needs_nrt = self._function_needs_nrt()
                 if needs_nrt:
@@ -365,6 +366,25 @@ class MLIRLower(object):
                     self.metadata["teardown_callbacks"] = self._teardown_callbacks
         finally:
             numba_cuda_mlir_context._compilation_options.reset(token)
+
+    def _apply_fastmath_flags(self):
+        """Stamp per-op ``#arith.fastmath`` attributes from the fastmath
+        target option onto this function's body, and rewrite f32 tanh to
+        its hardware approximation where the flags and target permit.
+
+        Runs before ``lower_capi_thunks`` so the C-ABI clone inherits the
+        attributes, and only walks this function's op: device callees are
+        cloned in pre-stamped under their own target options.
+        """
+        from numba_cuda_mlir.fastmath import (
+            apply_fastmath_to_function,
+            rewrite_approx_tanh,
+        )
+
+        fastmath = self.targetoptions.get("fastmath", False)
+        if fastmath:
+            apply_fastmath_to_function(self.mlir_funcOp, fastmath)
+            rewrite_approx_tanh(self.mlir_funcOp, fastmath, chip=self.targetoptions.get("chip"))
 
     @property
     def mlir_module(self) -> ir.Module:
@@ -495,7 +515,12 @@ extern "C" __global__ void
             chip = 'chip = "' + self.targetoptions["chip"] + '"'
             opt_level = int(self.targetoptions.get("opt_level", 2))
             flags = []
-            if self.targetoptions.get("fastmath", False):
+            from numba_cuda_mlir.fastmath import parse_fastmath
+
+            fastmath = parse_fastmath(self.targetoptions.get("fastmath", False))
+            # The module-level target flag is all-or-nothing; selective
+            # subsets are expressed per-op via #arith.fastmath attributes.
+            if "fast" in fastmath.flags:
                 flags.extend(["fast"])
             features = self.targetoptions.get("features", "")
             if not features or "+ptx" not in features:

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -368,13 +368,9 @@ class MLIRLower(object):
             numba_cuda_mlir_context._compilation_options.reset(token)
 
     def _apply_fastmath_flags(self):
-        """Stamp per-op ``#arith.fastmath`` attributes from the fastmath
-        target option onto this function's body, and rewrite f32 tanh to
-        its hardware approximation where the flags and target permit.
-
-        Runs before ``lower_capi_thunks`` so the C-ABI clone inherits the
-        attributes, and only walks this function's op: device callees are
-        cloned in pre-stamped under their own target options.
+        """Stamp per-op ``#arith.fastmath`` attributes and rewrite f32
+        tanh. Runs before ``lower_capi_thunks`` so the C-ABI clone
+        inherits the attributes.
         """
         from numba_cuda_mlir.fastmath import (
             apply_fastmath_to_function,

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -157,6 +157,10 @@ def _get_llvm70_capi():
         ctypes.POINTER(ctypes.c_char_p),  # out
         ctypes.POINTER(ctypes.c_size_t),  # out_len
         ctypes.POINTER(ctypes.c_char_p),  # err_out
+        # Deliberately last (matches CAPI.cpp): a stale library built without
+        # this parameter ignores the trailing argument, rather than the
+        # output pointers shifting by one slot.
+        ctypes.c_char_p,  # nvvm_options (space-separated, e.g. "-prec-div=0")
     ]
     lib.llvm70_free.restype = None
     lib.llvm70_free.argtypes = [ctypes.c_void_p]
@@ -239,6 +243,23 @@ def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
     out_len = ctypes.c_size_t()
     err_out = ctypes.c_char_p()
 
+    # Same per-flag knob gating as _nvvm_options, rendered as
+    # nvvmCompileProgram command-line options.
+    from numba_cuda_mlir.fastmath import nvvm_fastmath_options
+
+    knobs = nvvm_fastmath_options(target_options.get("fastmath", False))
+    nvvm_extra_options = [
+        f"-{name.replace('_', '-')}={1 if enabled else 0}"
+        for name, enabled in (
+            ("ftz", knobs.get("ftz")),
+            ("fma", knobs.get("fma")),
+            ("prec_div", knobs.get("prec_div")),
+            ("prec_sqrt", knobs.get("prec_sqrt")),
+        )
+        if enabled is not None
+    ]
+    nvvm_options_arg = " ".join(nvvm_extra_options).encode() or None
+
     rc = lib.llvm70_translate_gpu_module_from_op(
         raw_op,
         chip.encode(),
@@ -256,6 +277,7 @@ def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
         ctypes.byref(out),
         ctypes.byref(out_len),
         ctypes.byref(err_out),
+        nvvm_options_arg,
     )
 
     if rc != 0:
@@ -324,11 +346,12 @@ def _prepare_llvm_ir(module, dump=False, preserve_debug_info=False) -> bytes:
 
 def _nvvm_options(cc: str, target_options=None, **extra) -> dict:
     """Build libnvvm CompilationUnit options from arch + target options."""
+    from numba_cuda_mlir.fastmath import nvvm_fastmath_options
+
     opts = {"arch": f"compute_{cc}", **extra}
     if target_options is None:
         return opts
-    if target_options.get("fastmath"):
-        opts.update({"ftz": True, "fma": True, "prec_div": False, "prec_sqrt": False})
+    opts.update(nvvm_fastmath_options(target_options.get("fastmath", False)))
     # Note: we intentionally omit -g and -generate-line-info here.
     # Our MLIR pipeline embeds DWARF metadata (DICompileUnit, DISubprogram, DILocation)
     # into the LLVM IR when debug=True or lineinfo=True. libnvvm honors that metadata
@@ -550,6 +573,9 @@ def get_lto_ptx(cres, linker=None, target_options=None) -> str:
             cc = get_gpu_compute_capability(tuple)
             arch = get_gpu_compute_capability(str)
 
+        from numba_cuda_mlir.fastmath import nvvm_fastmath_options
+
+        knobs = nvvm_fastmath_options(target_options.get("fastmath", False))
         linker = Linker(
             cc=cc,
             arch=arch,
@@ -557,10 +583,10 @@ def get_lto_ptx(cres, linker=None, target_options=None) -> str:
             debug=target_options.get("debug", False),
             lineinfo=target_options.get("lineinfo", False),
             lto=True,
-            ftz=target_options.get("fastmath") or None,
-            prec_div=False if target_options.get("fastmath") else None,
-            prec_sqrt=False if target_options.get("fastmath") else None,
-            fma=target_options.get("fastmath") or None,
+            ftz=knobs.get("ftz"),
+            prec_div=knobs.get("prec_div"),
+            prec_sqrt=knobs.get("prec_sqrt"),
+            fma=knobs.get("fma"),
             optimization_level=int(target_options.get("opt_level", 3)),
             ptxas_options=target_options.get("ptxas_options", None),
             max_registers=target_options.get("max_registers", None),

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -157,9 +157,8 @@ def _get_llvm70_capi():
         ctypes.POINTER(ctypes.c_char_p),  # out
         ctypes.POINTER(ctypes.c_size_t),  # out_len
         ctypes.POINTER(ctypes.c_char_p),  # err_out
-        # Deliberately last (matches CAPI.cpp): a stale library built without
-        # this parameter ignores the trailing argument, rather than the
-        # output pointers shifting by one slot.
+        # Deliberately last (matches CAPI.cpp): a stale library ignores a
+        # trailing argument, so the output pointers never shift.
         ctypes.c_char_p,  # nvvm_options (space-separated, e.g. "-prec-div=0")
     ]
     lib.llvm70_free.restype = None

--- a/src/numba_cuda_mlir/numba_cuda/core/options.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/options.py
@@ -71,6 +71,9 @@ class FastMathOptions(AbstractOptionValue):
             return self.flags == other.flags
         return NotImplemented
 
+    def __hash__(self):
+        return hash(frozenset(self.flags))
+
 
 class ParallelOptions(AbstractOptionValue):
     """

--- a/src/numba_cuda_mlir/optimization/__init__.py
+++ b/src/numba_cuda_mlir/optimization/__init__.py
@@ -203,6 +203,34 @@ def _rewrite_fast_divisions(module: ir.Module, worklist):
         op.operation.erase()
 
 
+_POW_CALLEES = ("__nv_powf", "__nv_pow", "__nv_fast_powf")
+
+
+def _is_zero_power_call(op) -> bool:
+    if "callee" not in op.attributes:
+        return False
+    if ir.FlatSymbolRefAttr(op.attributes["callee"]).value not in _POW_CALLEES:
+        return False
+    exponent_op = op.operands[1].owner
+    if getattr(exponent_op, "name", None) != "llvm.mlir.constant":
+        return False
+    value = exponent_op.attributes["value"]
+    return isinstance(value, ir.FloatAttr) and ir.FloatAttr(value).value == 0.0
+
+
+def _fold_zero_powers(pow_ops):
+    """Replace libdevice pow calls with constant-zero exponents by one,
+    the result for every base; __nv_fast_powf returns NaN for negative,
+    NaN, zero, and infinite bases.
+    """
+    for op in pow_ops:
+        result = op.results[0]
+        with ir.InsertionPoint(op), op.location:
+            one = llvm.mlir_constant(ir.FloatAttr.get(result.type, 1.0))
+        result.replace_all_uses_with(one)
+        op.erase()
+
+
 def run_pre_codegen_patterns(module: ir.Module):
     """Collect every pattern's matches in a single walk, then rewrite;
     the rewrites erase and insert operations so they run after the walk.
@@ -211,6 +239,7 @@ def run_pre_codegen_patterns(module: ir.Module):
     cast_ops = []
     mem_ops = []
     fdiv_ops = []
+    pow_ops = []
 
     def collect(op):
         name = op.name
@@ -222,6 +251,9 @@ def run_pre_codegen_patterns(module: ir.Module):
         elif name == "llvm.fdiv":
             if _is_fast_division(op):
                 fdiv_ops.append(op)
+        elif name == "llvm.call":
+            if _is_zero_power_call(op):
+                pow_ops.append(op)
         elif "numba_cuda_mlir.arg_attrs" in op.attributes:
             arg_attr_ops.append(op)
         return ir.WalkResult.ADVANCE
@@ -234,3 +266,4 @@ def run_pre_codegen_patterns(module: ir.Module):
     _resolve_shared_bit_storage_float_accesses(mem_ops)
     if fdiv_ops:
         _rewrite_fast_divisions(module, fdiv_ops)
+    _fold_zero_powers(pow_ops)

--- a/src/numba_cuda_mlir/optimization/__init__.py
+++ b/src/numba_cuda_mlir/optimization/__init__.py
@@ -174,15 +174,9 @@ def _is_fast_division(op) -> bool:
 
 
 def _rewrite_fast_divisions(module: ir.Module, worklist):
-    """Lower f32 ``llvm.fdiv`` marked ``arcp`` (or ``fast``) to
-    ``__nv_fast_fdividef`` so it compiles to ``div.approx.f32``.
-
-    This mirrors numba-cuda, whose fastmath float32 division calls
-    ``__nv_fast_fdividef`` (libnvvm never selects ``div.approx`` from
-    instruction flags or the ``-prec-div=0`` option alone — those only reach
-    ``div.full``). Gating on the per-instruction ``arcp`` flag keeps the
-    transform selective per compiled function, including device callees
-    cloned in with their own fastmath options.
+    """Lower f32 ``llvm.fdiv`` marked ``arcp`` or ``fast`` to
+    ``__nv_fast_fdividef``, as numba-cuda does; libnvvm does not select
+    ``div.approx`` from instruction flags.
     """
     for gpu_module in module.body:
         if isinstance(gpu_module, gpu.GPUModuleOp):
@@ -210,11 +204,8 @@ def _rewrite_fast_divisions(module: ir.Module, worklist):
 
 
 def run_pre_codegen_patterns(module: ir.Module):
-    """Collect every pattern's matches in a single walk, then rewrite.
-
-    The patterns are independent (they match disjoint op kinds), so one
-    traversal feeds them all; rewrites run after the walk because they
-    erase and insert operations.
+    """Collect every pattern's matches in a single walk, then rewrite;
+    the rewrites erase and insert operations so they run after the walk.
     """
     arg_attr_ops = []
     cast_ops = []

--- a/src/numba_cuda_mlir/optimization/__init__.py
+++ b/src/numba_cuda_mlir/optimization/__init__.py
@@ -1,63 +1,45 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-import functools
 from numba_cuda_mlir._mlir.dialects import gpu, arith, llvm
 from numba_cuda_mlir._mlir import ir
 
 
-def recursively_apply(pattern):
-    @functools.wraps(pattern)
-    def wrapper(op):
-        if pattern(op):
-            return True
-        for region in op.regions:
-            for block in region.blocks:
-                for operation in block:
-                    if recursively_apply(pattern)(operation):
-                        return True
-        return False
+def _fixup_nvvm_arg_attrs(op):
+    attrs = [[j for j in i] for i in op.attributes["numba_cuda_mlir.arg_attrs"]]
+    if all(len(i) == 0 for i in attrs):
+        return
+    orig_arg_types = op.attributes["numba_cuda_mlir.orig_arg_types"]
+    arg_attrs = op.attributes["numba_cuda_mlir.arg_attrs"]
+    new_arg_attrs = []
+    for i, arg_attr in enumerate(arg_attrs):
+        new_arg_attr = {}
+        for namedattr in arg_attr:
+            if "numba_cuda_mlir.grid_constant" == namedattr.name:
+                new_arg_attr["nvvm.grid_constant"] = ir.UnitAttr.get()
+            else:
+                new_arg_attr[namedattr.name] = namedattr.attr
 
-    return wrapper
+        new_arg_attrs.append(ir.DictAttr.get(new_arg_attr))
+        orig_arg_type = orig_arg_types[i].value
 
-
-@recursively_apply
-def fixup_nvvm_arg_attrs(op: gpu.GPUFuncOp):
-    if "numba_cuda_mlir.arg_attrs" in op.attributes:
-        attrs = [[j for j in i] for i in op.attributes["numba_cuda_mlir.arg_attrs"]]
-        if all(len(i) == 0 for i in attrs):
-            return
-        orig_arg_types = op.attributes["numba_cuda_mlir.orig_arg_types"]
-        arg_attrs = op.attributes["numba_cuda_mlir.arg_attrs"]
-        new_arg_attrs = []
-        for i, arg_attr in enumerate(arg_attrs):
-            new_arg_attr = {}
-            for namedattr in arg_attr:
-                if "numba_cuda_mlir.grid_constant" == namedattr.name:
-                    new_arg_attr["nvvm.grid_constant"] = ir.UnitAttr.get()
-                else:
-                    new_arg_attr[namedattr.name] = namedattr.attr
-
+        # assuming the CAPI for memref types is expanded here
+        if isinstance(orig_arg_type, ir.MemRefType):
+            # append again for the aligned pointer
             new_arg_attrs.append(ir.DictAttr.get(new_arg_attr))
-            orig_arg_type = orig_arg_types[i].value
 
-            # assuming the CAPI for memref types is expanded here
-            if isinstance(orig_arg_type, ir.MemRefType):
-                # append again for the aligned pointer
-                new_arg_attrs.append(ir.DictAttr.get(new_arg_attr))
+            # Empty attr for the offset
+            new_arg_attrs.append(ir.DictAttr.get({}))
 
-                # Empty attr for the offset
-                new_arg_attrs.append(ir.DictAttr.get({}))
+            # Give empty attrs for the shape args
+            r = orig_arg_type.rank
+            new_arg_attrs.extend([ir.DictAttr.get({}) for _ in range(r)])
 
-                # Give empty attrs for the shape args
-                r = orig_arg_type.rank
-                new_arg_attrs.extend([ir.DictAttr.get({}) for _ in range(r)])
+            # Give empty attrs for the stride args
+            new_arg_attrs.extend([ir.DictAttr.get({}) for _ in range(r)])
 
-                # Give empty attrs for the stride args
-                new_arg_attrs.extend([ir.DictAttr.get({}) for _ in range(r)])
-
-        op.attributes["arg_attrs"] = ir.ArrayAttr.get(new_arg_attrs)
-        del op.attributes["numba_cuda_mlir.arg_attrs"]
-        del op.attributes["numba_cuda_mlir.orig_arg_types"]
+    op.attributes["arg_attrs"] = ir.ArrayAttr.get(new_arg_attrs)
+    del op.attributes["numba_cuda_mlir.arg_attrs"]
+    del op.attributes["numba_cuda_mlir.orig_arg_types"]
 
 
 _EXOTIC_FLOAT_TYPES = frozenset(
@@ -82,29 +64,21 @@ def _is_exotic_float(ty: ir.Type) -> bool:
     return isinstance(ty, ir.FloatType) and str(ty) in _EXOTIC_FLOAT_TYPES
 
 
-def _resolve_exotic_float_casts(module: ir.Module):
+def _is_exotic_float_cast(op) -> bool:
+    if len(op.results) != 1 or len(op.operands) != 1:
+        return False
+    src_ty = op.operands[0].type
+    dst_ty = op.results[0].type
+    return (isinstance(src_ty, ir.IntegerType) and _is_exotic_float(dst_ty)) or (
+        _is_exotic_float(src_ty) and isinstance(dst_ty, ir.IntegerType)
+    )
+
+
+def _resolve_exotic_float_casts(worklist):
     """Replace unrealized_conversion_cast between integer and exotic float
     types with arith.bitcast. MLIR's memref-to-LLVM lowering inserts these
     casts for sub-32-bit float element types because LLVM has no native
     representation for them."""
-    worklist = []
-
-    def collect(op):
-        if op.operation.name == "builtin.unrealized_conversion_cast":
-            if len(op.results) == 1 and len(op.operands) == 1:
-                src_ty = op.operands[0].type
-                dst_ty = op.results[0].type
-                if (isinstance(src_ty, ir.IntegerType) and _is_exotic_float(dst_ty)) or (
-                    _is_exotic_float(src_ty) and isinstance(dst_ty, ir.IntegerType)
-                ):
-                    worklist.append(op)
-        for region in op.operation.regions:
-            for block in region.blocks:
-                for child in block:
-                    collect(child)
-
-    collect(module.operation.opview)
-
     for op in worklist:
         src = op.operands[0]
         dst_ty = op.results[0].type
@@ -141,7 +115,7 @@ def _copy_op_attrs(src, dst):
         dst.operation.attributes[name] = src.operation.attributes[name]
 
 
-def _resolve_shared_bit_storage_float_accesses(module: ir.Module):
+def _resolve_shared_bit_storage_float_accesses(worklist):
     """Rewrite shared-memory LLVM scalar loads/stores so float operands use integer storage.
 
     For MLIR floating-point types whose ABI/storage representation is wider integer bits
@@ -151,18 +125,6 @@ def _resolve_shared_bit_storage_float_accesses(module: ir.Module):
     nvjitlink LTO can drop certain half-precision scalar stores before a widened load; forcing
     integer accesses preserves bit patterns across that optimization.
     """
-    worklist = []
-
-    def collect(op):
-        if op.operation.name in ("llvm.load", "llvm.store"):
-            worklist.append(op)
-        for region in op.operation.regions:
-            for block in region.blocks:
-                for child in block:
-                    collect(child)
-
-    collect(module.operation.opview)
-
     for op in worklist:
         if op.operation.name == "llvm.store":
             value = op.operands[0]
@@ -192,12 +154,92 @@ def _resolve_shared_bit_storage_float_accesses(module: ir.Module):
         op.operation.erase()
 
 
+_FAST_FDIVIDEF = "__nv_fast_fdividef"
+
+
+def _fastmath_flag_set(op) -> frozenset:
+    """Flag names from an op's #llvm.fastmath<...> attribute (empty if none)."""
+    attrs = op.operation.attributes
+    if "fastmathFlags" not in attrs:
+        return frozenset()
+    text = str(attrs["fastmathFlags"])  # e.g. "#llvm.fastmath<nnan, arcp>"
+    inner = text[text.index("<") + 1 : text.rindex(">")]
+    return frozenset(flag.strip() for flag in inner.split(",") if flag.strip())
+
+
+def _is_fast_division(op) -> bool:
+    return isinstance(op.results[0].type, ir.F32Type) and bool(
+        _fastmath_flag_set(op) & {"fast", "arcp"}
+    )
+
+
+def _rewrite_fast_divisions(module: ir.Module, worklist):
+    """Lower f32 ``llvm.fdiv`` marked ``arcp`` (or ``fast``) to
+    ``__nv_fast_fdividef`` so it compiles to ``div.approx.f32``.
+
+    This mirrors numba-cuda, whose fastmath float32 division calls
+    ``__nv_fast_fdividef`` (libnvvm never selects ``div.approx`` from
+    instruction flags or the ``-prec-div=0`` option alone — those only reach
+    ``div.full``). Gating on the per-instruction ``arcp`` flag keeps the
+    transform selective per compiled function, including device callees
+    cloned in with their own fastmath options.
+    """
+    for gpu_module in module.body:
+        if isinstance(gpu_module, gpu.GPUModuleOp):
+            block = gpu_module.regions[0].blocks[0]
+            has_decl = any(
+                getattr(op, "sym_name", None) and op.sym_name.value == _FAST_FDIVIDEF
+                for op in block
+            )
+            if not has_decl:
+                decl = ir.Operation.parse(f"llvm.func @{_FAST_FDIVIDEF}(f32, f32) -> f32")
+                ir.InsertionPoint.at_block_begin(block).insert(decl)
+
+    for op in worklist:
+        loc = op.operation.location
+        with ir.InsertionPoint(op), loc:
+            call = llvm.CallOp(
+                result=op.results[0].type,
+                callee_operands=[op.operands[0], op.operands[1]],
+                op_bundle_operands=[],
+                op_bundle_sizes=[],
+                callee=_FAST_FDIVIDEF,
+            )
+        op.results[0].replace_all_uses_with(call.results[0])
+        op.operation.erase()
+
+
 def run_pre_codegen_patterns(module: ir.Module):
-    fixup_nvvm_arg_attrs(module.operation)
-    _resolve_exotic_float_casts(module)
-    _resolve_shared_bit_storage_float_accesses(module)
-    # TODO(ajm): why does this not trigger?
-    # patterns = RewritePatternSet()
-    # patterns.add(gpu.GPUFuncOp, fixup_nvvm_arg_attrs)
-    # frozen = patterns.freeze()
-    # apply_patterns_and_fold_greedily(module, frozen)
+    """Collect every pattern's matches in a single walk, then rewrite.
+
+    The patterns are independent (they match disjoint op kinds), so one
+    traversal feeds them all; rewrites run after the walk because they
+    erase and insert operations.
+    """
+    arg_attr_ops = []
+    cast_ops = []
+    mem_ops = []
+    fdiv_ops = []
+
+    def collect(op):
+        name = op.name
+        if name == "builtin.unrealized_conversion_cast":
+            if _is_exotic_float_cast(op):
+                cast_ops.append(op)
+        elif name in ("llvm.load", "llvm.store"):
+            mem_ops.append(op)
+        elif name == "llvm.fdiv":
+            if _is_fast_division(op):
+                fdiv_ops.append(op)
+        elif "numba_cuda_mlir.arg_attrs" in op.attributes:
+            arg_attr_ops.append(op)
+        return ir.WalkResult.ADVANCE
+
+    module.operation.walk(collect)
+
+    for op in arg_attr_ops:
+        _fixup_nvvm_arg_attrs(op)
+    _resolve_exotic_float_casts(cast_ops)
+    _resolve_shared_bit_storage_float_accesses(mem_ops)
+    if fdiv_ops:
+        _rewrite_fast_divisions(module, fdiv_ops)

--- a/tests/numba_cuda_tests/cudapy/test_compiler.py
+++ b/tests/numba_cuda_tests/cudapy/test_compiler.py
@@ -108,7 +108,6 @@ class TestCompile(NumbaCUDATestCase):
         ptx, resty = self._handle_compile_result(ret, compile_function)
         self.assertEqual(resty, uint32)
 
-    @pytest.mark.xfail(True, reason="Regex doesn't match")
     def test_fastmath(self):
         self._test_fastmath(compile_ptx, {"device": True})
 

--- a/tests/numba_cuda_tests/cudapy/test_fastmath.py
+++ b/tests/numba_cuda_tests/cudapy/test_fastmath.py
@@ -278,10 +278,8 @@ class TestFastMathOption(NumbaCUDATestCase):
 
     @staticmethod
     def _debug_directives(ptx):
-        """Count of each debug-related directive in the PTX (.file/.loc
-        totals, .section and .target by name). .target matters most: a
-        spurious ", debug" there would force ptxas to disable optimization.
-        """
+        """Count of each debug directive (.file/.loc totals; .section and
+        .target by full text)."""
         counts = {}
         for line in ptx.splitlines():
             s = line.strip()
@@ -292,22 +290,17 @@ class TestFastMathOption(NumbaCUDATestCase):
         return counts
 
     def test_fastmath_with_lineinfo(self):
-        # The nsz flag survives to the flagged-instruction text path (arcp
-        # rewrites the division away, so alone it would not exercise it);
-        # that path used to emit full DWARF, which ptxas rejects at -O3.
+        # nsz keeps a flagged instruction alive so the compile takes the
+        # text path; arcp alone rewrites the division away.
         def kernel(r, x, y):
             r[0] = x / y + x
 
         sig = (float32[::1], float32, float32)
-        ptx, _ = compile_ptx(
-            kernel, sig, fastmath={"nsz", "arcp"}, lineinfo=True
-        )
+        ptx, _ = compile_ptx(kernel, sig, fastmath={"nsz", "arcp"}, lineinfo=True)
         self.assertIn("div.approx", ptx)
         self.assertIn(".file", ptx)
         precptx, _ = compile_ptx(kernel, sig, lineinfo=True)
-        self.assertEqual(
-            self._debug_directives(ptx), self._debug_directives(precptx)
-        )
+        self.assertEqual(self._debug_directives(ptx), self._debug_directives(precptx))
 
     def test_fastmath_with_debug(self):
         # Full debug info takes the same flagged-instruction text path as
@@ -316,26 +309,20 @@ class TestFastMathOption(NumbaCUDATestCase):
             r[0] = x / y + x
 
         sig = (float32[::1], float32, float32)
-        ptx, _ = compile_ptx(
-            kernel, sig, fastmath={"nsz", "arcp"}, debug=True, opt=False
-        )
+        ptx, _ = compile_ptx(kernel, sig, fastmath={"nsz", "arcp"}, debug=True, opt=False)
         self.assertIn("div.approx", ptx)
         self.assertIn(".file", ptx)
         precptx, _ = compile_ptx(kernel, sig, debug=True, opt=False)
-        self.assertEqual(
-            self._debug_directives(ptx), self._debug_directives(precptx)
-        )
+        self.assertEqual(self._debug_directives(ptx), self._debug_directives(precptx))
 
     def test_fastmath_with_lineinfo_jit(self):
-        # The dispatcher path links the PTX at full optimization; leftover
-        # DWARF made ptxas refuse ("Optimized debugging not supported").
+        # The dispatcher links the PTX at full optimization, where ptxas
+        # rejects any leftover DWARF.
         def kernel(r, x, y):
             r[0] = x / y + x
 
         sig = (float32[::1], float32, float32)
-        jitted = cuda.jit(sig, fastmath={"nsz", "arcp"}, lineinfo=True)(
-            kernel
-        )
+        jitted = cuda.jit(sig, fastmath={"nsz", "arcp"}, lineinfo=True)(kernel)
         self.assertIn("div.approx", _first_asm(jitted, sig))
 
     def test_fastmath_with_lineinfo_lto(self):
@@ -345,9 +332,7 @@ class TestFastMathOption(NumbaCUDATestCase):
             r[0] = x / y + x
 
         sig = (float32[::1], float32, float32)
-        cuda.jit(sig, fastmath={"nsz", "arcp"}, lineinfo=True, lto=True)(
-            kernel
-        )
+        cuda.jit(sig, fastmath={"nsz", "arcp"}, lineinfo=True, lto=True)(kernel)
 
     def test_nvvm_knobs_follow_flags(self):
         # The module-level libnvvm/ptxas knobs are implied per-flag, with

--- a/tests/numba_cuda_tests/cudapy/test_fastmath.py
+++ b/tests/numba_cuda_tests/cudapy/test_fastmath.py
@@ -279,13 +279,15 @@ class TestFastMathOption(NumbaCUDATestCase):
     @staticmethod
     def _debug_directives(ptx):
         """Count of each debug-related directive in the PTX (.file/.loc
-        totals, .section by name)."""
+        totals, .section and .target by name). .target matters most: a
+        spurious ", debug" there would force ptxas to disable optimization.
+        """
         counts = {}
         for line in ptx.splitlines():
             s = line.strip()
-            for d in (".file", ".loc", ".section"):
+            for d in (".file", ".loc", ".section", ".target"):
                 if s.startswith(d):
-                    key = s if d == ".section" else d
+                    key = s if d in (".section", ".target") else d
                     counts[key] = counts.get(key, 0) + 1
         return counts
 

--- a/tests/numba_cuda_tests/cudapy/test_fastmath.py
+++ b/tests/numba_cuda_tests/cudapy/test_fastmath.py
@@ -5,6 +5,7 @@ import sys
 from typing import List
 from dataclasses import dataclass, field
 import numba_cuda_mlir
+from numba_cuda_mlir import cuda
 from numba_cuda_mlir.numba_cuda.types import float32
 from numba_cuda_mlir.compiler import compile_ptx
 from math import cos, sin, tan, exp, log, log10, log2, pow, tanh, nextafter
@@ -22,24 +23,34 @@ class FastMathCriterion:
     prec_unexpected: List[str] = field(default_factory=list)
 
     def check(self, test: NumbaCUDATestCase, fast: str, prec: str):
-        test.assertTrue(all(i in fast for i in self.fast_expected))
-        test.assertTrue(all(i not in fast for i in self.fast_unexpected))
-        test.assertTrue(all(i in prec for i in self.prec_expected))
-        test.assertTrue(all(i not in prec for i in self.prec_unexpected))
+        for i in self.fast_expected:
+            test.assertIn(i, fast)
+        for i in self.fast_unexpected:
+            test.assertNotIn(i, fast)
+        for i in self.prec_expected:
+            test.assertIn(i, prec)
+        for i in self.prec_unexpected:
+            test.assertNotIn(i, prec)
 
 
-@pytest.mark.xfail(True, reason="Fastmath tests need new patterns")
+def _first_asm(dispatcher, sig):
+    asm = dispatcher.inspect_asm(sig)
+    if isinstance(asm, dict):
+        return next(iter(asm.values()))
+    return asm
+
+
 class TestFastMathOption(NumbaCUDATestCase):
-    def _test_fast_math_common(self, pyfunc, sig, device, criterion):
+    def _test_fast_math_common(self, pyfunc, sig, device, criterion, fastmath=True):
         # Test jit code path
-        fastver = numba_cuda_mlir.cuda.jit(sig, device=device, fastmath=True)(pyfunc)
+        fastver = numba_cuda_mlir.cuda.jit(sig, device=device, fastmath=fastmath)(pyfunc)
         precver = numba_cuda_mlir.cuda.jit(sig, device=device)(pyfunc)
 
-        criterion.check(self, fastver.inspect_asm(sig), precver.inspect_asm(sig))
+        criterion.check(self, _first_asm(fastver, sig), _first_asm(precver, sig))
 
         # Test compile_ptx code path
-        fastptx, _ = compile_ptx_for_current_device(pyfunc, sig, device=device, fastmath=True)
-        precptx, _ = compile_ptx_for_current_device(pyfunc, sig, device=device)
+        fastptx, _ = compile_ptx(pyfunc, sig, device=device, fastmath=fastmath)
+        precptx, _ = compile_ptx(pyfunc, sig, device=device)
 
         criterion.check(self, fastptx, precptx)
 
@@ -201,6 +212,113 @@ class TestFastMathOption(NumbaCUDATestCase):
             ),
         )
 
+    def test_divf_arcp_only(self):
+        # Selective fastmath: arcp alone opts into approximate division.
+        def kernel(r, x, y):
+            r[0] = x / y
+
+        sig = (float32[::1], float32, float32)
+        arcpptx, _ = compile_ptx(kernel, sig, fastmath={"arcp"})
+        self.assertIn("div.approx", arcpptx)
+        self.assertNotIn("div.rn.f32", arcpptx)
+
+    def test_divf_arcp_only_jit(self):
+        # The selective form must also survive the dispatcher path, not
+        # just compile_ptx.
+        def kernel(r, x, y):
+            r[0] = x / y
+
+        sig = (float32[::1], float32, float32)
+        fastver = cuda.jit(sig, fastmath={"arcp"})(kernel)
+        self.assertIn("div.approx", _first_asm(fastver, sig))
+
+    def test_divf_nsz_only_stays_precise_division(self):
+        # Selective fastmath: a subset without arcp/fast must not use the
+        # fastest approximate division.
+        def kernel(r, x, y):
+            r[0] = x / y
+
+        sig = (float32[::1], float32, float32)
+        nszptx, _ = compile_ptx(kernel, sig, fastmath={"nsz"})
+        self.assertNotIn("div.approx", nszptx)
+
+    def test_sinf_afn_only(self):
+        # afn opts into approximate functions without touching division.
+        def kernel(r, x, y):
+            r[0] = sin(x) / y
+
+        sig = (float32[::1], float32, float32)
+        afnptx, _ = compile_ptx(kernel, sig, fastmath={"afn"})
+        self.assertIn("sin.approx", afnptx)
+        self.assertNotIn("div.approx", afnptx)
+
+    def test_fastmath_flags_in_mlir(self):
+        # Selective flags are stamped per-op as #arith.fastmath attributes.
+        from numba_cuda_mlir.compiler import compile_mlir
+
+        def kernel(r, x, y):
+            r[0] = x / y
+
+        sig = (float32[::1], float32, float32)
+        m = str(compile_mlir(kernel, sig, fastmath={"nnan", "arcp"}))
+        self.assertIn("fastmath<nnan,arcp>", m)
+        m = str(compile_mlir(kernel, sig, fastmath=True))
+        self.assertIn("fastmath<fast>", m)
+        m = str(compile_mlir(kernel, sig))
+        self.assertNotIn("fastmath<", m)
+
+    def test_fastmath_invalid_flag_rejected(self):
+        def kernel(r, x, y):
+            r[0] = x / y
+
+        sig = (float32[::1], float32, float32)
+        with self.assertRaises(Exception) as cm:
+            compile_ptx(kernel, sig, fastmath={"bogus"})
+        self.assertIn("bogus", str(cm.exception))
+
+    def test_fastmath_with_lineinfo(self):
+        # Regression test: with debug info present, the LLVM70 fast-math
+        # text round-trip used to fail re-parsing on the compile unit's
+        # emission kind ("expected emission kind").
+        def kernel(r, x, y):
+            r[0] = x / y
+
+        sig = (float32[::1], float32, float32)
+        ptx, _ = compile_ptx(kernel, sig, fastmath=True, lineinfo=True)
+        self.assertIn("div.approx", ptx)
+        self.assertIn(".file", ptx)
+
+    def test_fastmath_with_debug(self):
+        # Full debug info takes the same LLVM70 text round-trip as lineinfo;
+        # both fast-math and the debug line table must survive it.
+        def kernel(r, x, y):
+            r[0] = x / y
+
+        sig = (float32[::1], float32, float32)
+        ptx, _ = compile_ptx(kernel, sig, fastmath=True, debug=True, opt=False)
+        self.assertIn("div.approx", ptx)
+        self.assertIn(".file", ptx)
+
+    def test_nvvm_knobs_follow_flags(self):
+        # The module-level libnvvm/ptxas knobs are implied per-flag, with
+        # 'fast' (the bool form) enabling all four as numba-cuda does.
+        from numba_cuda_mlir.fastmath import nvvm_fastmath_options
+
+        self.assertEqual(
+            nvvm_fastmath_options(True),
+            {"ftz": True, "fma": True, "prec_div": False, "prec_sqrt": False},
+        )
+        self.assertEqual(nvvm_fastmath_options(False), {})
+        self.assertEqual(nvvm_fastmath_options({"arcp"}), {"prec_div": False})
+        self.assertEqual(nvvm_fastmath_options({"afn"}), {"prec_sqrt": False})
+        self.assertEqual(nvvm_fastmath_options({"contract"}), {"fma": True})
+        self.assertEqual(nvvm_fastmath_options({"nnan", "nsz"}), {})
+
+    @pytest.mark.xfail(
+        True,
+        reason="mlir backend does not yet raise ZeroDivisionError for float "
+        "division under debug=True (python error model); unrelated to fastmath",
+    )
     def test_divf_exception(self):
         def f10(r, x, y):
             r[0] = x / y

--- a/tests/numba_cuda_tests/cudapy/test_fastmath.py
+++ b/tests/numba_cuda_tests/cudapy/test_fastmath.py
@@ -276,6 +276,19 @@ class TestFastMathOption(NumbaCUDATestCase):
             compile_ptx(kernel, sig, fastmath={"bogus"})
         self.assertIn("bogus", str(cm.exception))
 
+    @staticmethod
+    def _debug_directives(ptx):
+        """Count of each debug-related directive in the PTX (.file/.loc
+        totals, .section by name)."""
+        counts = {}
+        for line in ptx.splitlines():
+            s = line.strip()
+            for d in (".file", ".loc", ".section"):
+                if s.startswith(d):
+                    key = s if d == ".section" else d
+                    counts[key] = counts.get(key, 0) + 1
+        return counts
+
     def test_fastmath_with_lineinfo(self):
         # Regression test: with debug info present, the LLVM70 fast-math
         # text round-trip used to fail re-parsing on the compile unit's
@@ -287,6 +300,12 @@ class TestFastMathOption(NumbaCUDATestCase):
         ptx, _ = compile_ptx(kernel, sig, fastmath=True, lineinfo=True)
         self.assertIn("div.approx", ptx)
         self.assertIn(".file", ptx)
+        # The round-trip spells emission kind 3 as LineTablesOnly for the
+        # reparse; that must not change what debug output is emitted.
+        precptx, _ = compile_ptx(kernel, sig, lineinfo=True)
+        self.assertEqual(
+            self._debug_directives(ptx), self._debug_directives(precptx)
+        )
 
     def test_fastmath_with_debug(self):
         # Full debug info takes the same LLVM70 text round-trip as lineinfo;
@@ -298,6 +317,10 @@ class TestFastMathOption(NumbaCUDATestCase):
         ptx, _ = compile_ptx(kernel, sig, fastmath=True, debug=True, opt=False)
         self.assertIn("div.approx", ptx)
         self.assertIn(".file", ptx)
+        precptx, _ = compile_ptx(kernel, sig, debug=True, opt=False)
+        self.assertEqual(
+            self._debug_directives(ptx), self._debug_directives(precptx)
+        )
 
     def test_nvvm_knobs_follow_flags(self):
         # The module-level libnvvm/ptxas knobs are implied per-flag, with

--- a/tests/numba_cuda_tests/cudapy/test_fastmath.py
+++ b/tests/numba_cuda_tests/cudapy/test_fastmath.py
@@ -292,36 +292,61 @@ class TestFastMathOption(NumbaCUDATestCase):
         return counts
 
     def test_fastmath_with_lineinfo(self):
-        # Regression test: with debug info present, the LLVM70 fast-math
-        # text round-trip used to fail re-parsing on the compile unit's
-        # emission kind ("expected emission kind").
+        # The nsz flag survives to the flagged-instruction text path (arcp
+        # rewrites the division away, so alone it would not exercise it);
+        # that path used to emit full DWARF, which ptxas rejects at -O3.
         def kernel(r, x, y):
-            r[0] = x / y
+            r[0] = x / y + x
 
         sig = (float32[::1], float32, float32)
-        ptx, _ = compile_ptx(kernel, sig, fastmath=True, lineinfo=True)
+        ptx, _ = compile_ptx(
+            kernel, sig, fastmath={"nsz", "arcp"}, lineinfo=True
+        )
         self.assertIn("div.approx", ptx)
         self.assertIn(".file", ptx)
-        # The round-trip spells emission kind 3 as LineTablesOnly for the
-        # reparse; that must not change what debug output is emitted.
         precptx, _ = compile_ptx(kernel, sig, lineinfo=True)
         self.assertEqual(
             self._debug_directives(ptx), self._debug_directives(precptx)
         )
 
     def test_fastmath_with_debug(self):
-        # Full debug info takes the same LLVM70 text round-trip as lineinfo;
-        # both fast-math and the debug line table must survive it.
+        # Full debug info takes the same flagged-instruction text path as
+        # lineinfo; both fast-math and the debug output must survive it.
         def kernel(r, x, y):
-            r[0] = x / y
+            r[0] = x / y + x
 
         sig = (float32[::1], float32, float32)
-        ptx, _ = compile_ptx(kernel, sig, fastmath=True, debug=True, opt=False)
+        ptx, _ = compile_ptx(
+            kernel, sig, fastmath={"nsz", "arcp"}, debug=True, opt=False
+        )
         self.assertIn("div.approx", ptx)
         self.assertIn(".file", ptx)
         precptx, _ = compile_ptx(kernel, sig, debug=True, opt=False)
         self.assertEqual(
             self._debug_directives(ptx), self._debug_directives(precptx)
+        )
+
+    def test_fastmath_with_lineinfo_jit(self):
+        # The dispatcher path links the PTX at full optimization; leftover
+        # DWARF made ptxas refuse ("Optimized debugging not supported").
+        def kernel(r, x, y):
+            r[0] = x / y + x
+
+        sig = (float32[::1], float32, float32)
+        jitted = cuda.jit(sig, fastmath={"nsz", "arcp"}, lineinfo=True)(
+            kernel
+        )
+        self.assertIn("div.approx", _first_asm(jitted, sig))
+
+    def test_fastmath_with_lineinfo_lto(self):
+        # The same combination through an LTO link: the LTOIR must not
+        # carry full debug info either.
+        def kernel(r, x, y):
+            r[0] = x / y + x
+
+        sig = (float32[::1], float32, float32)
+        cuda.jit(sig, fastmath={"nsz", "arcp"}, lineinfo=True, lto=True)(
+            kernel
         )
 
     def test_nvvm_knobs_follow_flags(self):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -838,6 +838,54 @@ def test_pow():
     np.testing.assert_almost_equal(result.copy_to_host()[0], 8.0, decimal=5)
 
 
+def test_pow_zero_exponent():
+    values = np.array([np.nan, 0.0, -0.0, np.inf, -np.inf, -2.0], dtype=np.float32)
+    zero = np.float32(0.0)
+    negative_zero = np.float32(-0.0)
+
+    for fastmath in (False, {"afn"}, True):
+
+        @cuda.jit(fastmath=fastmath)
+        def pow_zero_kernel(result, bases):
+            i = cuda.grid(1)
+            result[0, i] = bases[i] ** (zero - zero)
+            result[1, i] = bases[i] ** negative_zero
+
+        bases = cuda.to_device(values)
+        result = cuda.device_array((2, values.size), dtype=np.float32)
+        pow_zero_kernel[1, values.size](result, bases)
+
+        expected = np.ones((2, values.size), dtype=np.float32)
+        np.testing.assert_array_equal(result.copy_to_host(), expected)
+
+
+def test_pow_zero_exponent_folds_before_codegen():
+    from numba_cuda_mlir._mlir import ir
+    from numba_cuda_mlir.lowering_utilities import context
+    from numba_cuda_mlir.optimization import run_pre_codegen_patterns
+
+    module_text = """
+    module {
+      llvm.func @__nv_fast_powf(f32, f32) -> f32
+      llvm.func @kernel(%arg0: f32, %arg1: f32) -> f32 {
+        %zero = llvm.mlir.constant(0.000000e+00 : f32) : f32
+        %half = llvm.mlir.constant(5.000000e-01 : f32) : f32
+        %0 = llvm.call @__nv_fast_powf(%arg0, %zero) : (f32, f32) -> f32
+        %1 = llvm.call @__nv_fast_powf(%arg1, %half) : (f32, f32) -> f32
+        %2 = llvm.fadd %0, %1 : f32
+        llvm.return %2 : f32
+      }
+    }
+    """
+    with context.get_context():
+        module = ir.Module.parse(module_text)
+        run_pre_codegen_patterns(module)
+        folded = str(module)
+
+    assert folded.count("llvm.call @__nv_fast_powf") == 1
+    assert "1.000000e+00" in folded
+
+
 def test_nextafter():
     """Test nextafter function"""
 


### PR DESCRIPTION
Fixes #220.

`fastmath` accepted only a bool; it now accepts `bool | set | dict | FastMathOptions` over the eight LLVM flags, validated at decoration time (new module `fastmath.py`).

Each lowered function is walked once and every fastmath-capable `arith`/`math` op is stamped with `#arith.fastmath<...>`. The capable-op set is discovered from the generated bindings, so it tracks the bundled MLIR. Device callees compile under their own options and are cloned in already stamped, so flags scope per function.

Two rewrites cover instructions the flags alone cannot produce, both the same substitutions numba-cuda makes: f32 division under `arcp` or `fast` becomes `__nv_fast_fdividef`, and f32 `tanh` under `afn` or `fast` on sm_75+ becomes `tanh.approx.f32`. Constant-zero powers are folded to 1.0 before lowering; `__nv_fast_powf` returns NaN for negative, NaN, zero, and infinite bases.

The module-level libnvvm/ptxas knobs were all-or-nothing off the bool. Each is now derived from the flag that requests it, and they now reach libnvvm on the sm<100 path through a new trailing CAPI parameter.

The LLVM 7 C API cannot set per-instruction fast-math flags. On the sm<100 path, flagged instructions get marker value names, the flag keywords are inserted into the printed IR, and the text is passed to libnvvm, whose parser accepts it directly. It also names the compile unit's emission kind 3, which LLVM 7 prints empty and cannot re-parse; any substitute kind it can parse makes libnvvm emit full DWARF, which ptxas refuses to link above -O0. The tests check that debug output, including `.target`, is unchanged, and that the PTX and LTO links succeed under `lineinfo`.

**Tests**

- `test_fastmath.py`: `{"arcp"}` gives `div.approx` on both compile paths, `{"nsz"}` keeps precise division, `{"afn"}` gives `sin.approx` without approximate division, invalid flags are rejected, per-op attributes appear in the MLIR, the knob mapping is unit-tested, and fastmath with `lineinfo`/`debug` keeps `div.approx` with identical debug directives.
- `fastmath_flags.mlir` (new lit test): full, selective, and unflagged instructions survive the sm<100 text path.
- `test_math.py`: `x ** (0.0)` and `x ** (-0.0)` return 1.0 for NaN, +-0.0, +-inf, and -2.0 bases under `fastmath=False`, `{"afn"}`, and `True`; the fold is unit-tested on a parsed module.

**Verification:** (sm_89, Windows) 24/26 xfailed fastmath tests go red->green, 2 stay xfailed (fastmath doesn't propagate into device functions from decorated kernel, no ZeroDivisionError); GPU fast-vs-precise results agree to relative error 7e-8.

Written by Chris' bot, rewritten repeatedly by Chris.

