### PR TITLE
Keep compiler locals in value form

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -3335,8 +3335,7 @@ extern "C" __global__ void
             # BaseTuple multi-assign uses per-element stack slots.
             if isinstance(var_type, types.UniTuple) and not isinstance(slot, tuple):
                 return tuple(
-                    memref.load(memref=slot, indices=[index_of(i)])
-                    for i in range(var_type.count)
+                    memref.load(memref=slot, indices=[index_of(i)]) for i in range(var_type.count)
                 )
 
             return self._load_stack_slot(var_type, slot)

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -733,7 +733,7 @@ extern "C" __global__ void
                 for elem_type in self._tuple_element_types(var_type)
             )
 
-        mlir_type = self.get_storage_type(var_type)
+        mlir_type = self.get_mlir_type(var_type)
         if not _is_valid_memref_element_type(mlir_type):
             return self.alloca(mlir_type, count=1)
 
@@ -748,7 +748,7 @@ extern "C" __global__ void
                 if isinstance(var_type, types.NoneType):
                     continue
                 if isinstance(var_type, types.UniTuple):
-                    elem_mlir_type = self.get_storage_type(var_type.dtype)
+                    elem_mlir_type = self.get_mlir_type(var_type.dtype)
                     memref_type = ir.MemRefType.get(
                         shape=[var_type.count], element_type=elem_mlir_type
                     )
@@ -759,7 +759,7 @@ extern "C" __global__ void
                 if isinstance(var_type, types.BaseTuple):
                     self.varmap[var_name] = self._allocate_stack_slot_for_type(var_type)
                     continue
-                mlir_type = self.get_storage_type(var_type)
+                mlir_type = self.get_mlir_type(var_type)
 
                 if not _is_valid_memref_element_type(mlir_type):
                     self.varmap[var_name] = self.alloca(mlir_type, count=1)
@@ -3307,11 +3307,10 @@ extern "C" __global__ void
             trace("index=%s", index)
             loadOp = memref.load(memref=slot, indices=[index])
             trace("loadOp=%s", loadOp)
-            return self.from_storage(var_type, loadOp)
+            return loadOp
 
         trace("Loading %s from LLVM stack slot", type(var_type).__name__)
-        stored = llvm.load(res=self.get_storage_type(var_type), addr=slot)
-        return self.from_storage(var_type, stored)
+        return llvm.load(res=self.get_mlir_type(var_type), addr=slot)
 
     def _load_var(self, var: numba_ir.Var) -> Any:
         """
@@ -3336,9 +3335,7 @@ extern "C" __global__ void
             # BaseTuple multi-assign uses per-element stack slots.
             if isinstance(var_type, types.UniTuple) and not isinstance(slot, tuple):
                 return tuple(
-                    self.from_storage(
-                        var_type.dtype, memref.load(memref=slot, indices=[index_of(i)])
-                    )
+                    memref.load(memref=slot, indices=[index_of(i)])
                     for i in range(var_type.count)
                 )
 
@@ -3412,18 +3409,16 @@ extern "C" __global__ void
 
         if self.nrt.type_has_nrt_meminfo(var_type) and isinstance(value, ir.Value):
             if isinstance(slot.type, MemRefType):
-                old = self.from_storage(var_type, memref.load(memref=slot, indices=[index_of(0)]))
+                old = memref.load(memref=slot, indices=[index_of(0)])
             else:
-                old_stored = llvm.load(res=self.get_storage_type(var_type), addr=slot)
-                old = self.from_storage(var_type, old_stored)
+                old = llvm.load(res=self.get_mlir_type(var_type), addr=slot)
             self.decref(var_type, old)
 
-        stored_value = self.as_storage(var_type, value) if isinstance(value, ir.Value) else value
         if isinstance(slot.type, MemRefType):
-            memref.store(value=stored_value, memref=slot, indices=[index_of(0)])
+            memref.store(value=value, memref=slot, indices=[index_of(0)])
         else:
             trace("Storing %s to LLVM stack slot", type(var_type).__name__)
-            llvm.store(value=stored_value, addr=slot)
+            llvm.store(value=value, addr=slot)
 
     def store_var(self, var, value):
         """
@@ -3448,8 +3443,7 @@ extern "C" __global__ void
             if isinstance(var_type, types.UniTuple) and not isinstance(slot, tuple):
                 assert isinstance(value, (tuple, list))
                 for i, elem in enumerate(value):
-                    stored = self.as_storage(var_type.dtype, elem)
-                    memref.store(value=stored, memref=slot, indices=[index_of(i)])
+                    memref.store(value=elem, memref=slot, indices=[index_of(i)])
                 return
 
             self._store_stack_slot(var_type, slot, value)

