### PR TITLE
Only read back kernel error code when debug=True

### DIFF
--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -1462,6 +1462,11 @@ struct KernelDispatcher {
     std::vector<bool> constant_arg_flags;
     ProfileMap arg_profiles;
     FamilyMap kernel_families;
+    // When false, launches stay asynchronous: the post-launch device-side error
+    // readback (cuCtxSynchronize + cuMemcpyDtoH of __numba_cuda_mlir_error_code)
+    // is skipped. Mirrors numba-cuda, which only surfaces kernel exceptions
+    // (raise/assert/bounds checks) when the kernel is compiled with debug=True.
+    bool debug = false;
 };
 
 void get_pyarg_types(PyObject* const* pyargs, Py_ssize_t num_pyargs,
@@ -2090,16 +2095,36 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
                      error_name, get_cuda_error(res));
     }
 
-    // Check for kernel error codes (set by device-side assertion replacements)
-    if (!check_kernel_error_code(kernel_iter->second.cukernel.lib))
-        return ErrorRaised;
+    // Check for kernel error codes (set by device-side assertion replacements).
+    // Only done for debug kernels, matching numba-cuda: this is the sole point
+    // that forces a synchronous cuCtxSynchronize + status readback, so gating it
+    // here keeps ordinary (debug=False) launches asynchronous. check_kernel_error_code
+    // synchronizes the context, so track whether that already happened.
+    bool context_synchronized = false;
+    if (dispatcher.debug) {
+        if (!check_kernel_error_code(kernel_iter->second.cukernel.lib))
+            return ErrorRaised;
+        context_synchronized = true;
+    }
 
-    // Copy scalar records back from device to host
-    for (const auto& info : helper->record_copies) {
-        CUresult copy_res = g_cuMemcpyDtoH(info.host_ptr, info.device_ptr, info.size);
-        if (copy_res != CUDA_SUCCESS) {
-            return raise(PyExc_RuntimeError, "Failed to copy record back from device: %s",
-                         get_cuda_error(copy_res));
+    // Copy scalar records back from device to host. These blocking DtoH copies
+    // read results the kernel just wrote, so the kernel must have completed
+    // first. Previously that ordering came for free from the (unconditional)
+    // error-check synchronization above; now that the check is debug-gated,
+    // synchronize here when it did not already run.
+    if (!helper->record_copies.empty()) {
+        if (!context_synchronized) {
+            CUresult sync_res = g_cuCtxSynchronize();
+            if (sync_res != CUDA_SUCCESS)
+                return raise(PyExc_RuntimeError, "Failed to synchronize CUDA context: %s",
+                             get_cuda_error(sync_res));
+        }
+        for (const auto& info : helper->record_copies) {
+            CUresult copy_res = g_cuMemcpyDtoH(info.host_ptr, info.device_ptr, info.size);
+            if (copy_res != CUDA_SUCCESS) {
+                return raise(PyExc_RuntimeError, "Failed to copy record back from device: %s",
+                             get_cuda_error(copy_res));
+            }
         }
     }
 
@@ -2126,13 +2151,14 @@ Result<std::vector<bool>> parse_constant_arg_flags(PyObject* tuple) {
 }
 
 int KernelDispatcher_init(PyObject* self, PyObject* args, PyObject* kwargs) {
-    const char* keywords[] = {"", "", "", nullptr};
+    const char* keywords[] = {"", "", "", "debug", nullptr};
     PyObject* compile_func = nullptr;
     PyObject* py_constant_arg_flags = nullptr;
     PyObject* ensure_context_func = Py_None;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O", const_cast<char**>(keywords),
+    int debug = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|Op", const_cast<char**>(keywords),
                                      &compile_func, &py_constant_arg_flags,
-                                     &ensure_context_func))
+                                     &ensure_context_func, &debug))
         return -1;
 
     Result<std::vector<bool>> constant_arg_flags = parse_constant_arg_flags(py_constant_arg_flags);
@@ -2142,6 +2168,7 @@ int KernelDispatcher_init(PyObject* self, PyObject* args, PyObject* kwargs) {
     dispatcher.compile_func = newref(compile_func);
     dispatcher.ensure_context_func = newref(ensure_context_func);
     dispatcher.constant_arg_flags = std::move(*constant_arg_flags);
+    dispatcher.debug = (debug != 0);
     return 0;
 }
 

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -1565,10 +1565,15 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         return MLIRDispatcherType(self)
 
     def _new_kernel_dispatcher(self):
+        # Only debug kernels pay the per-launch device-side error readback
+        # (cuCtxSynchronize + status D2H). This mirrors numba-cuda, where kernel
+        # exceptions (raise/assert/bounds checks) surface only with debug=True;
+        # debug=False launches stay asynchronous.
         return _cext.KernelDispatcher(
             self._compile,
             get_constant_args(self.py_func),
             _ensure_numba_cuda_context,
+            debug=bool(self.targetoptions.get("debug", False)),
         )
 
     @property

