### PR TITLE
Move benchmarks and doc_examples to norecursedirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ conflicts = [
 
 [tool.pytest.ini_options]
 testpaths = [ "tests" ]
+norecursedirs = [ "benchmarks", "doc_examples" ]
 filterwarnings = [
     "ignore:The CUDA driver version is older than the backend version:RuntimeWarning",
     "ignore:Grid size.*will likely result in GPU under-utilization:",
@@ -197,7 +198,6 @@ markers = [
 addopts = [
     "--reruns=3",
     "--only-rerun=Call to cuMemAlloc results in CUDA_ERROR_ILLEGAL_ADDRESS",
-    "--ignore=tests/doc_examples",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This closes #136 with the solution @acosmicflamingo proposed.