### PR TITLE
Make the SSA reaching-definition search iterative

### DIFF
--- a/src/numba_cuda_mlir/numba_cuda/core/ssa.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/ssa.py
@@ -415,58 +415,101 @@ class _FixSSAVars(_BaseHandler):
         This method would look at all dominance frontiers.
         Insert phi node if necessary.
         """
-        _logger.debug("find_def_from_top label %r", label)
+        return self._find_def_iteratively(states, label, loc, from_top=True)
+
+    def _find_def_from_bottom(self, states, label, loc):
+        """Find definition from within the block at ``label``."""
+        return self._find_def_iteratively(states, label, loc, from_top=False)
+
+    def _find_def_iteratively(self, states, label, loc, from_top):
+        """Iterative driver for the reaching-definition search.
+
+        Equivalent to a mutual recursion between the *from_top* and
+        *from_bottom* searches, but implemented with an explicit worklist
+        so that the search depth is bounded by available memory rather
+        than the interpreter recursion limit.  The dominator chains
+        walked here grow with the size of the function's CFG, so large
+        functions (e.g. kernels with big fully-inlined callees) would
+        otherwise overflow the recursion limit.
+
+        Each ``pending`` item is a ``(phinode, pred, loc)`` triple whose
+        resolved incoming definition must be appended to ``phinode``.
+        Predecessors are pushed in reverse so the LIFO pop order matches
+        the depth-first order of the recursive formulation exactly,
+        keeping phi creation order — and thus fresh-variable numbering —
+        identical.
+        """
+        pending = []
+        result = self._walk_def_chain(states, label, loc, from_top, pending)
+        while pending:
+            phinode, pred, philoc = pending.pop()
+            incoming_def = self._walk_def_chain(
+                states,
+                pred,
+                philoc,
+                False,
+                pending,
+            )
+            _logger.debug("incoming_def %s", incoming_def)
+            phinode.value.incoming_values.append(incoming_def.target)
+            phinode.value.incoming_blocks.append(pred)
+        return result
+
+    def _walk_def_chain(self, states, label, loc, from_top, pending):
+        """Walk a single def-search chain without recursion.
+
+        Alternates between the *from_bottom* step (take the last
+        definition in the block, if any) and the *from_top* step (insert
+        a phi node, or hop to the immediate dominator).  A phi node is
+        registered in ``defmap`` before its predecessors are resolved,
+        so a chain revisiting the block terminates there; resolution of
+        the phi's incoming values is deferred onto ``pending``.
+        """
         cfg = states["cfg"]
         defmap = states["defmap"]
         phimap = states["phimap"]
         phi_locations = states["phi_locations"]
 
-        if label in phi_locations:
-            scope = states["scope"]
-            loc = states["block"].loc
-            # fresh variable
-            freshvar = scope.redefine(states["varname"], loc=loc)
-            # insert phi
-            phinode = ir.Assign(
-                target=freshvar,
-                value=ir.Expr.phi(loc=loc),
-                loc=loc,
-            )
-            _logger.debug("insert phi node %s at %s", phinode, label)
-            defmap[label].insert(0, phinode)
-            phimap[label].append(phinode)
-            # Find incoming values for the Phi node
-            for pred, _ in cfg.predecessors(label):
-                incoming_def = self._find_def_from_bottom(
-                    states,
-                    pred,
+        while True:
+            if not from_top:
+                _logger.debug("find_def_from_bottom label %r", label)
+                defs = defmap[label]
+                if defs:
+                    return defs[-1]
+                from_top = True
+
+            _logger.debug("find_def_from_top label %r", label)
+            if label in phi_locations:
+                scope = states["scope"]
+                loc = states["block"].loc
+                # fresh variable
+                freshvar = scope.redefine(states["varname"], loc=loc)
+                # insert phi
+                phinode = ir.Assign(
+                    target=freshvar,
+                    value=ir.Expr.phi(loc=loc),
                     loc=loc,
                 )
-                _logger.debug("incoming_def %s", incoming_def)
-                phinode.value.incoming_values.append(incoming_def.target)
-                phinode.value.incoming_blocks.append(pred)
-            return phinode
-        else:
-            idom = cfg.immediate_dominators()[label]
-            if idom == label:
-                # We have searched to the top of the idom tree.
-                # Since we still cannot find a definition,
-                # we will warn.
-                _warn_about_uninitialized_variable(states["varname"], loc)
-                return UndefinedVariable
-            _logger.debug("idom %s from label %s", idom, label)
-            return self._find_def_from_bottom(states, idom, loc=loc)
-
-    def _find_def_from_bottom(self, states, label, loc):
-        """Find definition from within the block at ``label``."""
-        _logger.debug("find_def_from_bottom label %r", label)
-        defmap = states["defmap"]
-        defs = defmap[label]
-        if defs:
-            lastdef = defs[-1]
-            return lastdef
-        else:
-            return self._find_def_from_top(states, label, loc=loc)
+                _logger.debug("insert phi node %s at %s", phinode, label)
+                defmap[label].insert(0, phinode)
+                phimap[label].append(phinode)
+                # Defer the search for the phi's incoming values;
+                # reversed so they resolve in predecessor order.
+                preds = [pred for pred, _ in cfg.predecessors(label)]
+                for pred in reversed(preds):
+                    pending.append((phinode, pred, loc))
+                return phinode
+            else:
+                idom = cfg.immediate_dominators()[label]
+                if idom == label:
+                    # We have searched to the top of the idom tree.
+                    # Since we still cannot find a definition,
+                    # we will warn.
+                    _warn_about_uninitialized_variable(states["varname"], loc)
+                    return UndefinedVariable
+                _logger.debug("idom %s from label %s", idom, label)
+                label = idom
+                from_top = False
 
     def _stmt_index(self, defstmt, block, stop=-1):
         """Find the positional index of the statement at ``block``.

