### PR TITLE
Honor planner dynamic shared-memory minima

### DIFF
--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -84,6 +84,24 @@ Extensions that consume launch metadata during the earlier AST-transform phase
 must opt in with ``uses_launch_config = True`` so launch qualification is active
 before whole-function planning begins.
 
+When generated code needs a minimum amount of dynamic shared memory, record it
+with
+:py:func:`~numba_cuda_mlir.extending.set_required_dynamic_shared_memory`.
+Repeated calls keep the largest requirement. At launch, Numba-CUDA-MLIR uses
+the larger of this compile-time requirement and the user's configured
+``sharedmem`` value. The configured value remains the specialization and
+configure-cache key; the minimum only adjusts the native launch.
+
+.. code-block:: python
+
+   from numba_cuda_mlir.extending import set_required_dynamic_shared_memory
+
+   class ScratchPlanner(WholeFunctionPlanner):
+       def run(self):
+           required_bytes = plan_scratch_storage(self.state.func_ir)
+           set_required_dynamic_shared_memory(self.state, required_bytes)
+           return False
+
 Register every planner before compiling a dispatcher that needs it.
 Registration does not invalidate an overload that the dispatcher has already
 compiled and cached in memory; a planner registered later applies only when a
@@ -99,6 +117,8 @@ cache key. In-memory overload reuse is unchanged.
 .. autofunction:: numba_cuda_mlir.extending.register_planner
 
 .. autofunction:: numba_cuda_mlir.extending.require_launch_config
+
+.. autofunction:: numba_cuda_mlir.extending.set_required_dynamic_shared_memory
 
 Typing
 ------

--- a/src/numba_cuda_mlir/_whole_function_planners.py
+++ b/src/numba_cuda_mlir/_whole_function_planners.py
@@ -3,6 +3,7 @@
 
 """Whole-function extension planning after device-function inlining."""
 
