### PR TITLE
Attribute inlined cross-file lines to their own DWARF file entry

### DIFF
--- a/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
@@ -217,6 +217,9 @@ public:
   LLVMMetadataRef createDIFunction(LLVMMetadataRef scope, const char *name,
                                    size_t nameLen, LLVMMetadataRef file,
                                    unsigned lineNo, LLVMMetadataRef type);
+  LLVMMetadataRef createDILexicalBlockFile(LLVMMetadataRef scope,
+                                           LLVMMetadataRef file,
+                                           unsigned discriminator = 0);
   void setSubprogram(LLVMValueRef fn, LLVMMetadataRef sp);
   void setDebugLocation(unsigned line, unsigned col, LLVMMetadataRef scope);
   void clearDebugLocation();
@@ -443,6 +446,8 @@ private:
            unsigned, LLVMDIFlags, LLVMBool)
   LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateDebugLocation, LLVMContextRef,
            unsigned, unsigned, LLVMMetadataRef, LLVMMetadataRef)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateLexicalBlockFile,
+           LLVMDIBuilderRef, LLVMMetadataRef, LLVMMetadataRef, unsigned)
   LLVM_FN(void, fnSetCurrentDebugLocation, LLVMBuilderRef, LLVMValueRef)
   LLVM_FN(LLVMValueRef, fnMetadataAsValue, LLVMContextRef, LLVMMetadataRef)
   LLVM_FN(void, fnSetSubprogram, LLVMValueRef, LLVMMetadataRef)

--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -92,8 +92,13 @@ private:
   LLVMMetadataRef diSubroutineType = nullptr;
   llvm::StringMap<LLVMMetadataRef> diFileCache;
   LLVMMetadataRef currentSubprogram = nullptr;
+  // File of the current subprogram; locations in other files are scoped
+  // through a DILexicalBlockFile so DWARF attributes them correctly.
+  llvm::StringRef currentSubprogramFile;
+  llvm::StringMap<LLVMMetadataRef> fileScopeCache;
 
   LLVMMetadataRef getOrCreateDIFile(llvm::StringRef filename);
+  LLVMMetadataRef getOrCreateFileScope(llvm::StringRef filename);
   void setDebugLocFromOp(mlir::Operation *op);
   std::tuple<llvm::StringRef, unsigned, unsigned>
   extractFileLineCol(mlir::Location loc);