--- a/src/numba_cuda_mlir/numba_cuda/core/ssa.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/ssa.py
@@ -410,37 +410,25 @@ class _FixSSAVars(_BaseHandler):
         return selected_def
 
     def _find_def_from_top(self, states, label, loc):
-        """Find definition reaching block of ``label``.
+        """Find definition reaching the top of the block at ``label``,
+        inserting phi nodes where necessary.
 
-        This method would look at all dominance frontiers.
-        Insert phi node if necessary.
-        """
-        return self._find_def_iteratively(states, label, loc, from_top=True)
-
-    def _find_def_from_bottom(self, states, label, loc):
-        """Find definition from within the block at ``label``."""
-        return self._find_def_iteratively(states, label, loc, from_top=False)
-
-    def _find_def_iteratively(self, states, label, loc, from_top):
-        """Iterative driver for the reaching-definition search.
-
-        Equivalent to a mutual recursion between the *from_top* and
-        *from_bottom* searches, but implemented with an explicit worklist
-        so that the search depth is bounded by available memory rather
-        than the interpreter recursion limit.  The dominator chains
-        walked here grow with the size of the function's CFG, so large
-        functions (e.g. kernels with big fully-inlined callees) would
-        otherwise overflow the recursion limit.
+        Iterative driver for the reaching-definition search: the
+        dominator chains walked by ``_walk_def_chain`` grow with the size
+        of the function's CFG, so large functions (e.g. kernels with big
+        fully-inlined callees) would overflow the recursion limit if each
+        block cost a stack frame. The search depth here is bounded by
+        available memory instead.
 
         Each ``pending`` item is a ``(phinode, pred, loc)`` triple whose
         resolved incoming definition must be appended to ``phinode``.
         Predecessors are pushed in reverse so the LIFO pop order matches
-        the depth-first order of the recursive formulation exactly,
-        keeping phi creation order — and thus fresh-variable numbering —
+        the depth-first order of the recursive formulation this replaced,
+        keeping phi creation order, and thus fresh-variable numbering,
         identical.
         """
         pending = []
-        result = self._walk_def_chain(states, label, loc, from_top, pending)
+        result = self._walk_def_chain(states, label, loc, True, pending)
         while pending:
             phinode, pred, philoc = pending.pop()
             incoming_def = self._walk_def_chain(

--- a/src/numba_cuda_mlir/numba_cuda/core/ssa.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/ssa.py
@@ -413,19 +413,11 @@ class _FixSSAVars(_BaseHandler):
         """Find definition reaching the top of the block at ``label``,
         inserting phi nodes where necessary.
 