+import operator
 from threading import RLock
 
 from numba_cuda_mlir._launch_config import (
@@ -11,6 +12,9 @@ from numba_cuda_mlir._launch_config import (
 )
 from numba_cuda_mlir.numba_cuda.core import postproc
 from numba_cuda_mlir.numba_cuda.core.ir_utils import build_definitions, simplify_CFG
+
+
+_REQUIRED_DYNAMIC_SHARED_MEMORY_KEY = "required_dynamic_shared_memory"
 
 
 class _RequireLaunchConfig(RuntimeError):
@@ -122,6 +126,29 @@ def require_launch_config(state) -> dict:
     return launch_config
 
 
+def set_required_dynamic_shared_memory(state, size_in_bytes) -> None:
+    """Record the minimum dynamic shared memory required by this compile.
+
+    Repeated calls retain the largest requirement. The value affects the
+    eventual launch without changing the configured launch specialization key.
+    """
+
+    if isinstance(size_in_bytes, bool):
+        raise TypeError("required dynamic shared memory must be an integer")
+    try:
+        size_in_bytes = operator.index(size_in_bytes)
+    except TypeError:
+        raise TypeError("required dynamic shared memory must be an integer") from None
+    if size_in_bytes < 0:
+        raise ValueError("required dynamic shared memory cannot be negative")
+
+    metadata = getattr(state, "metadata", None)
+    if not isinstance(metadata, dict):
+        raise TypeError("compiler state metadata must be a dict")
+    previous = metadata.get(_REQUIRED_DYNAMIC_SHARED_MEMORY_KEY, 0)
+    metadata[_REQUIRED_DYNAMIC_SHARED_MEMORY_KEY] = max(previous, size_in_bytes)
+
+
 def register_planner(planner_cls):
     """Register a whole-function planner class.
 
@@ -132,4 +159,9 @@ def register_planner(planner_cls):
     return _planner_registry.register(planner_cls)
 
 
-__all__ = ["WholeFunctionPlanner", "register_planner", "require_launch_config"]
+__all__ = [
+    "WholeFunctionPlanner",
+    "register_planner",
+    "require_launch_config",
+    "set_required_dynamic_shared_memory",
+]

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -673,25 +673,28 @@ class _ArgMarshaller:
                     if active_launch_config is not None
                     else self._available_launch_config
                 )
-                configured_sharedmem = _normalize_launch_sharedmem(launcher_config["sharedmem"])
-                effective_sharedmem = max(configured_sharedmem, required_dynamic_shared_memory)
-                if effective_sharedmem > configured_sharedmem:
-                    adjusted_launcher_key = (
-                        id(active_kernel_dispatcher),
-                        active_launch_config_generation,
-                        effective_sharedmem,
-                    )
-                    if adjusted_launcher_key != self._adjusted_launcher_key:
-                        self._adjusted_launcher = LaunchConfiguration(
-                            active_kernel_dispatcher,
-                            launcher_config["grid"],
-                            launcher_config["block"],
-                            self._launch_stream,
+                # Plain launch configurations may preserve backend-specific
+                # sharedmem sentinels; normalize only when an adjustment is needed.
+                if required_dynamic_shared_memory:
+                    configured_sharedmem = _normalize_launch_sharedmem(launcher_config["sharedmem"])
+                    effective_sharedmem = max(configured_sharedmem, required_dynamic_shared_memory)
+                    if effective_sharedmem > configured_sharedmem:
+                        adjusted_launcher_key = (
+                            id(active_kernel_dispatcher),
+                            active_launch_config_generation,
                             effective_sharedmem,
-                            launcher_config.get("cluster"),
                         )
-                        self._adjusted_launcher_key = adjusted_launcher_key
-                    launcher = self._adjusted_launcher
+                        if adjusted_launcher_key != self._adjusted_launcher_key:
+                            self._adjusted_launcher = LaunchConfiguration(
+                                active_kernel_dispatcher,
+                                launcher_config["grid"],
+                                launcher_config["block"],
+                                self._launch_stream,
+                                effective_sharedmem,
+                                launcher_config.get("cluster"),
+                            )
+                            self._adjusted_launcher_key = adjusted_launcher_key
+                        launcher = self._adjusted_launcher
 
             if active_launch_config is not None:
                 _compile_arg_types.launch_config = active_launch_config

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -40,6 +40,7 @@ from numba_cuda_mlir.numba_cuda.core.compiler_lock import global_compiler_lock
 from numba_cuda_mlir.numba_cuda.dispatcher import Dispatcher
 from numba_cuda_mlir.numba_cuda.core.options import TargetOptions
 from numba_cuda_mlir._whole_function_planners import (
+    _REQUIRED_DYNAMIC_SHARED_MEMORY_KEY,
     _RequireLaunchConfig,
     _planner_registry,
 )
@@ -434,6 +435,8 @@ class _ArgMarshaller:
         self._launch_config_generation = launch_config_generation
         self._stream_ref = stream_ref
         self._launch_stream = launch_stream
+        self._adjusted_launcher_key = None
+        self._adjusted_launcher = None
         self._sig_cache = {}  # {type_key: (argtypes, fast_ok)}
         self._array_sig_cache = {}  # {type_key: [(argtypes, ((idx, array_key), ...))]}
 
@@ -637,6 +640,7 @@ class _ArgMarshaller:
                     active_kernel_dispatcher,
                     active_launch_config_generation,
                     active_launch_config,
+                    required_dynamic_shared_memory,
                 ) = ready_launch
                 if (
                     active_kernel_dispatcher is not self._kernel_dispatcher
@@ -663,6 +667,31 @@ class _ArgMarshaller:
                     self._launch_config = active_launch_config
                     self._kernel_dispatcher = active_kernel_dispatcher
                     self._launch_config_generation = active_launch_config_generation
+
+                launcher_config = (
+                    active_launch_config
+                    if active_launch_config is not None
+                    else self._available_launch_config
+                )
+                configured_sharedmem = _normalize_launch_sharedmem(launcher_config["sharedmem"])
+                effective_sharedmem = max(configured_sharedmem, required_dynamic_shared_memory)
+                if effective_sharedmem > configured_sharedmem:
+                    adjusted_launcher_key = (
+                        id(active_kernel_dispatcher),
+                        active_launch_config_generation,
+                        effective_sharedmem,
+                    )
+                    if adjusted_launcher_key != self._adjusted_launcher_key:
+                        self._adjusted_launcher = LaunchConfiguration(
+                            active_kernel_dispatcher,
+                            launcher_config["grid"],
+                            launcher_config["block"],
+                            self._launch_stream,
+                            effective_sharedmem,
+                            launcher_config.get("cluster"),
+                        )
+                        self._adjusted_launcher_key = adjusted_launcher_key
+                    launcher = self._adjusted_launcher
 
             if active_launch_config is not None:
                 _compile_arg_types.launch_config = active_launch_config
@@ -2432,17 +2461,21 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
 
         if configured_launch_config is None and not self._requires_launch_config:
             kernel_dispatcher = self._c
+            compile_result = self.overloads.get(argtypes)
             if (
                 configured_kernel_dispatcher is not kernel_dispatcher
                 or configured_launch_config_generation is not None
-                or self.overloads.get(argtypes) is None
+                or compile_result is None
             ):
                 return None
             # Launch sensitivity or the native dispatcher may have changed
             # during the unlocked overload lookup.
             if self._requires_launch_config or self._c is not kernel_dispatcher:
                 return None
-            return kernel_dispatcher, None, None
+            required_dynamic_shared_memory = compile_result.metadata.get(
+                _REQUIRED_DYNAMIC_SHARED_MEMORY_KEY, 0
+            )
+            return kernel_dispatcher, None, None, required_dynamic_shared_memory
 
         with self._launch_config_lock:
             launch_config = (
@@ -2453,8 +2486,9 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             if launch_config is None:
                 return None
             launch_config_key = _launch_config_key(launch_config)
+            compile_result = self._find_launch_config_overload_locked(argtypes, launch_config_key)
             if (
-                self._find_launch_config_overload_locked(argtypes, launch_config_key) is None
+                compile_result is None
                 or configured_launch_config_generation != self._launch_config_generation
                 or self._launch_config_dispatchers.get(launch_config_key)
                 is not configured_kernel_dispatcher
@@ -2465,6 +2499,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 configured_kernel_dispatcher,
                 configured_launch_config_generation,
                 launch_config,
+                compile_result.metadata.get(_REQUIRED_DYNAMIC_SHARED_MEMORY_KEY, 0),
             )
 
     @global_compiler_lock
@@ -2520,8 +2555,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 "kernel precompilation completed without publishing a matching overload"
             )
 
+        required_dynamic_shared_memory = compile_result.metadata.get(
+            _REQUIRED_DYNAMIC_SHARED_MEMORY_KEY, 0
+        )
         if launch_config is None:
-            return self._c, None, None
+            return self._c, None, None, required_dynamic_shared_memory
         if not self._requires_launch_config and configured_launch_config is not None:
             if self._is_kernel_dispatcher_registered(
                 configured_launch_config,
@@ -2532,6 +2570,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     configured_kernel_dispatcher,
                     configured_launch_config_generation,
                     configured_launch_config,
+                    required_dynamic_shared_memory,
                 )
             # A retained marshaller may outlive recompile() or removal of the
             # extension that originally opted it into launch specialization.
@@ -2540,9 +2579,19 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             kernel_dispatcher, generation = self._get_launch_config_dispatcher_and_generation(
                 launch_config
             )
-            return kernel_dispatcher, generation, launch_config
+            return (
+                kernel_dispatcher,
+                generation,
+                launch_config,
+                required_dynamic_shared_memory,
+            )
         kernel_dispatcher, generation = self._get_kernel_dispatcher_and_generation(launch_config)
-        return kernel_dispatcher, generation, launch_config
+        return (
+            kernel_dispatcher,
+            generation,
+            launch_config,
+            required_dynamic_shared_memory,
+        )
 
     def _raise_ambiguous(self, argtypes, tied):
         sigs_str = "\n".join(f"{sig_args} -> none" for sig_args in tied)

--- a/src/numba_cuda_mlir/extending/__init__.py
+++ b/src/numba_cuda_mlir/extending/__init__.py
@@ -29,6 +29,7 @@ from numba_cuda_mlir._whole_function_planners import (
     WholeFunctionPlanner,
     register_planner,
     require_launch_config,
+    set_required_dynamic_shared_memory,
 )
 
 lowering_registry = LoweringRegistry()
@@ -48,6 +49,7 @@ __all__ = [
     "refresh_registries",
     "register_planner",
     "require_launch_config",
+    "set_required_dynamic_shared_memory",
     "overload",
     "overload_attribute",
     "overload_method",

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -40,6 +40,7 @@ class _Dispatcher:
             configured_kernel_dispatcher,
             configured_launch_config_generation,
             configured_launch_config,
+            0,
         )
 
     def _remember_kernel_dispatcher(
@@ -277,7 +278,7 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
                 configured_launch_config_generation,
             )
         )
-        ready_launch = launch_kernel_dispatcher, 7, active_launch_config
+        ready_launch = launch_kernel_dispatcher, 7, active_launch_config, 0
         return ready_launch
 
     def launch_configuration(
@@ -362,7 +363,7 @@ def test_arg_marshaller_rebinds_for_retained_launch_extension_snapshot(monkeypat
 
     def prepare_for_launch(*args):
         prepare_calls.append(args)
-        return refreshed_kernel_dispatcher, 8, launch_config
+        return refreshed_kernel_dispatcher, 8, launch_config, 0
 
     dispatcher._get_ready_launch = lambda *args: None
     dispatcher._prepare_for_launch = prepare_for_launch
@@ -418,6 +419,113 @@ def test_arg_marshaller_ready_launch_does_not_mutate_dispatcher_registration():
     marshaller()
 
     assert dispatcher.remembered_dispatchers == []
+
+
+def test_arg_marshaller_raises_and_caches_dynamic_shared_memory_minimum(monkeypatch):
+    kernel_dispatcher = object()
+    launch_config = {
+        "grid": (3, 1, 1),
+        "block": (64, 1, 1),
+        "sharedmem": 128,
+        "cluster": (2, 1, 1),
+    }
+    dispatcher = _Dispatcher()
+    dispatcher._requires_launch_config = True
+    launches = []
+    original_launches = []
+
+    def get_ready_launch(*args):
+        return kernel_dispatcher, 7, launch_config, 4096
+
+    def launch_configuration(
+        native_dispatcher,
+        griddim,
+        blockdim,
+        stream,
+        sharedmem,
+        cluster,
+    ):
+        launches.append(
+            (
+                native_dispatcher,
+                griddim,
+                blockdim,
+                stream,
+                sharedmem,
+                cluster,
+            )
+        )
+        return lambda value: ("adjusted", value)
+
+    dispatcher._get_ready_launch = get_ready_launch
+    dispatcher._prepare_for_launch = lambda *args: pytest.fail(
+        "ready launches must not take the compiler lock"
+    )
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+    marshaller = _ArgMarshaller(
+        lambda value: original_launches.append(value),
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+        available_launch_config=launch_config,
+        kernel_dispatcher=kernel_dispatcher,
+        launch_config_generation=7,
+        launch_stream=123,
+    )
+
+    assert marshaller(1) == ("adjusted", 1)
+    assert marshaller(2) == ("adjusted", 2)
+    assert launches == [
+        (
+            kernel_dispatcher,
+            (3, 1, 1),
+            (64, 1, 1),
+            123,
+            4096,
+            (2, 1, 1),
+        )
+    ]
+    assert not original_launches
+    assert marshaller._launch_config is launch_config
+    assert marshaller._available_launch_config is launch_config
+    assert launch_config["sharedmem"] == 128
+
+
+def test_arg_marshaller_preserves_larger_user_shared_memory(monkeypatch):
+    kernel_dispatcher = object()
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 8192,
+        "cluster": None,
+    }
+    dispatcher = _Dispatcher()
+    dispatcher._requires_launch_config = True
+    dispatcher._get_ready_launch = lambda *args: (
+        kernel_dispatcher,
+        3,
+        launch_config,
+        4096,
+    )
+    dispatcher._prepare_for_launch = lambda *args: pytest.fail(
+        "ready launches must not take the compiler lock"
+    )
+    monkeypatch.setattr(
+        descriptor_mod,
+        "LaunchConfiguration",
+        lambda *args: pytest.fail("a larger configured sharedmem must be preserved"),
+    )
+    launches = []
+    marshaller = _ArgMarshaller(
+        lambda value: launches.append(value) or "original",
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+        available_launch_config=launch_config,
+        kernel_dispatcher=kernel_dispatcher,
+        launch_config_generation=3,
+    )
+
+    assert marshaller(7) == "original"
+    assert launches == [7]
 
 
 def test_configure_records_normalized_launch_config(monkeypatch):
@@ -567,9 +675,12 @@ def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
     retained_generation = marshaller._launch_config_generation
     observed_configs = []
 
+    compile_result = _CompileResult((types.int32,))
+    compile_result.metadata["required_dynamic_shared_memory"] = 2048
+
     def compile_result_for(argtypes, launch_config):
         observed_configs.append(launch_config)
-        return object()
+        return compile_result
 
     monkeypatch.setattr(dispatcher, "_compile_result_for", compile_result_for)
     dispatcher.extensions.clear()
@@ -587,6 +698,7 @@ def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
         retained_kernel_dispatcher,
         retained_generation,
         retained_launch_config,
+        2048,
     )
     assert observed_configs == [retained_launch_config]
 
@@ -604,8 +716,19 @@ def test_ready_launch_known_signature_avoids_lock_and_overload_iteration(monkeyp
         def __iter__(self):
             pytest.fail("the unlocked readiness check must not iterate overloads")
 
-    dispatcher.overloads = ExactOnlyOverloads({(): object()})
+    compile_result = _CompileResult(())
+    compile_result.metadata["required_dynamic_shared_memory"] = 1024
+    dispatcher.overloads = ExactOnlyOverloads({(): compile_result})
     monkeypatch.setattr(_planner_registry, "_planners", [object()])
+
+    assert dispatcher._get_ready_launch(
+        (),
+        None,
+        None,
+        dispatcher._c,
+        None,
+    ) == (dispatcher._c, None, None, 1024)
+    compile_result.metadata.pop("required_dynamic_shared_memory")
 
     monkeypatch.setattr(
         descriptor_mod.global_compiler_lock,
@@ -639,7 +762,7 @@ def test_prelaunch_rechecks_readiness_after_global_compiler_lock(monkeypatch):
     def publish_during_acquire():
         original_acquire()
         events.append("lock")
-        dispatcher.overloads[()] = object()
+        dispatcher.overloads[()] = _CompileResult(())
 
     monkeypatch.setattr(dispatcher, "_get_ready_launch", observe_ready_launch)
     monkeypatch.setattr(descriptor_mod.global_compiler_lock, "acquire", publish_during_acquire)
@@ -681,7 +804,9 @@ def test_ready_launch_validates_specialized_state():
     argtypes = (types.int32,)
     launch_key = descriptor_mod._launch_config_key(launch_config)
     kernel_dispatcher, generation = dispatcher._get_kernel_dispatcher_and_generation(launch_config)
-    dispatcher._launch_config_overloads[(argtypes, launch_key)] = object()
+    compile_result = _CompileResult(argtypes)
+    compile_result.metadata["required_dynamic_shared_memory"] = 2048
+    dispatcher._launch_config_overloads[(argtypes, launch_key)] = compile_result
 
     assert dispatcher._get_ready_launch(
         argtypes,
@@ -689,7 +814,7 @@ def test_ready_launch_validates_specialized_state():
         launch_config,
         kernel_dispatcher,
         generation,
-    ) == (kernel_dispatcher, generation, launch_config)
+    ) == (kernel_dispatcher, generation, launch_config, 2048)
     assert (
         dispatcher._get_ready_launch(
             argtypes,

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -528,6 +528,83 @@ def test_arg_marshaller_preserves_larger_user_shared_memory(monkeypatch):
     assert launches == [7]
 
 
+def test_arg_marshaller_preserves_raw_sharedmem_without_required_minimum(monkeypatch):
+    class RegisteredPlannerRegistry:
+        has_planners = True
+
+    kernel_dispatcher = object()
+    available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": "dynamic",
+        "cluster": None,
+    }
+    dispatcher = _Dispatcher()
+    dispatcher._get_ready_launch = lambda *args: (
+        kernel_dispatcher,
+        None,
+        None,
+        0,
+    )
+    dispatcher._prepare_for_launch = lambda *args: pytest.fail(
+        "ready launches must not take the compiler lock"
+    )
+    monkeypatch.setattr(
+        descriptor_mod,
+        "_planner_registry",
+        RegisteredPlannerRegistry(),
+    )
+    launches = []
+    marshaller = _ArgMarshaller(
+        lambda value: launches.append(value) or "original",
+        dispatcher=dispatcher,
+        available_launch_config=available_launch_config,
+        kernel_dispatcher=kernel_dispatcher,
+    )
+
+    assert marshaller(7) == "original"
+    assert launches == [7]
+
+
+def test_arg_marshaller_rejects_raw_sharedmem_when_minimum_requires_adjustment(
+    monkeypatch,
+):
+    class RegisteredPlannerRegistry:
+        has_planners = True
+
+    kernel_dispatcher = object()
+    available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": "dynamic",
+        "cluster": None,
+    }
+    dispatcher = _Dispatcher()
+    dispatcher._get_ready_launch = lambda *args: (
+        kernel_dispatcher,
+        None,
+        None,
+        4096,
+    )
+    dispatcher._prepare_for_launch = lambda *args: pytest.fail(
+        "ready launches must not take the compiler lock"
+    )
+    monkeypatch.setattr(
+        descriptor_mod,
+        "_planner_registry",
+        RegisteredPlannerRegistry(),
+    )
+    marshaller = _ArgMarshaller(
+        lambda value: pytest.fail("invalid sharedmem must fail before launch"),
+        dispatcher=dispatcher,
+        available_launch_config=available_launch_config,
+        kernel_dispatcher=kernel_dispatcher,
+    )
+
+    with pytest.raises(TypeError, match="sharedmem.*integer-convertible"):
+        marshaller(7)
+
+
 def test_configure_records_normalized_launch_config(monkeypatch):
     captured = []
 

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -22,6 +22,7 @@ from numba_cuda_mlir.extending import (
     WholeFunctionPlanner,
     register_planner,
     require_launch_config,
+    set_required_dynamic_shared_memory,
 )
 from numba_cuda_mlir.numba_cuda.compiler import run_frontend
 from numba_cuda_mlir.numba_cuda.core import ir
@@ -193,6 +194,32 @@ def test_launch_config_promotion_is_visible_to_later_planners_in_same_attempt():
     assert observed == promoted
     assert promoted[0]["sharedmem"] == 0
     assert tracker.required is True
+
+
+def test_required_dynamic_shared_memory_is_max_accumulated():
+    state = SimpleNamespace(metadata={})
+
+    set_required_dynamic_shared_memory(state, 1024)
+    set_required_dynamic_shared_memory(state, np.int64(512))
+    set_required_dynamic_shared_memory(state, 4096)
+
+    assert state.metadata["required_dynamic_shared_memory"] == 4096
+
+
+@pytest.mark.parametrize("value", [True, False, 1.5, "1024", object()])
+def test_required_dynamic_shared_memory_rejects_non_integer_values(value):
+    with pytest.raises(TypeError, match="must be an integer"):
+        set_required_dynamic_shared_memory(SimpleNamespace(metadata={}), value)
+
+
+def test_required_dynamic_shared_memory_rejects_negative_values():
+    with pytest.raises(ValueError, match="cannot be negative"):
+        set_required_dynamic_shared_memory(SimpleNamespace(metadata={}), -1)
+
+
+def test_required_dynamic_shared_memory_requires_compiler_metadata():
+    with pytest.raises(TypeError, match="metadata must be a dict"):
+        set_required_dynamic_shared_memory(SimpleNamespace(), 0)
 
 
 def test_ir_is_repaired_between_modifying_planners():
@@ -658,3 +685,34 @@ def test_planner_can_request_distinct_launch_config_specializations(
 
     configured_after_demand = kernel.configure(1, 32)
     assert configured_after_demand._launch_config["block"] == (32, 1, 1)
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_planner_dynamic_shared_memory_minimum_reaches_launch(
+    isolated_global_planners,
+):
+    required_bytes = 32 * 1024
+    last_scratch_index = required_bytes // np.dtype(np.int32).itemsize - 1
+
+    class ScratchPlanner(WholeFunctionPlanner):
+        def run(self):
+            if self.is_device_function:
+                return False
+            set_required_dynamic_shared_memory(self.state, required_bytes)
+            return False
+
+    register_planner(ScratchPlanner)
+
+    @cuda.jit
+    def kernel(output):
+        scratch = cuda.shared.array(0, dtype=types.int32)
+        if cuda.threadIdx.x == 0:
+            scratch[last_scratch_index] = 42
+            output[0] = scratch[last_scratch_index]
+
+    output = np.zeros(1, dtype=np.int32)
+    kernel[1, 1](output)
+
+    assert output[0] == 42
+    [compile_result] = kernel.overloads.values()
+    assert compile_result.metadata["required_dynamic_shared_memory"] == required_bytes


### PR DESCRIPTION
## Summary

- Add public `set_required_dynamic_shared_memory(state, size_in_bytes)`
  planner metadata with integer validation and max accumulation.
- Retain the exact matching compile result during prelaunch and return its
  dynamic shared-memory requirement separately from launch-specialization
  metadata.
- Launch with `max(configured_sharedmem, required_sharedmem)` through a cached
  replacement launcher while preserving the native dispatcher, grid, block,
  stream, cluster, and configure-cache identity.
- Keep the user's raw configured shared-memory value untouched when no
  adjustment is needed; opaque backend sentinels are not coerced merely because
  a planner is registered.
- Document the extension API and cover launch/cache behavior plus a real
  dynamic-shared-memory kernel.

## Why this is needed

A generated kernel may know its scratch requirement only after extension
planning has selected and specialized its device providers. For example,
`cuda.coop.numba_mlir` materializes the CUB implementations used by a kernel,
reads their exact `sizeof` / `alignof` metadata, and packs every `TempStorage`
use. If that plan crosses the device's default shared-memory allowance, the
generated code needs opt-in dynamic shared memory even though the user never
wrote a byte count at the launch site.

Without a compile-result-to-launch channel, the kernel can be compiled against a
larger scratch region while `kernel[grid, block](...)` still launches with zero
dynamic shared memory. Asking users to repeat an implementation-owned byte count
in every launch also leaks provider details and becomes stale when the block
shape, dtype, algorithm, or provider changes.

This PR gives planners a public way to publish that per-compile minimum and
makes the launcher honor it. It is the upstream contract CCCL needs to replace
its provisional private `__launch_min_sharedmem_bytes__` bookkeeping.

## Concrete use

The user-facing kernel remains ordinary and does not duplicate provider scratch
metadata:

```python
import cuda.coop.numba_mlir as coop
from numba_cuda_mlir import cuda

ITEMS_PER_THREAD = 2

@cuda.jit
def shared_temp_storage_kernel(values, result):
    scratch = coop.TempStorage()
    items = coop.ThreadData(items_per_thread=ITEMS_PER_THREAD, dtype=values.dtype)
    scanned = coop.ThreadData(items_per_thread=ITEMS_PER_THREAD, dtype=values.dtype)

    coop.block.load(values, items, temp_storage=scratch)
    coop.block.exclusive_sum(items, scanned, temp_storage=scratch)
    coop.block.radix_sort_keys(
        scanned, begin_bit=0, end_bit=16, temp_storage=scratch
    )
    coop.block.store(result, scanned, temp_storage=scratch)

# The extension owns the scratch calculation; there is no hidden byte count here.
shared_temp_storage_kernel[1, 128](values, result)
```

A simplified extension-side planner looks like this:

```python
from numba_cuda_mlir.extending import (
    WholeFunctionPlanner,
    register_planner,
    require_launch_config,
    set_required_dynamic_shared_memory,
)

@register_planner
class CoopPlanner(WholeFunctionPlanner):
    def run(self):
        if not has_coop_markers(self.state.func_ir):
            return False

        launch = require_launch_config(self.state)
        plan = rewrite_and_plan_coop(
            self.state.func_ir,
            block_dim=launch["block"],
        )
        set_required_dynamic_shared_memory(
            self.state,
            plan.dynamic_shared_bytes,
        )
        return plan.modified
```

`require_launch_config()` promotes exact configured facts into the current
compiler attempt. `set_required_dynamic_shared_memory()` records the planned
minimum on that exact result. Repeated calls keep the largest minimum, so
independently composed providers remain safe.

## Launch behavior

If the planner records 64 KiB, `kernel[grid, block](...)` launches with 64 KiB.
If the user explicitly configures 96 KiB, the launch keeps 96 KiB. In general,
the native launch uses
`max(configured_sharedmem, required_sharedmem)` while preserving the selected
native dispatcher, grid, block, stream, and cluster.

The configured value remains the specialization and `configure()` cache key.
The derived minimum does not create a second user-visible specialization or
mutate the configured launch object; an adjusted native launcher is created only
when needed and cached for reuse. Provider planning remains compile-time, with
no runtime provider dispatch or provider-specific resource argument in the
Python API.

## Stack

Depends on #202, then #203. #202 is merged; this branch is based exactly on the
refreshed #203 head
`85f03e212e27a6901e50403f8f55bae6c893af9e`.

GitHub cannot use a branch in the fork as the base of an upstream pull request,
so this PR targets `main` and temporarily includes #203. The isolated #238
changes are:

- `ade1ada` Honor planner dynamic shared-memory minima
- `9a12e9b` Preserve raw shared memory without adjustment

Exact isolated range: `85f03e2..9a12e9b`.

Fixes #61.

## Validation

- Exact local head: `9a12e9b75545b471d262fd233794a10f1ab48d47`.
- Exact-source focused descriptor/planner suite: 91 passed on SM120 and
  91 passed on SM75.
- Regressions cover max accumulation, adjusted-launcher caching, configured
  versus required minima, and opaque raw shared-memory values both when no
  adjustment is needed and when a positive minimum requires comparison.
- 32 KiB dynamic-shared-memory launch smoke: passed independently on SM120 and
  SM75.
- Changed-range pre-commit and `git diff --check`: passed.
- Fresh exact-head GitHub Actions:
  [run 30375428432](https://github.com/NVIDIA/numba-cuda-mlir/actions/runs/30375428432)
  completed green with 124 successful jobs and 4 expected skips; the complete
  PR rollup is 128 passed, 4 skipped, and zero failed or pending.

Co-authored-by: Codex 5.6 Sol Ultra Fast