--- a/tests/test_local_stack_slots.py
+++ b/tests/test_local_stack_slots.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+import numpy as np
+
+from numba_cuda_mlir import cuda
+
+
+def _compiled_mlir(kernel):
+    return next(iter(kernel.inspect_mlir().values()))
+
+
+def _assert_memref_slot(mlir, slot_type):
+    escaped_type = re.escape(slot_type)
+    assert re.search(rf"memref\.alloca\(\) : {escaped_type}", mlir)
+    assert re.search(rf"memref\.store .* : {escaped_type}", mlir)
+    assert re.search(rf"memref\.load .* : {escaped_type}", mlir)
+
+
+def _assert_llvm_slot(mlir, slot_type):
+    escaped_type = re.escape(slot_type)
+    assert re.search(rf"llvm\.alloca .* x {escaped_type}", mlir)
+    assert re.search(rf"llvm\.store .* : {escaped_type}, !llvm\.ptr", mlir)
+    assert re.search(rf"llvm\.load .* -> {escaped_type}", mlir)
+
+
+def test_multiply_assigned_boolean_uses_value_type_slot():
+    @cuda.jit
+    def kernel(inp, out):
+        flag = inp[0] > 0
+        if inp[1] > 0:
+            flag = inp[2] > 0
+        else:
+            flag = inp[3] > 0
+        out[0] = flag
+
+    out = np.zeros(1, dtype=np.bool_)
+    for inp, expected in (
+        (np.array([1, 1, 0, 1], dtype=np.int32), False),
+        (np.array([0, 0, 0, 1], dtype=np.int32), True),
+    ):
+        kernel[1, 1](inp, out)
+        assert out[0] == expected
+
+    mlir = _compiled_mlir(kernel)
+    _assert_memref_slot(mlir, "memref<1xi1>")
+    assert "memref<?xi8" in mlir
+
+
+def test_multiply_assigned_unituple_uses_value_type_slots():
+    @cuda.jit
+    def kernel(inp, out):
+        flags = (inp[0] > 0, inp[1] > 0)
+        if inp[2] > 0:
+            flags = (inp[3] > 0, inp[4] > 0)
+        else:
+            flags = (inp[5] > 0, inp[6] > 0)
+        out[0] = flags[0]
+        out[1] = flags[1]
+
+    out = np.zeros(2, dtype=np.bool_)
+    for inp, expected in (
+        (np.array([0, 0, 1, 1, 0, 0, 1], dtype=np.int32), [True, False]),
+        (np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int32), [False, True]),
+    ):
+        kernel[1, 1](inp, out)
+        np.testing.assert_array_equal(out, expected)
+
+    _assert_memref_slot(_compiled_mlir(kernel), "memref<2xi1>")
+
+
+def test_multiply_assigned_heterogeneous_tuple_uses_value_type_slots():
+    @cuda.jit
+    def kernel(inp, bool_out, int_out):
+        pair = (inp[0] > 0, inp[1])
+        if inp[2] > 0:
+            pair = (inp[3] > 0, inp[4])
+        else:
+            pair = (inp[5] > 0, inp[6])
+        bool_out[0] = pair[0]
+        int_out[0] = pair[1]
+
+    bool_out = np.zeros(1, dtype=np.bool_)
+    int_out = np.zeros(1, dtype=np.int32)
+    for inp, expected in (
+        (np.array([0, 0, 1, 1, 8, 0, 9], dtype=np.int32), (True, 8)),
+        (np.array([1, 1, 0, 0, 8, 0, 9], dtype=np.int32), (False, 9)),
+    ):
+        kernel[1, 1](inp, bool_out, int_out)
+        assert (bool_out[0], int_out[0]) == expected
+
+    mlir = _compiled_mlir(kernel)
+    _assert_memref_slot(mlir, "memref<1xi1>")
+    _assert_memref_slot(mlir, "memref<1xi32>")
+
+
+def test_multiply_assigned_optional_uses_value_type_llvm_slot():
+    @cuda.jit
+    def kernel(inp, out):
+        value = inp[0]
+        if inp[1] > 0:
+            value = None
+        else:
+            value = inp[2]
+        if value is None:
+            out[0] = np.int32(-1)
+        else:
+            out[0] = value
+
+    out = np.zeros(1, dtype=np.int32)
+    for inp, expected in (
+        (np.array([7, 1, 9], dtype=np.int32), -1),
+        (np.array([7, 0, 9], dtype=np.int32), 9),
+    ):
+        kernel[1, 1](inp, out)
+        assert out[0] == expected
+
+    mlir = _compiled_mlir(kernel)
+    _assert_llvm_slot(mlir, "!llvm.struct<(i32, i1)>")
+    assert "!llvm.struct<(i32, i8)>" not in mlir


### PR DESCRIPTION
Multiply-assigned locals were allocated stack slots in their storage type (i8 for booleans, i8 struct members for Optionals) and every store and load went through an `as_storage`/`from_storage` conversion. The slots now use the value type (`i1`, `struct<(i32, i1)>`) and the conversions are gone. Arrays, records, and ctypes storage keep their storage representation.

For a multiply-assigned Optional local the None flag now stays in predicate registers (`mov.pred`) instead of round-tripping through 16-bit registers (`mov.u16` plus `setp`). For plain boolean locals ptxas already erased the difference.

**Tests**

- `tests/test_local_stack_slots.py` (new): multiply-assigned boolean, boolean UniTuple, heterogeneous tuple, and Optional locals get value-typed slots and compute correct results; array element storage stays i8.

**Verification:** (sm_89, Windows) the 4 new tests go red->green on the slot-type assertions; the full tests/ suite shows no new failures against main (4347 passed).

Written by Chris' bot, rewritten repeatedly by Chris.