-        Iterative driver for the reaching-definition search: the
-        dominator chains walked by ``_walk_def_chain`` grow with the size
-        of the function's CFG, so large functions (e.g. kernels with big
-        fully-inlined callees) would overflow the recursion limit if each
-        block cost a stack frame. The search depth here is bounded by
-        available memory instead.
-
-        Each ``pending`` item is a ``(phinode, pred, loc)`` triple whose
-        resolved incoming definition must be appended to ``phinode``.
-        Predecessors are pushed in reverse so the LIFO pop order matches
-        the depth-first order of the recursive formulation this replaced,
-        keeping phi creation order, and thus fresh-variable numbering,
-        identical.
+        Runs on an explicit worklist so the search depth does not grow
+        with the CFG. Each ``pending`` item is a ``(phinode, pred, loc)``
+        triple whose resolved incoming definition is appended to
+        ``phinode``; predecessors are pushed in reverse so phi nodes are
+        created, and fresh variables numbered, in depth-first order.
         """
         pending = []
         result = self._walk_def_chain(states, label, loc, True, pending)
@@ -444,7 +436,7 @@ class _FixSSAVars(_BaseHandler):
         return result
 
     def _walk_def_chain(self, states, label, loc, from_top, pending):
-        """Walk a single def-search chain without recursion.
+        """Walk a single def-search chain.
 
         Alternates between the *from_bottom* step (take the last
         definition in the block, if any) and the *from_top* step (insert

--- a/tests/numba_cuda_tests/cudapy/test_ssa.py
+++ b/tests/numba_cuda_tests/cudapy/test_ssa.py
@@ -6,11 +6,13 @@ Tests for SSA reconstruction
 
 import sys
 import copy
+import inspect
 import logging
 
 import numpy as np
 
 from numba_cuda_mlir.numba_cuda import types
+from numba_cuda_mlir.numba_cuda.core import ir
 import numba_cuda_mlir
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.numba_cuda.core import errors
@@ -442,3 +444,58 @@ class TestReportedSSAIssues(SSABaseTest):
 
         np.testing.assert_array_equal(python, expect)
         np.testing.assert_array_equal(nb, expect)
+
+
+class TestSSADeepCFG(NumbaCUDATestCase):
+    """
+    The reaching-definition search must not recurse per CFG block,
+    otherwise functions whose dominator chains are longer than the
+    interpreter recursion limit (e.g. kernels with large fully-inlined
+    device functions) fail to compile with RecursionError.
+
+    This test works on Numba IR only and does not require a GPU.
+    """
+
+    def test_deep_dominator_chain_def_search(self):
+        from numba_cuda_mlir.numba_cuda.compiler import run_frontend
+        from numba_cuda_mlir.numba_cuda.core.ssa import reconstruct_ssa
+
+        # `a` is an SSA violator (two definitions) whose use sits at the
+        # far end of a long immediate-dominator chain built from
+        # conditionals that neither define `a` nor lie on its dominance
+        # frontier, so the def search must walk the entire chain.
+        n_conditionals = 500
+        src_lines = ["def deep_cfg(x):", "    a = 0", "    if x < 0:", "        a = 1"]
+        for i in range(n_conditionals):
+            src_lines.append(f"    if x > {i}:")
+            src_lines.append(f"        b{i} = x")
+        src_lines.append("    return a")
+        ns = {}
+        exec("\n".join(src_lines), ns)
+
+        # Run the frontend at the current recursion limit; constrain only
+        # the SSA pass, the way the default 1000-frame limit constrains a
+        # much larger kernel.
+        func_ir = run_frontend(ns["deep_cfg"])
+        self.assertGreater(len(func_ir.blocks), 2 * n_conditionals)
+
+        current_depth = len(inspect.stack())
+        old_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(current_depth + 400)
+        try:
+            func_ir = reconstruct_ssa(func_ir)
+        finally:
+            sys.setrecursionlimit(old_limit)
+
+        # The reaching definition at the `return` must be the phi joining
+        # the two definitions of `a`, not an artifact of a truncated walk.
+        phis = [
+            stmt
+            for blk in func_ir.blocks.values()
+            for stmt in blk.body
+            if isinstance(stmt, ir.Assign)
+            and isinstance(stmt.value, ir.Expr)
+            and stmt.value.op == "phi"
+        ]
+        self.assertEqual(len(phis), 1)
+        self.assertEqual(len(phis[0].value.incoming_values), 2)


### PR DESCRIPTION
Fixes #222.

The reaching-definition search recursed once per CFG block, through a mutual recursion between `_find_def_from_top` and `_find_def_from_bottom`, so large control-flow graphs overflowed the interpreter recursion limit. `_find_def_from_top` now drives the search as a loop: `_walk_def_chain` walks one dominator chain, and phi incoming values are deferred onto an explicit stack and resolved in the same depth-first order as before, so phi creation order and fresh-variable numbering are unchanged. `_find_def_from_bottom` had no callers left and is removed.

**Tests**

- `test_ssa.py` gains a deep-CFG test: a 500-conditional dominator chain reconstructs under a recursion limit a few hundred frames above the test's own stack depth and yields the expected single two-input phi.

**Verification:** (sm_89, Windows) the new test goes red->green; the previous implementation raises `RecursionError` on the same CFG at the default limit. Frame depth no longer grows with CFG size (a 4000-block CFG reconstructs at the current stack depth plus 100). With the old implementation patched back in, old and new produce identical IR over if/else, loops, nested loops, while/break/continue, and uninitialized-variable shapes. `test_ssa.py` passes and SSA reconstruction time is unchanged within noise.

Written by Chris' bot, rewritten repeatedly by Chris.