--- a/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
@@ -209,6 +209,8 @@ llvm::Error LLVM70IRBuilder::resolveSymbols() {
   RESOLVE(fnDIBuilderCreateSubroutineType, "LLVMDIBuilderCreateSubroutineType");
   RESOLVE(fnDIBuilderCreateFunction, "LLVMDIBuilderCreateFunction");
   RESOLVE(fnDIBuilderCreateDebugLocation, "LLVMDIBuilderCreateDebugLocation");
+  RESOLVE(fnDIBuilderCreateLexicalBlockFile,
+          "LLVMDIBuilderCreateLexicalBlockFile");
   RESOLVE(fnSetCurrentDebugLocation, "LLVMSetCurrentDebugLocation");
   RESOLVE(fnMetadataAsValue, "LLVMMetadataAsValue");
   RESOLVE(fnSetSubprogram, "LLVMSetSubprogram");
@@ -678,6 +680,11 @@ LLVMMetadataRef LLVM70IRBuilder::createDIFunction(LLVMMetadataRef scope,
       diBuilder, scope, name, nameLen, name, nameLen, file, lineNo, type,
       /*IsLocalToUnit=*/false, /*IsDefinition=*/true,
       /*ScopeLine=*/lineNo, LLVMDIFlagZero, /*IsOptimized=*/false);
+}
+LLVMMetadataRef LLVM70IRBuilder::createDILexicalBlockFile(
+    LLVMMetadataRef scope, LLVMMetadataRef file, unsigned discriminator) {
+  return fnDIBuilderCreateLexicalBlockFile(diBuilder, scope, file,
+                                           discriminator);
 }
 void LLVM70IRBuilder::setSubprogram(LLVMValueRef fn, LLVMMetadataRef sp) {
   fnSetSubprogram(fn, sp);

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -252,6 +252,17 @@ LLVMMetadataRef MLIRToLLVM70::getOrCreateDIFile(llvm::StringRef filename) {
   return file;
 }
 
+LLVMMetadataRef MLIRToLLVM70::getOrCreateFileScope(llvm::StringRef filename) {
+  auto it = fileScopeCache.find(filename);
+  if (it != fileScopeCache.end())
+    return it->second;
+
+  LLVMMetadataRef scope = b.createDILexicalBlockFile(
+      currentSubprogram, getOrCreateDIFile(filename));
+  fileScopeCache[filename] = scope;
+  return scope;
+}
+
 void MLIRToLLVM70::setDebugLocFromOp(Operation *op) {
   if (!diCompileUnit)
     return;
@@ -263,6 +274,12 @@ void MLIRToLLVM70::setDebugLocFromOp(Operation *op) {
   }
 
   LLVMMetadataRef scope = currentSubprogram ? currentSubprogram : diCompileUnit;
+  // Code inlined from other source files carries locations in those
+  // files. Scope such lines through a DILexicalBlockFile so the DWARF
+  // line table references the correct file instead of mis-filing the
+  // line numbers under the subprogram's file.
+  if (currentSubprogram && filename != currentSubprogramFile)
+    scope = getOrCreateFileScope(filename);
   b.setDebugLocation(line, col, scope);
 }
 
@@ -450,14 +467,16 @@ llvm::Error MLIRToLLVM70::translateFuncOp(Operation *op) {
   // Attach debug info subprogram to this function.
   if (diCompileUnit) {
     auto [filename, line, col] = extractFileLineCol(funcOp.getLoc());
-    LLVMMetadataRef diFile =
-        filename.empty() ? getOrCreateDIFile("llvm70_module")
-                         : getOrCreateDIFile(filename);
+    llvm::StringRef subprogramFile =
+        filename.empty() ? "llvm70_module" : filename;
+    LLVMMetadataRef diFile = getOrCreateDIFile(subprogramFile);
     std::string name = funcOp.getName().str();
     currentSubprogram =
         b.createDIFunction(diFile, name.c_str(), name.size(), diFile,
                            line ? line : 1, diSubroutineType);
     b.setSubprogram(fn, currentSubprogram);
+    currentSubprogramFile = subprogramFile;
+    fileScopeCache.clear();
   }
 
   // Create basic blocks (forward pass for branch targets)
@@ -484,6 +503,8 @@ llvm::Error MLIRToLLVM70::translateFuncOp(Operation *op) {
   }
 
   currentSubprogram = nullptr;
+  currentSubprogramFile = llvm::StringRef();
+  fileScopeCache.clear();
   b.clearDebugLocation();
 
   return llvm::Error::success();

--- a/src/numba_cuda_mlir/mlir_debuginfo.py
+++ b/src/numba_cuda_mlir/mlir_debuginfo.py
@@ -465,6 +465,8 @@ class DIBuilder:
         self.di_local_vars: dict[str, ir.Attribute] = {}
         self.di_expression = None
         self.arg_names: set[str] = set()
+        self._source_files: dict[str, tuple[str, str]] = {}
+        self.di_file_scopes: dict[str, ir.Attribute] = {}
 
         raw_path = getattr(loc, "filename", None)
         if not raw_path or not raw_path.strip():
@@ -479,6 +481,7 @@ class DIBuilder:
                 return
 
         self.valid = True
+        self._main_path = raw_path
         filename = os.path.basename(raw_path)
         directory = os.path.dirname(raw_path) or "."
 
@@ -513,6 +516,26 @@ class DIBuilder:
             f"subprogramFlags = {_mlir_string_attr(subprogram_flags)}"
             f">"
         )
+
+    def add_source_file(self, raw_path):
+        """Register an additional source file for line mapping.
+
+        Instructions inlined from other Python files carry locations in
+        those files. Each registered file becomes a DILexicalBlockFile
+        scoped to the subprogram, so its lines land in the correct DWARF
+        file entry instead of being mis-filed under the subprogram's
+        file.
+        """
+        if not self.valid or not raw_path or not raw_path.strip():
+            return
+        if raw_path == self._main_path or raw_path in self._source_files:
+            return
+        if raw_path.startswith("<") and raw_path.endswith(">"):
+            if not linecache.getlines(raw_path):
+                return
+        filename = os.path.basename(raw_path)
+        directory = os.path.dirname(raw_path) or "."
+        self._source_files[raw_path] = (filename, directory)
 
     def add_local_variable(self, name, line, numba_type, *, arg_index=None):
         """Register a local variable for debug info emission."""
@@ -551,6 +574,22 @@ class DIBuilder:
             var_keys.append((var.name, key))
         attrs["numba_cuda_mlir.di_expr"] = "#llvm.di_expression<>"
 
+        scope_keys = []
+        for i, (raw_path, (filename, directory)) in enumerate(self._source_files.items()):
+            file_str = (
+                f"#llvm.di_file<{_mlir_string_attr(filename)} in {_mlir_string_attr(directory)}>"
+            )
+            scope_str = (
+                f"#llvm.di_lexical_block_file<"
+                f"scope = {self._di_sp_str}, "
+                f"file = {file_str}, "
+                f"discriminator = 0"
+                f">"
+            )
+            key = f"numba_cuda_mlir.di_file_scope_{i}"
+            attrs[key] = scope_str
+            scope_keys.append((raw_path, key))
+
         attr_strs = ", ".join(f"{k} = {v}" for k, v in attrs.items())
         module_str = f"module attributes {{{attr_strs}}} {{}}"
 
@@ -560,5 +599,7 @@ class DIBuilder:
             self.di_expression = helper.operation.attributes["numba_cuda_mlir.di_expr"]
             for name, key in var_keys:
                 self.di_local_vars[name] = helper.operation.attributes[key]
+            for raw_path, key in scope_keys:
+                self.di_file_scopes[raw_path] = helper.operation.attributes[key]
 
         return self.di_subprogram

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -209,6 +209,14 @@ class MLIRLower(object):
                 if self._debug_full:
                     # Variable-level debug info only for full debug, not lineinfo-only
                     self._collect_debug_variables()
+                # Instructions inlined from other Python files carry
+                # locations in those files; register each so it gets a
+                # DILexicalBlockFile scope and a DWARF file entry.
+                for block in self.blocks.values():
+                    for inst in block.body:
+                        inst_path = getattr(inst.loc, "filename", None)
+                        if inst_path:
+                            self._di_builder.add_source_file(inst_path)
                 self._di_subprogram = self._di_builder.build()
                 self.mlir_loc = ir.Location.fused(
                     [self.mlir_loc], metadata=self._di_subprogram, context=ctx
@@ -883,6 +891,12 @@ extern "C" __global__ void
                         line=self.loc.line,
                         col=self.loc.col,
                     )
+                    # Locations in files other than the subprogram's get
+                    # a DILexicalBlockFile scope so DWARF attributes them
+                    # to the correct file.
+                    file_scope = self._di_builder.di_file_scopes.get(self.loc.filename)
+                    if file_scope is not None:
+                        inst_loc = ir.Location.fused([inst_loc], metadata=file_scope)
                     with inst_loc:
                         self.lower_inst(inst)
                 else:

--- a/tests/lineinfo_usecases.py
+++ b/tests/lineinfo_usecases.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Device functions in a separate file for multi-file lineinfo tests."""
+
+from numba_cuda_mlir import cuda
+
+
+@cuda.jit(device=True)
+def helper_scale_offset(x):
+    y = x * 2.0
+    y = y + 1.0
+    return y

--- a/tests/test_lineinfo.py
+++ b/tests/test_lineinfo.py
@@ -14,6 +14,8 @@ import os
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir import types, compiler, testing
 
+from lineinfo_usecases import helper_scale_offset
+
 
 def k(x: cuda.DeviceNDArray):
     x[0] = x[0] + 1
@@ -78,3 +80,53 @@ def test_ptx_lineinfo_device_function():
         """,
         ptx,
     )
