### PR TITLE
Allow importing `cext` on CPU only machines

### DIFF
--- a/cext/launcher/cuda_helper.cpp
+++ b/cext/launcher/cuda_helper.cpp
@@ -15,6 +15,9 @@ const char* get_cuda_error(CUresult res) {
 }
 
 PyObject* get_max_grid_size(PyObject*, PyObject *args) {
+    if (!ensure_cuda_available())
+        return NULL;
+
     int device_id;
     if (!PyArg_ParseTuple(args, "i", &device_id))
         return NULL;
@@ -38,6 +41,9 @@ PyObject* get_max_grid_size(PyObject*, PyObject *args) {
 }
 
 PyObject* get_compute_capability(PyObject*, PyObject*) {
+    if (!ensure_cuda_available())
+        return NULL;
+
     int major, minor;
     CUdevice dev;
     CUresult res = g_cuDeviceGet(&dev, 0);

--- a/cext/launcher/cuda_loader.cpp
+++ b/cext/launcher/cuda_loader.cpp
@@ -5,6 +5,8 @@
 #include "cuda_loader.h"
 #include "cuda_helper.h"
 
+#include <string>
+
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -119,7 +121,13 @@ FOREACH_CUDA_FUNCTION_TO_LOAD(DEFINE_CUDA_FUNCTION_GLOBAL)
         return ErrorRaised;
 
 
-Status cuda_loader_init() {
+// A missing driver is deliberately NOT fatal here so cuda may be imported 
+// on a cpu only machine. 
+static bool g_cuda_available = false;
+static std::string g_cuda_load_error;
+
+
+static Status load_cuda_driver() {
     // loader is static to keep the handle alive for the lifetime of the process
 #ifdef _WIN32
     static DynamicLoader loader("nvcuda.dll");
@@ -139,4 +147,47 @@ Status cuda_loader_init() {
     FOREACH_CUDA_FUNCTION_TO_LOAD(GET_PROC_ADDRESS)
 
     return OK;
+}
+
+Status cuda_loader_init() {
+    if (load_cuda_driver()) {
+        g_cuda_available = true;
+        return OK;
+    }
+
+    // defer driver search to ensure_cuda_available().
+    g_cuda_available = false;
+    if (PyErr_Occurred()) {
+        PyObject *type, *value, *tb;
+        PyErr_Fetch(&type, &value, &tb);
+        if (value) {
+            PyObject* str = PyObject_Str(value);
+            if (str) {
+                const char* c = PyUnicode_AsUTF8(str);
+                if (c)
+                    g_cuda_load_error = c;
+                Py_DECREF(str);
+            }
+        }
+        Py_XDECREF(type);
+        Py_XDECREF(value);
+        Py_XDECREF(tb);
+        PyErr_Clear();
+    }
+    if (g_cuda_load_error.empty())
+        g_cuda_load_error = "the CUDA driver library (libcuda.so.1) could not be loaded";
+    return OK;
+}
+
+bool cuda_is_available() {
+    return g_cuda_available;
+}
+
+Status ensure_cuda_available() {
+    if (g_cuda_available)
+        return OK;
+    return raise(PyExc_RuntimeError,
+                 "CUDA is not available: %s. A working NVIDIA driver is required "
+                 "for GPU operations (importing numba_cuda_mlir succeeds without one).",
+                 g_cuda_load_error.c_str());
 }

--- a/cext/launcher/cuda_loader.cpp
+++ b/cext/launcher/cuda_loader.cpp
@@ -121,8 +121,8 @@ FOREACH_CUDA_FUNCTION_TO_LOAD(DEFINE_CUDA_FUNCTION_GLOBAL)
         return ErrorRaised;
 
 
-// A missing driver is deliberately NOT fatal here so cuda may be imported 
-// on a cpu only machine. 
+// A missing driver is deliberately NOT fatal here so cuda may be imported
+// on a cpu only machine.
 static bool g_cuda_available = false;
 static std::string g_cuda_load_error;
 

--- a/cext/launcher/cuda_loader.h
+++ b/cext/launcher/cuda_loader.h
@@ -9,6 +9,10 @@
 
 Status cuda_loader_init();
 
+bool cuda_is_available();
+
+Status ensure_cuda_available();
+
 #define FOREACH_CUDA_FUNCTION_TO_LOAD(X) \
     X(cuInit, 2000) \
     X(cuLibraryLoadData, 12000) \

--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -117,6 +117,8 @@ private:
 };
 
 Result<CudaLibrary> load_cuda_library(const void* cubin) {
+    if (!ensure_cuda_available())
+        return ErrorRaised;
     // Get current context to associate with library.
     // We require that CUDA is already initialized and a context exists.
     // This is typically done by numba's driver or by the user.

--- a/cext/launcher/module.cpp
+++ b/cext/launcher/module.cpp
@@ -45,5 +45,9 @@ PyMODINIT_FUNC PyInit__cext() {
     if (!llvm_downgrade_init(m.get()))
         return nullptr;
 
+    if (PyModule_AddIntConstant(m.get(), "cuda_available",
+                                cuda_is_available() ? 1 : 0) < 0)
+        return nullptr;
+
     return m.release();
 }


### PR DESCRIPTION
This PR fixes an issue exposed by import changes between `0.3.0` and `0.4.1` where the package can't import due to a missing driver on CPU only machines. It seems to come down to `cext` not being importable, I think the best change might be to fix it at the c++ level so that another quiet import change that hits `cext` doesn't reintroduce this later. That is what is proposed here. 