--- a/tests/test_kernel_exceptions.py
+++ b/tests/test_kernel_exceptions.py
@@ -1,7 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for kernel exception handling via error code mechanism."""
+"""Tests for kernel exception handling via error code mechanism.
+
+Kernel exceptions (``raise``/``assert``/bounds checks) surface to the host only
+when the kernel is compiled with ``debug=True``. This matches numba-cuda and the
+documented behavior in ``docs/source/user/cudapysupported.rst``: with
+``debug=False`` the launch stays asynchronous and no device-side error readback
+(``cuCtxSynchronize`` + status ``cuMemcpyDtoH``) is performed. See issue #232.
+"""
 
 import numpy as np
 import pytest
@@ -13,40 +20,74 @@ from numba_cuda_mlir.tools import get_gpu_compute_capability
 
 @cuda.jit
 def tuple_bounds_check_kernel(out, idx):
-    """Kernel that accesses a tuple with bounds checking."""
+    """Kernel that accesses a tuple with bounds checking (debug=False)."""
     t = (10, 20, 30)
     out[0] = t[idx]
 
 
-def test_tuple_index_out_of_bounds_raises():
-    """Test that out-of-bounds tuple access raises IndexError."""
+@cuda.jit(debug=True, opt=False)
+def tuple_bounds_check_kernel_debug(out, idx):
+    """Same kernel compiled with debug=True, so kernel exceptions surface."""
+    t = (10, 20, 30)
+    out[0] = t[idx]
+
+
+def test_tuple_index_in_bounds():
+    """In-bounds tuple access works regardless of debug."""
     out = cuda.device_array(1, dtype=np.int32)
 
-    # Valid access should work
     tuple_bounds_check_kernel[1, 1](out, 0)
-    result = out.copy_to_host()
-    assert result[0] == 10
+    cuda.synchronize()
+    assert out.copy_to_host()[0] == 10
 
     tuple_bounds_check_kernel[1, 1](out, 2)
-    result = out.copy_to_host()
-    assert result[0] == 30
-
-    # Out-of-bounds access should raise IndexError
-    with pytest.raises(IndexError, match="out of bounds"):
-        tuple_bounds_check_kernel[1, 1](out, 5)
+    cuda.synchronize()
+    assert out.copy_to_host()[0] == 30
 
 
-def test_multiple_errors_first_wins():
-    """Test that when multiple errors occur, the first one wins."""
+def test_tuple_index_out_of_bounds_raises_with_debug():
+    """Out-of-bounds tuple access raises IndexError when debug=True."""
     out = cuda.device_array(1, dtype=np.int32)
 
-    # First error should be captured
-    with pytest.raises(IndexError):
-        tuple_bounds_check_kernel[1, 1](out, 100)
+    # Valid access should still work.
+    tuple_bounds_check_kernel_debug[1, 1](out, 0)
+    cuda.synchronize()
+    assert out.copy_to_host()[0] == 10
 
-    # Error should be reset, so another error can be raised
+    # Out-of-bounds access should raise IndexError. With debug=True the check
+    # runs inside the (now synchronous) launch, so the launch call itself raises.
+    with pytest.raises(IndexError, match="out of bounds"):
+        tuple_bounds_check_kernel_debug[1, 1](out, 5)
+        cuda.synchronize()
+
+
+def test_tuple_index_out_of_bounds_no_raise_without_debug():
+    """With debug=False, kernel exceptions do not surface: the launch stays
+    asynchronous and no device-side error readback is performed."""
+    out = cuda.device_array(1, dtype=np.int32)
+
+    # Out-of-bounds index, but debug=False -> must not raise.
+    tuple_bounds_check_kernel[1, 1](out, 5)
+    cuda.synchronize()
+
+
+def test_error_resets_between_launches():
+    """The device error global is reset after each debug=True readback, so a
+    later launch surfaces its own error instead of being masked (or falsely
+    triggered) by a prior launch's code.
+
+    With debug=True the readback runs inside the launch call, so each launch
+    raises directly.
+    """
+    out = cuda.device_array(1, dtype=np.int32)
+
+    # First launch's out-of-bounds access is read back and raises.
     with pytest.raises(IndexError):
-        tuple_bounds_check_kernel[1, 1](out, 200)
+        tuple_bounds_check_kernel_debug[1, 1](out, 100)
+
+    # The global was reset to 0, so the second launch surfaces its own error.
+    with pytest.raises(IndexError):
+        tuple_bounds_check_kernel_debug[1, 1](out, 200)
 
 
 def test_error_global_in_ptx():
@@ -111,12 +152,18 @@ def test_ltoir_device_functions_share_error_global():
     ],
 )
 def test_raise_only_kernel(debug, opt):
-    """Test that raise-only kernel compiles and surfaces RuntimeError to host."""
+    """A raise-only kernel compiles; the RuntimeError surfaces only with debug=True."""
 
     @cuda.jit(debug=debug, opt=opt)
     def k():
         raise RuntimeError("Error")
 
-    with pytest.raises(RuntimeError, match="Runtime error in kernel"):
+    if debug:
+        with pytest.raises(RuntimeError, match="Runtime error in kernel"):
+            k[1, 1]()
+            cuda.synchronize()
+    else:
+        # debug=False: exceptions are not checked; the launch is asynchronous
+        # and must not raise.
         k[1, 1]()
         cuda.synchronize()


### PR DESCRIPTION
## Summary

Every kernel launch was **synchronous**, eliminating host/device overlap and multi-stream concurrency (issue #232).

Root cause: `check_kernel_error_code` runs after every successful launch (`cext/launcher/kernel.cpp`) and always performs a blocking `cuCtxSynchronize` + 4-byte `cuMemcpyDtoH` to read the device-side `__numba_cuda_mlir_error_code` global. Because `_ensure_error_global` defines that global in **every** compilation unit, the check never takes its symbol-not-found early exit, so the synchronization happens on every launch of every kernel.

## Fix

Gate the error readback on `debug`, mirroring numba-cuda (`_Kernel.launch` reads the error code only for debug kernels) and the documented contract that `raise`/`assert` only take effect with `debug=True`:

- **`cext/launcher/kernel.cpp`** — `check_kernel_error_code` (the sole `cuCtxSynchronize` + status D2H in the launch path) now runs only when `dispatcher.debug`. The `debug` flag is parsed in `KernelDispatcher_init` (optional 4th arg, backward-compatible).
- **`src/numba_cuda_mlir/descriptor.py`** — passes `debug=` through `_new_kernel_dispatcher` (the sole dispatcher construction site).
- The eager scalar-record (`record_copies`) writeback previously relied on that unconditional sync for kernel-completion ordering; a local `cuCtxSynchronize` preserves it when the debug check didn't already run (`ctx_guard` holds the launch context through this path, so it targets the correct context).

## Behavior change

With `debug=False`, kernel `raise`/`assert`/bounds-checks no longer surface at launch (they surface with `debug=True`). This matches numba-cuda, the docs, and both linked issues. Genuine async launch errors now surface at the next synchronization point — correct CUDA async semantics.

## Verification (on RTX 5880 Ada, CUDA 13.x, numba-cuda-mlir 0.4.1 + this change)

Issue #232 reproducer:

| | launch call | event after record |
|---|---|---|
| Before | **0.4383 s** (synchronous) | `pending: False` (already complete) |
| After | **0.0001 s** (async) | `pending: True` |

Exception gating preserved:
- `debug=True` out-of-bounds → `IndexError: Index out of bounds in kernel` ✅
- `debug=True` `raise` → `RuntimeError: Runtime error in kernel` ✅
- `debug=False` out-of-bounds → no raise (async) ✅

## Tests

`tests/test_kernel_exceptions.py` updated to the debug-gated contract (raising cases use `debug=True`; a new case asserts no-raise for `debug=False`). The canonical `tests/numba_cuda_tests/cudapy/test_exception.py` was already written debug-gated and passes unchanged. Audited repo-wide: no other test expects a device-side kernel exception from a `debug=False` launch, and `descriptor.py` is the sole `_cext.KernelDispatcher` construction site.

Fixes #232

---

### PLC Local Security Evidence (Advisory)

Branch: `fix/async-kernel-launch-232` · HEAD: `6fc58dd`

Local advisory checks only. Authoritative release gates remain Pulse, SonarQube, Coverity, BlackDuck, nSpect, ScanSpect, OSRB, and Anchore — none of the rows below are release-gate results.

| Check | Status | Tool | Details | Artifact |
|-------|--------|------|---------|----------|
| Secrets | SKIP | Pulse Secret Scanner | Pulse registry unreachable (not `docker login`'d locally; advisory) | `.plc/security/pulse-secret-scan.json` |
| SAST | PASS | Semgrep (bundled rules) | 0 high, 0 medium, 0 low on changed files | `.plc/security/semgrep.json` |
| Dependencies | WARN | pip-audit / osv-scanner | Source changed but no manifest/lockfile in scope — no dependencies modified in this change | `.plc/security/` |
| License | N/A | — | No dependencies added | — |
| Container | N/A | — | No container in this change | — |
| Security Review | PASS | inline | 0 high findings — launcher sync-gating + C++ arg parse; no auth/crypto/input-validation/secret surface, no new allocations | inline in PR diff |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