+
+
+def kernel_calling_helper(x):
+    x[0] = helper_scale_offset(x[0])
+
+
+def _check_multi_file_ptx(ptx):
+    kernel_name = os.path.basename(inspect.getsourcefile(kernel_calling_helper))
+    helper_name = os.path.basename(inspect.getsourcefile(helper_scale_offset.py_func))
+
+    # The exact surviving body line depends on optimization, so only
+    # require that some line is attributed to the helper's file, and
+    # that the kernel's own lines still reference the kernel's file.
+    testing.filecheck(
+        f"""
+        CHECK-DAG: .file\t[[kernel_id:[0-9]+]] "{{{{.*}}}}{kernel_name}"
+        CHECK-DAG: .file\t[[helper_id:[0-9]+]] "{{{{.*}}}}{helper_name}"
+        CHECK-DAG: .loc\t[[helper_id]] {{{{[0-9]+}}}}
+        CHECK-DAG: .loc\t[[kernel_id]] {{{{[0-9]+}}}}
+        """,
+        ptx,
+    )
+
+
+def test_ptx_lineinfo_multiple_source_files():
+    """Code inlined from another file gets its own .file entry.
+
+    Lines from an inlined device function must be attributed to that
+    function's source file (via a DILexicalBlockFile scope), not
+    mis-filed under the calling kernel's file.
+    """
+    ptx, _ = compiler.compile_ptx(
+        kernel_calling_helper,
+        types.void(types.float32[:]),
+        lineinfo=True,
+    )
+    assert ptx is not None
+    _check_multi_file_ptx(ptx)
+
+
+def test_ptx_debug_multiple_source_files():
+    """Full debug info attributes cross-file lines the same way lineinfo does."""
+    ptx, _ = compiler.compile_ptx(
+        kernel_calling_helper,
+        types.void(types.float32[:]),
+        debug=True,
+        opt=False,
+    )
+    assert ptx is not None
+    _check_multi_file_ptx(ptx)


### PR DESCRIPTION
Fixes #224.

Debug locations whose file is not the subprogram's file were scoped directly to the subprogram, which pairs their line numbers with the kernel's file. They are now scoped through a `DILexicalBlockFile` that references the correct `DIFile`, so the PTX line table lists each source file and the `.loc` directives reference the right one. This applies to `lineinfo=True` and `debug=True`, on both compute-capability paths:

- sm_100+ path (LLVM 20+ dialect): the `DIBuilder` registers each additional source file found among the function's instruction locations and emits one `#llvm.di_lexical_block_file` per file, scoped to the subprogram. Instruction locations in those files get the matching scope attribute.
- LLVM70 path (below sm_100): the translator keeps a per-function cache of `DILexicalBlockFile` scopes keyed by filename, created through the newly bound `LLVMDIBuilderCreateLexicalBlockFile` entry point, and uses one whenever an instruction's file differs from the subprogram's.

**Tests** (new, in `tests/test_lineinfo.py`)

- A kernel calling a device function in another file, under `lineinfo=True` and `debug=True`, yields `.file` entries for both files, a `.loc` referencing the helper's, and `.loc` entries for the kernel's own lines still referencing the kernel's.

Written by Chris' bot, rewritten repeatedly by Chris.
