### PR TITLE
Retry kernel compilation with scalar literals

### DIFF
--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -238,6 +238,7 @@ Status check_kernel_error_code(const CudaLibrary& lib) {
 
 enum class ConstantArgType {
     INT64,
+    UINT64,
     BOOL,
     FLOAT64,
     STRING,
@@ -247,6 +248,7 @@ struct ConstantArg {
     ConstantArgType type;
     union {
         int64_t i64;
+        uint64_t u64;
         double f64;
     } value;
     std::string str;
@@ -261,6 +263,13 @@ struct ConstantArg {
         } else {
             value.i64 = static_cast<int64_t>(val);
         }
+    }
+
+    ConstantArg(uint64_t val) :
+        type(ConstantArgType::UINT64),
+        value{}
+    {
+        value.u64 = val;
     }
 
     ConstantArg(bool val) :
@@ -282,6 +291,8 @@ struct ConstantArg {
         case ConstantArgType::INT64:
         case ConstantArgType::BOOL:
             return value.i64 == other.value.i64;
+        case ConstantArgType::UINT64:
+            return value.u64 == other.value.u64;
         case ConstantArgType::FLOAT64:
             // compare bits of two floats directly
             uint64_t this_float_bits, other_float_bits;
@@ -645,16 +656,37 @@ ScalarExtractor get_scalar_extractor(PythonArgKind kind) {
     }
 }
 
+std::vector<bool> effective_constant_arg_flags(
+        const std::vector<bool>& constant_arg_flags,
+        const std::vector<bool>& literal_arg_flags,
+        const std::vector<PyTypeObject*>& arg_types) {
+    assert(constant_arg_flags.size() == literal_arg_flags.size());
+
+    // Tuple/list arguments are flattened before the native launch, while the
+    // flags describe top-level Python parameters. Literal retry rejects that
+    // ABI today, but every profile still needs one safe flag per native arg.
+    std::vector<bool> effective_flags(arg_types.size(), false);
+    const size_t represented_arg_count = std::min(arg_types.size(), constant_arg_flags.size());
+    for (size_t i = 0; i < represented_arg_count; ++i) {
+        // Numba literal typing accepts exact built-in int/bool values, not
+        // int subclasses, IntEnum members, or NumPy integer scalars.
+        bool literal_eligible = arg_types[i] == &PyLong_Type || arg_types[i] == &PyBool_Type;
+        effective_flags[i] = constant_arg_flags[i] || (literal_arg_flags[i] && literal_eligible);
+    }
+    return effective_flags;
+}
+
 struct PythonArgProfile {
     RefPtr<KernelFamily> family;
     std::vector<PythonArgKind> arg_kinds;
+    std::vector<bool> constant_arg_flags;
 
     // Populated on first use: per-arg fast extractors for all-scalar, no-constant profiles.
     // Empty if the profile contains arrays, TMA descriptors, or unsupported scalar types.
     std::vector<ScalarExtractor> fast_extractors;
     bool fast_path_checked = false;
 
-    void maybe_init_fast_path(const std::vector<bool>& constant_flags) {
+    void maybe_init_fast_path() {
         if (fast_path_checked) return;
         fast_path_checked = true;
 
@@ -662,7 +694,7 @@ struct PythonArgProfile {
         std::vector<ScalarExtractor> extractors;
         extractors.reserve(arg_kinds.size());
         for (size_t i = 0; i < arg_kinds.size(); ++i) {
-            if (i < constant_flags.size() && constant_flags[i])
+            if (constant_arg_flags[i])
                 return;  // constant args need the full path
             ScalarExtractor ex = get_scalar_extractor(arg_kinds[i]);
             if (!ex) return;  // unsupported type (array, complex, etc.)
@@ -1062,8 +1094,21 @@ inline Status extract_np_datetime(PyObject* pyobj, bool is_constant, LaunchHelpe
 }
 
 inline Status extract_py_long(PyObject* pyobj, bool is_constant, LaunchHelper& helper) {
-    int64_t value = pylong_as<int64_t>(pyobj);
-    if (PyErr_Occurred()) return ErrorRaised;
+    int64_t value;
+    uint64_t unsigned_value = 0;
+    bool is_unsigned = false;
+    long long signed_value = PyLong_AsLongLong(pyobj);
+    if (PyErr_Occurred()) {
+        if (!PyErr_ExceptionMatches(PyExc_OverflowError)) return ErrorRaised;
+        PyErr_Clear();
+        unsigned long long raw_unsigned_value = PyLong_AsUnsignedLongLong(pyobj);
+        if (PyErr_Occurred()) return ErrorRaised;
+        unsigned_value = static_cast<uint64_t>(raw_unsigned_value);
+        value = static_cast<int64_t>(unsigned_value);
+        is_unsigned = true;
+    } else {
+        value = static_cast<int64_t>(signed_value);
+    }
 
     size_t start_idx = helper.cuargs.size();
     helper.cuargs.push_back(cuda_arg_i64(value));
@@ -1072,6 +1117,8 @@ inline Status extract_py_long(PyObject* pyobj, bool is_constant, LaunchHelper& h
     if (is_constant) {
         if (PyBool_Check(pyobj))
             helper.constants.push_back(ConstantArg(value != 0));
+        else if (is_unsigned)
+            helper.constants.push_back(ConstantArg(unsigned_value));
         else
             helper.constants.push_back(ConstantArg(value));
     }
@@ -1526,6 +1573,7 @@ struct KernelDispatcher {
     PyPtr compile_func;
     PyPtr ensure_context_func;
     std::vector<bool> constant_arg_flags;
+    std::vector<bool> literal_arg_flags;
     ProfileMap arg_profiles;
     FamilyMap kernel_families;
     // When false, launches stay asynchronous: the post-launch device-side error
@@ -1862,13 +1910,20 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
                     std::make_pair(std::move(param_kinds), std::move(new_family))).first;
         }
 
+        std::vector<bool> profile_constant_arg_flags = effective_constant_arg_flags(
+                dispatcher.constant_arg_flags,
+                dispatcher.literal_arg_flags,
+                helper->pyarg_types);
         profile = dispatcher.arg_profiles.insert(
                     std::move(helper->pyarg_types),
-                    PythonArgProfile{family_iter->second, std::move(arg_kinds)});
+                    PythonArgProfile{
+                        family_iter->second,
+                        std::move(arg_kinds),
+                        std::move(profile_constant_arg_flags)});
     }
 
     // Try fast scalar extraction path
-    profile->maybe_init_fast_path(dispatcher.constant_arg_flags);
+    profile->maybe_init_fast_path();
 
     KernelFamily::KernelMap::iterator kernel_iter;
     ContextGuard ctx_guard;
@@ -1930,7 +1985,7 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
     } else {
         // Standard path: full extraction with per-type switch
         if (!extract_cuda_args(pyargs, num_pyargs, profile->arg_kinds,
-                               dispatcher.constant_arg_flags, *helper)) {
+                               profile->constant_arg_flags, *helper)) {
             return ErrorRaised;
         }
 
@@ -2219,23 +2274,37 @@ Result<std::vector<bool>> parse_constant_arg_flags(PyObject* tuple) {
 }
 
 int KernelDispatcher_init(PyObject* self, PyObject* args, PyObject* kwargs) {
-    const char* keywords[] = {"", "", "", "debug", nullptr};
+    const char* keywords[] = {"", "", "", "debug", "literal_arg_flags", nullptr};
     PyObject* compile_func = nullptr;
     PyObject* py_constant_arg_flags = nullptr;
     PyObject* ensure_context_func = Py_None;
+    PyObject* py_literal_arg_flags = Py_None;
     int debug = 0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|Op", const_cast<char**>(keywords),
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|OpO", const_cast<char**>(keywords),
                                      &compile_func, &py_constant_arg_flags,
-                                     &ensure_context_func, &debug))
+                                     &ensure_context_func, &debug, &py_literal_arg_flags))
         return -1;
 
     Result<std::vector<bool>> constant_arg_flags = parse_constant_arg_flags(py_constant_arg_flags);
     if (!constant_arg_flags.is_ok()) return -1;
+    std::vector<bool> literal_arg_flags(constant_arg_flags->size(), false);
+    if (py_literal_arg_flags != Py_None) {
+        Result<std::vector<bool>> parsed = parse_constant_arg_flags(py_literal_arg_flags);
+        if (!parsed.is_ok()) return -1;
+        if (parsed->size() != constant_arg_flags->size()) {
+            PyErr_SetString(
+                PyExc_TypeError,
+                "literal_arg_flags must have the same length as constant_arg_flags");
+            return -1;
+        }
+        literal_arg_flags = std::move(*parsed);
+    }
 
     KernelDispatcher& dispatcher = py_unwrap<KernelDispatcher>(self);
     dispatcher.compile_func = newref(compile_func);
     dispatcher.ensure_context_func = newref(ensure_context_func);
     dispatcher.constant_arg_flags = std::move(*constant_arg_flags);
+    dispatcher.literal_arg_flags = std::move(literal_arg_flags);
     dispatcher.debug = (debug != 0);
     return 0;
 }
@@ -2488,6 +2557,9 @@ struct hash<ConstantArg> {
         switch (arg.type) {
         case ConstantArgType::INT64:
             return std::hash<int64_t>{}(arg.value.i64);
+        case ConstantArgType::UINT64:
+            return std::hash<uint64_t>{}(arg.value.u64)
+                 ^ (static_cast<size_t>(ConstantArgType::UINT64) << 1);
         case ConstantArgType::BOOL:
             // Shift the BOOL tag past the 0/1 payload bit before mixing it into
             // the integer hash, so BOOL values do not just swap INT64 0/1 hashes.

--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -238,6 +238,7 @@ Status check_kernel_error_code(const CudaLibrary& lib) {
 
 enum class ConstantArgType {
     INT64,
+    BOOL,
     FLOAT64,
     STRING,
 };
@@ -262,6 +263,13 @@ struct ConstantArg {
         }
     }
 
+    ConstantArg(bool val) :
+        type(ConstantArgType::BOOL),
+        value{}
+    {
+        value.i64 = static_cast<int64_t>(val);
+    }
+
     explicit ConstantArg(std::string val) :
         type(ConstantArgType::STRING),
         value{},
@@ -272,6 +280,7 @@ struct ConstantArg {
         if (type != other.type) return false;
         switch (type) {
         case ConstantArgType::INT64:
+        case ConstantArgType::BOOL:
             return value.i64 == other.value.i64;
         case ConstantArgType::FLOAT64:
             // compare bits of two floats directly
@@ -1060,8 +1069,12 @@ inline Status extract_py_long(PyObject* pyobj, bool is_constant, LaunchHelper& h
     helper.cuargs.push_back(cuda_arg_i64(value));
     helper.arg_metadata.push_back({ArgMetadata::Kind::Scalar, start_idx, 0});
 
-    if (is_constant)
-        helper.constants.push_back(ConstantArg(value));
+    if (is_constant) {
+        if (PyBool_Check(pyobj))
+            helper.constants.push_back(ConstantArg(value != 0));
+        else
+            helper.constants.push_back(ConstantArg(value));
+    }
 
     return OK;
 }
@@ -2475,6 +2488,11 @@ struct hash<ConstantArg> {
         switch (arg.type) {
         case ConstantArgType::INT64:
             return std::hash<int64_t>{}(arg.value.i64);
+        case ConstantArgType::BOOL:
+            // Shift the BOOL tag past the 0/1 payload bit before mixing it into
+            // the integer hash, so BOOL values do not just swap INT64 0/1 hashes.
+            return std::hash<int64_t>{}(arg.value.i64)
+                 ^ (static_cast<size_t>(ConstantArgType::BOOL) << 1);
         case ConstantArgType::FLOAT64:
             // hash float bits directly
             uint64_t float_bits;

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -174,12 +174,16 @@ typing proceeds, raise
 Kernel dispatch retries such requests with value-specialized argument types as
 long as each request adds at least one new literal position. Pass zero-based,
 top-level argument positions, for example ``ForceLiteralArg({1})``. Runtime
-Python ``int`` and ``bool`` values follow Numba's literal semantics; each
-distinct value receives an exact overload and native constant-argument
-specialization. A request that adds no new positions is diagnosed as a repeated
-literal typing request. Since the recorded position set only grows and is
-bounded by the kernel's parameters, staged requests from multiple planners
-terminate without a fixed retry limit.
+values whose exact type is the built-in Python ``int`` or ``bool`` follow
+Numba's literal semantics; each distinct value receives an exact overload and
+native constant-argument specialization. Recorded positions are conditional
+dispatch hints, not permanent restrictions on later signatures. Other runtime
+types retain their normally inferred type and may compile a generic overload.
+If that compilation itself requests an unsupported literal value, dispatch
+reports the unsupported request. A request that adds no new positions is
+diagnosed as a repeated literal typing request. Since the recorded position set
+only grows and is bounded by the kernel's parameters, staged requests from
+multiple planners terminate without a fixed retry limit.
 
 If a whole-function planner promotes launch metadata before requesting a
 literal, dispatch remembers that launch requirement and activates it for every

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -171,6 +171,23 @@ match (other templates are tried). To force a literal to be resolved before
 typing proceeds, raise
 :py:class:`numba_cuda_mlir.errors.ForceLiteralArg`.
 
+Kernel dispatch retries one such request with value-specialized argument
+types. Pass zero-based, top-level argument positions, for example
+``ForceLiteralArg({1})``. Runtime Python ``int`` and ``bool`` values follow
+Numba's literal semantics; each distinct value receives an exact overload and
+native constant-argument specialization. If a whole-function planner promotes
+launch metadata before requesting a literal, dispatch remembers that launch
+requirement and activates it for the literal-qualified attempt. Combining both
+requirements therefore takes two compiler attempts: the initial generic
+argument typing with in-place launch promotion, followed by literal-qualified
+typing with launch metadata active from the beginning.
+
+Literal retry does not yet support an extension argument that flattens into
+multiple native launch arguments. Such a request raises a ``TypeError`` rather
+than risking a mismatch between top-level positions and native constant flags.
+Struct-like extension arguments are tracked by `issue #60
+<https://github.com/NVIDIA/numba-cuda-mlir/issues/60>`_.
+
 
 Defining new types
 ------------------

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -171,16 +171,23 @@ match (other templates are tried). To force a literal to be resolved before
 typing proceeds, raise
 :py:class:`numba_cuda_mlir.errors.ForceLiteralArg`.
 
-Kernel dispatch retries one such request with value-specialized argument
-types. Pass zero-based, top-level argument positions, for example
-``ForceLiteralArg({1})``. Runtime Python ``int`` and ``bool`` values follow
-Numba's literal semantics; each distinct value receives an exact overload and
-native constant-argument specialization. If a whole-function planner promotes
-launch metadata before requesting a literal, dispatch remembers that launch
-requirement and activates it for the literal-qualified attempt. Combining both
-requirements therefore takes two compiler attempts: the initial generic
-argument typing with in-place launch promotion, followed by literal-qualified
-typing with launch metadata active from the beginning.
+Kernel dispatch retries such requests with value-specialized argument types as
+long as each request adds at least one new literal position. Pass zero-based,
+top-level argument positions, for example ``ForceLiteralArg({1})``. Runtime
+Python ``int`` and ``bool`` values follow Numba's literal semantics; each
+distinct value receives an exact overload and native constant-argument
+specialization. A request that adds no new positions is diagnosed as a repeated
+literal typing request. Since the recorded position set only grows and is
+bounded by the kernel's parameters, staged requests from multiple planners
+terminate without a fixed retry limit.
+
+If a whole-function planner promotes launch metadata before requesting a
+literal, dispatch remembers that launch requirement and activates it for every
+literal-qualified attempt. Combining launch promotion with one literal request
+therefore takes two compiler attempts: the initial generic argument typing with
+in-place launch promotion, followed by literal-qualified typing with launch
+metadata active from the beginning. Each additional staged literal discovery
+adds one compiler attempt.
 
 Literal retry does not yet support an extension argument that flattens into
 multiple native launch arguments. Such a request raises a ``TypeError`` rather

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -2870,7 +2870,6 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self,
         args,
         launch_config_retry_budget=_CONFIGURE_CACHE_STALE_RETRY_LIMIT,
-        literal_retry_budget=1,
     ):
         from numba_cuda_mlir import mlir_compiler
         from numba_cuda_mlir.compiler import CompileResult
@@ -2889,8 +2888,10 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         else:
             argtypes = tuple(typeof(arg) for arg in args)
         runtime_values = tuple(getattr(_compile_arg_types, "values", tuple(args)))
-        argtypes = self._literalize_argtypes(argtypes, runtime_values, abi_arg_count=len(args))
-        if self._literal_arg_positions:
+        with self._launch_config_lock:
+            attempt_literal_arg_positions = self._literal_arg_positions
+            argtypes = self._literalize_argtypes(argtypes, runtime_values, abi_arg_count=len(args))
+        if attempt_literal_arg_positions:
             override_argtypes = argtypes
         active_extensions = getattr(_compile_arg_types, "extensions", _MISSING)
         has_extension_snapshot = active_extensions is not _MISSING
@@ -3054,32 +3055,25 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     override_argtypes=override_argtypes,
                 )
         except errors.ForceLiteralArg as exc:
-            if literal_retry_budget <= 0:
-                raise errors.CompilerError(
-                    "Repeated literal typing request during kernel compilation"
-                ) from exc
             with self._launch_config_lock:
-                changed = self._record_literal_arg_positions(
+                self._record_literal_arg_positions(
                     exc.requested_args,
                     runtime_values,
                     len(args),
                 )
+                made_literal_progress = self._literal_arg_positions != attempt_literal_arg_positions
                 if (
-                    changed
+                    made_literal_progress
                     and active_launch_config is None
                     and launch_config_tracker is not None
                     and launch_config_tracker.required
                 ):
                     self._requires_launch_config = True
-            if not changed:
+            if not made_literal_progress:
                 raise errors.CompilerError(
                     "Repeated literal typing request during kernel compilation"
                 ) from exc
-            return self._compile_impl(
-                args,
-                launch_config_retry_budget,
-                literal_retry_budget - 1,
-            )
+            return self._compile_impl(args, launch_config_retry_budget)
         except _RequireLaunchConfig:
             raise RuntimeError(
                 "whole-function planner requires launch metadata, but compilation "
@@ -3136,11 +3130,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                         "Kernel launch configuration was invalidated repeatedly during compile(); "
                         "retry after concurrent recompile() calls finish."
                     )
-                return self._compile_impl(
-                    args,
-                    launch_config_retry_budget - 1,
-                    literal_retry_budget,
-                )
+                return self._compile_impl(args, launch_config_retry_budget - 1)
             if emit_launch_config_cache_notice:
                 message = (
                     "Persistent disk cache is disabled for launch-config-specialized "

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -1647,18 +1647,20 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         # (cuCtxSynchronize + status D2H). This mirrors numba-cuda, where kernel
         # exceptions (raise/assert/bounds checks) surface only with debug=True;
         # debug=False launches stay asynchronous.
-        constant_args = list(get_constant_args(self.py_func))
+        constant_args = tuple(get_constant_args(self.py_func))
+        literal_args = [False] * len(constant_args)
         for index in self._literal_arg_positions:
-            if index >= len(constant_args):
+            if index >= len(literal_args):
                 raise TypeError(
                     "literal argument request refers to an argument outside the kernel signature"
                 )
-            constant_args[index] = True
+            literal_args[index] = True
         return _cext.KernelDispatcher(
             self._compile,
-            tuple(constant_args),
+            constant_args,
             _ensure_numba_cuda_context,
             debug=bool(self.targetoptions.get("debug", False)),
+            literal_arg_flags=tuple(literal_args),
         )
 
     @property
@@ -1704,10 +1706,17 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         return frozenset(normalized)
 
     @staticmethod
-    def _literal_type_for_value(value, index):
+    def _supports_literal_launch_value(value):
+        # ``types.literal`` supports these built-in scalar values. Keep this
+        # exact: int subclasses, IntEnum, and NumPy scalars are not Numba
+        # literals even when they share the launcher's integer ABI.
+        return type(value) in (int, bool)
+
+    @classmethod
+    def _literal_type_for_value(cls, value, index):
         # Match Numba's literal semantics while limiting launch arguments to
         # scalar kinds understood by the native launcher's constant cache.
-        if not isinstance(value, (bool, int)):
+        if not cls._supports_literal_launch_value(value):
             raise TypeError(
                 "literal launch retry only supports top-level Python int and bool "
                 f"arguments; argument {index} is {type(value).__name__}"
@@ -2614,6 +2623,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     "literal argument request refers to an argument outside the kernel signature"
                 )
             if isinstance(literalized[index], types.Literal):
+                continue
+            if not self._supports_literal_launch_value(values[index]):
                 continue
             literalized[index] = self._literal_type_for_value(values[index], index)
         return tuple(literalized)

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -3,6 +3,7 @@
 import collections
 from contextlib import contextmanager
 from dataclasses import dataclass
+import operator
 import sys
 import sysconfig
 import os
@@ -80,6 +81,7 @@ _DISPATCHER_STATE_ATTRS = (
     "_launch_config_dispatchers",
     "_launch_config_generation",
     "_requires_launch_config",
+    "_literal_arg_positions",
     "_launch_config_cache_misses",
     "_launch_config_cache_hits",
     "_launch_config_cache_notice_emitted",
@@ -587,11 +589,14 @@ class _ArgMarshaller:
                 coerced_types.append(runtime_type)
         return coerced_args, coerced_types
 
-    def _launch(self, argtypes, launch_args):
+    def _launch(self, argtypes, launch_args, launch_values=None):
         """Set compile arg types and invoke the C++ launcher with error handling."""
         # Preserve existing thread-local state for nested launches triggered by
         # compile-time helpers.
+        if launch_values is None:
+            launch_values = launch_args
         previous_types = getattr(_compile_arg_types, "types", _MISSING)
+        previous_values = getattr(_compile_arg_types, "values", _MISSING)
         previous_launch_config = getattr(_compile_arg_types, "launch_config", _MISSING)
         previous_available_launch_config = getattr(
             _compile_arg_types, "available_launch_config", _MISSING
@@ -599,6 +604,7 @@ class _ArgMarshaller:
         previous_extensions = getattr(_compile_arg_types, "extensions", _MISSING)
         try:
             _compile_arg_types.types = argtypes
+            _compile_arg_types.values = tuple(launch_values)
             if self._available_launch_config is not None:
                 _compile_arg_types.available_launch_config = self._available_launch_config
             elif hasattr(_compile_arg_types, "available_launch_config"):
@@ -615,13 +621,31 @@ class _ArgMarshaller:
             active_launch_config_generation = self._launch_config_generation
             launcher = self._launcher
             dispatcher = self._dispatcher
+            literal_prelaunch = bool(getattr(dispatcher, "_literal_arg_positions", ()))
+            literal_prelaunch_check = getattr(
+                dispatcher, "_literal_dispatcher_needs_prelaunch", None
+            )
+            if literal_prelaunch and literal_prelaunch_check is not None:
+                literal_prelaunch = literal_prelaunch_check(
+                    active_launch_config,
+                    active_kernel_dispatcher,
+                    active_launch_config_generation,
+                )
             if dispatcher is not None and (
                 _planner_registry.has_planners
                 or getattr(dispatcher, "_requires_launch_config", False)
                 or self._launch_config is not None
+                or literal_prelaunch
             ):
+                effective_argtypes = tuple(argtypes)
+                if getattr(dispatcher, "_literal_arg_positions", ()):
+                    effective_argtypes = dispatcher._literalize_argtypes(
+                        effective_argtypes,
+                        tuple(launch_values),
+                        abi_arg_count=len(launch_args),
+                    )
                 ready_launch = dispatcher._get_ready_launch(
-                    tuple(argtypes),
+                    effective_argtypes,
                     self._available_launch_config,
                     self._launch_config,
                     self._kernel_dispatcher,
@@ -630,6 +654,7 @@ class _ArgMarshaller:
                 if ready_launch is None:
                     ready_launch = dispatcher._prepare_for_launch(
                         tuple(launch_args),
+                        tuple(launch_values),
                         tuple(argtypes),
                         self._available_launch_config,
                         self._launch_config,
@@ -713,6 +738,11 @@ class _ArgMarshaller:
                     delattr(_compile_arg_types, "types")
             else:
                 _compile_arg_types.types = previous_types
+            if previous_values is _MISSING:
+                if hasattr(_compile_arg_types, "values"):
+                    delattr(_compile_arg_types, "values")
+            else:
+                _compile_arg_types.values = previous_values
             if previous_launch_config is _MISSING:
                 if hasattr(_compile_arg_types, "launch_config"):
                     delattr(_compile_arg_types, "launch_config")
@@ -827,7 +857,7 @@ class _ArgMarshaller:
         flat_args = []
         for arg in coerced_args:
             _flatten_arg(arg, flat_args)
-        result = self._launch(coerced_types, flat_args)
+        result = self._launch(coerced_types, flat_args, coerced_args)
 
         for callback in callbacks:
             callback()
@@ -1576,6 +1606,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self._launch_config_dispatchers = collections.OrderedDict()
         self._launch_config_generation = 0
         self._requires_launch_config = False
+        self._literal_arg_positions = frozenset()
         self._c = self._new_kernel_dispatcher()
         self.extensions = targetoptions.get("extensions") or []
         self._specialized = False
@@ -1616,9 +1647,16 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         # (cuCtxSynchronize + status D2H). This mirrors numba-cuda, where kernel
         # exceptions (raise/assert/bounds checks) surface only with debug=True;
         # debug=False launches stay asynchronous.
+        constant_args = list(get_constant_args(self.py_func))
+        for index in self._literal_arg_positions:
+            if index >= len(constant_args):
+                raise TypeError(
+                    "literal argument request refers to an argument outside the kernel signature"
+                )
+            constant_args[index] = True
         return _cext.KernelDispatcher(
             self._compile,
-            get_constant_args(self.py_func),
+            tuple(constant_args),
             _ensure_numba_cuda_context,
             debug=bool(self.targetoptions.get("debug", False)),
         )
@@ -1627,9 +1665,100 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
     def _launch_config_enabled(self):
         return self._requires_launch_config or _extensions_use_launch_config(self.extensions)
 
+    def _literal_dispatcher_needs_prelaunch(
+        self,
+        launch_config,
+        kernel_dispatcher,
+        launch_config_generation,
+    ):
+        """Whether a retained marshaller predates the active constant flags."""
+        if not self._literal_arg_positions:
+            return False
+        if launch_config is None:
+            return kernel_dispatcher is not self._c
+        return not self._is_kernel_dispatcher_registered(
+            launch_config,
+            kernel_dispatcher,
+            launch_config_generation,
+        )
+
     def _mark_requires_launch_config(self):
         with self._launch_config_lock:
             self._requires_launch_config = True
+
+    @staticmethod
+    def _normalize_literal_arg_positions(positions):
+        normalized = set()
+        for index in positions:
+            if isinstance(index, bool):
+                raise TypeError("literal argument positions must be integers")
+            try:
+                index = operator.index(index)
+            except TypeError:
+                raise TypeError("literal argument positions must be integers") from None
+            if index < 0:
+                raise TypeError("literal argument positions must be non-negative")
+            normalized.add(index)
+        if not normalized:
+            raise TypeError("literal argument retry must request at least one argument")
+        return frozenset(normalized)
+
+    @staticmethod
+    def _literal_type_for_value(value, index):
+        # Match Numba's literal semantics while limiting launch arguments to
+        # scalar kinds understood by the native launcher's constant cache.
+        if not isinstance(value, (bool, int)):
+            raise TypeError(
+                "literal launch retry only supports top-level Python int and bool "
+                f"arguments; argument {index} is {type(value).__name__}"
+            )
+        try:
+            return types.literal(value)
+        except errors.LiteralTypingError as exc:
+            raise TypeError(
+                "literal launch retry only supports top-level Python int and bool "
+                f"arguments; argument {index} is {value!r}"
+            ) from exc
+
+    def _record_literal_arg_positions(self, positions, values, abi_arg_count):
+        positions = self._normalize_literal_arg_positions(positions)
+        values = tuple(values)
+        parameter_count = len(inspect.signature(self.py_func).parameters)
+        if any(index >= parameter_count for index in positions):
+            raise TypeError(
+                "literal argument request refers to an argument outside the kernel signature"
+            )
+        if len(values) != parameter_count:
+            raise TypeError("literal argument retry requires top-level runtime argument values")
+        if abi_arg_count != len(values):
+            raise TypeError(
+                "literal launch retry does not yet support flattened launch arguments; "
+                "extension struct arguments require issue #60"
+            )
+        for index in positions:
+            self._literal_type_for_value(values[index], index)
+
+        with self._launch_config_lock:
+            updated = self._literal_arg_positions | positions
+            if updated == self._literal_arg_positions:
+                return False
+
+            old_dispatchers = [self._c, *self._launch_config_dispatchers.values()]
+            self._literal_arg_positions = updated
+            self.overloads.clear()
+            self._launch_config_overloads.clear()
+            self._launch_config_generation += 1
+            self._launch_config_dispatchers.clear()
+            self._c = self._new_kernel_dispatcher()
+            for dispatcher in old_dispatchers:
+                self._retain_old_dispatcher(dispatcher)
+
+            self._configure_cache.clear()
+            inflight = tuple(self._configure_cache_inflight.values())
+            self._configure_cache_inflight.clear()
+            for event in inflight:
+                event.set()
+        return True
 
     def _get_kernel_dispatcher(self, launch_config):
         dispatcher, _ = self._get_kernel_dispatcher_and_generation(launch_config)
@@ -1730,6 +1859,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 self._launch_config_generation = 0
             if not hasattr(self, "_requires_launch_config"):
                 self._requires_launch_config = False
+            if not hasattr(self, "_literal_arg_positions"):
+                self._literal_arg_positions = frozenset()
             if not hasattr(self, "_launch_config_cache_misses"):
                 self._launch_config_cache_misses = collections.Counter()
             if not hasattr(self, "_launch_config_cache_hits"):
@@ -1960,6 +2091,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             sigs=sigs,
             launch_config_sigs=launch_config_sigs,
             requires_launch_config=self._requires_launch_config,
+            literal_arg_positions=tuple(sorted(self._literal_arg_positions)),
         )
 
     @classmethod
@@ -1973,6 +2105,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         sigs,
         launch_config_sigs=(),
         requires_launch_config=False,
+        literal_arg_positions=(),
     ):
         """Rebuild an MLIRDispatcher after serialization."""
         try:
@@ -1983,6 +2116,13 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self.locals = locals
         self._set_uuid(uuid)
         self._requires_launch_config = bool(requires_launch_config)
+        self._literal_arg_positions = (
+            self._normalize_literal_arg_positions(literal_arg_positions)
+            if literal_arg_positions
+            else frozenset()
+        )
+        if self._literal_arg_positions:
+            self._c = self._new_kernel_dispatcher()
         for sig in sigs:
             self.compile(sig)
         for sig, launch_config_key in launch_config_sigs:
@@ -2006,11 +2146,16 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 return existing
 
         previous_types = getattr(_compile_arg_types, "types", _MISSING)
+        previous_values = getattr(_compile_arg_types, "values", _MISSING)
         previous_launch_config = getattr(_compile_arg_types, "launch_config", _MISSING)
         previous_extensions = getattr(_compile_arg_types, "extensions", _MISSING)
         previous_force_launch_config = getattr(_compile_arg_types, "force_launch_config", _MISSING)
         try:
             _compile_arg_types.types = argtypes
+            _compile_arg_types.values = tuple(
+                argtype.literal_value if isinstance(argtype, types.Literal) else None
+                for argtype in argtypes
+            )
             _compile_arg_types.launch_config = launch_config
             _compile_arg_types.extensions = self.extensions
             _compile_arg_types.force_launch_config = True
@@ -2021,6 +2166,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                     delattr(_compile_arg_types, "types")
             else:
                 _compile_arg_types.types = previous_types
+            if previous_values is _MISSING:
+                if hasattr(_compile_arg_types, "values"):
+                    delattr(_compile_arg_types, "values")
+            else:
+                _compile_arg_types.values = previous_values
             if previous_launch_config is _MISSING:
                 if hasattr(_compile_arg_types, "launch_config"):
                     delattr(_compile_arg_types, "launch_config")
@@ -2348,6 +2498,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         runtime_type, allowing subtype compatibility."""
         if sig_arg == runtime_type:
             return True
+        if isinstance(sig_arg, types.Literal) or isinstance(runtime_type, types.Literal):
+            return False
         # If signature has CPointer and runtime is int (pointer address), accept
         if isinstance(sig_arg, types.CPointer) and isinstance(runtime_type, types.Integer):
             return True
@@ -2370,6 +2522,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         Mirrors numba's Rating.astuple() ordering so lower tuples are better."""
         if sig_arg == runtime_type:
             return (0, 0, 0)
+        if isinstance(sig_arg, types.Literal) or isinstance(runtime_type, types.Literal):
+            return None
         if isinstance(sig_arg, types.Integer) and isinstance(runtime_type, types.Integer):
             if runtime_type.bitwidth <= sig_arg.bitwidth:
                 return (0, 0, 1)
@@ -2436,6 +2590,32 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         best_rate = candidates[0][0]
         tied = [sig_args for rate, sig_args in candidates if rate == best_rate]
         return tied, True
+
+    def _literalize_argtypes(self, argtypes, values, *, abi_arg_count=None):
+        """Apply recorded literal requests to top-level runtime argument types."""
+        argtypes = tuple(argtypes)
+        if not self._literal_arg_positions:
+            return argtypes
+
+        values = tuple(values)
+        if len(values) != len(argtypes):
+            raise TypeError("literal argument retry requires top-level runtime argument values")
+        if abi_arg_count is not None and abi_arg_count != len(values):
+            raise TypeError(
+                "literal launch retry does not yet support flattened launch arguments; "
+                "extension struct arguments require issue #60"
+            )
+
+        literalized = list(argtypes)
+        for index in self._literal_arg_positions:
+            if index >= len(literalized):
+                raise TypeError(
+                    "literal argument request refers to an argument outside the kernel signature"
+                )
+            if isinstance(literalized[index], types.Literal):
+                continue
+            literalized[index] = self._literal_type_for_value(values[index], index)
+        return tuple(literalized)
 
     def _compile_result_for(self, argtypes, launch_config):
         if launch_config is not None:
@@ -2509,6 +2689,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
     def _prepare_for_launch(
         self,
         args,
+        values,
         argtypes,
         available_launch_config,
         configured_launch_config,
@@ -2520,8 +2701,9 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 return _normalize_available_launch_config(available_launch_config)
             return configured_launch_config
 
+        effective_argtypes = self._literalize_argtypes(argtypes, values, abi_arg_count=len(args))
         ready_launch = self._get_ready_launch(
-            argtypes,
+            effective_argtypes,
             available_launch_config,
             configured_launch_config,
             configured_kernel_dispatcher,
@@ -2531,7 +2713,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             return ready_launch
 
         launch_config = active_launch_config()
-        compile_result = self._compile_result_for(argtypes, launch_config)
+        compile_result = self._compile_result_for(effective_argtypes, launch_config)
         if compile_result is None:
             if (
                 launch_config is not None
@@ -2551,7 +2733,10 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 )
             self._compile_impl(list(args))
             launch_config = active_launch_config()
-            compile_result = self._compile_result_for(argtypes, launch_config)
+            effective_argtypes = self._literalize_argtypes(
+                argtypes, values, abi_arg_count=len(args)
+            )
+            compile_result = self._compile_result_for(effective_argtypes, launch_config)
 
         if compile_result is None:
             raise RuntimeError(
@@ -2680,7 +2865,12 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 return (cubin, func_name, cooperative, self._make_post_load_hook())
             return (cubin, func_name, cooperative)
 
-    def _compile_impl(self, args, launch_config_retry_budget=_CONFIGURE_CACHE_STALE_RETRY_LIMIT):
+    def _compile_impl(
+        self,
+        args,
+        launch_config_retry_budget=_CONFIGURE_CACHE_STALE_RETRY_LIMIT,
+        literal_retry_budget=1,
+    ):
         from numba_cuda_mlir import mlir_compiler
         from numba_cuda_mlir.compiler import CompileResult
 
@@ -2697,6 +2887,10 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             argtypes = override_argtypes
         else:
             argtypes = tuple(typeof(arg) for arg in args)
+        runtime_values = tuple(getattr(_compile_arg_types, "values", tuple(args)))
+        argtypes = self._literalize_argtypes(argtypes, runtime_values, abi_arg_count=len(args))
+        if self._literal_arg_positions:
+            override_argtypes = argtypes
         active_extensions = getattr(_compile_arg_types, "extensions", _MISSING)
         has_extension_snapshot = active_extensions is not _MISSING
         if not has_extension_snapshot:
@@ -2854,10 +3048,37 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             with self._compile_profiler():
                 result = mlir_compiler.mlir_compiler_entry(
                     pyfunc=self.py_func,
-                    func_args=list(args),
+                    func_args=list(runtime_values),
                     targetoptions=targetoptions,
                     override_argtypes=override_argtypes,
                 )
+        except errors.ForceLiteralArg as exc:
+            if literal_retry_budget <= 0:
+                raise errors.CompilerError(
+                    "Repeated literal typing request during kernel compilation"
+                ) from exc
+            with self._launch_config_lock:
+                changed = self._record_literal_arg_positions(
+                    exc.requested_args,
+                    runtime_values,
+                    len(args),
+                )
+                if (
+                    changed
+                    and active_launch_config is None
+                    and launch_config_tracker is not None
+                    and launch_config_tracker.required
+                ):
+                    self._requires_launch_config = True
+            if not changed:
+                raise errors.CompilerError(
+                    "Repeated literal typing request during kernel compilation"
+                ) from exc
+            return self._compile_impl(
+                args,
+                launch_config_retry_budget,
+                literal_retry_budget - 1,
+            )
         except _RequireLaunchConfig:
             raise RuntimeError(
                 "whole-function planner requires launch metadata, but compilation "
@@ -2914,7 +3135,11 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                         "Kernel launch configuration was invalidated repeatedly during compile(); "
                         "retry after concurrent recompile() calls finish."
                     )
-                return self._compile_impl(args, launch_config_retry_budget - 1)
+                return self._compile_impl(
+                    args,
+                    launch_config_retry_budget - 1,
+                    literal_retry_budget,
+                )
             if emit_launch_config_cache_notice:
                 message = (
                     "Persistent disk cache is disabled for launch-config-specialized "

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -2122,6 +2122,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             else frozenset()
         )
         if self._literal_arg_positions:
+            self._retain_old_dispatcher(self._c)
             self._c = self._new_kernel_dispatcher()
         for sig in sigs:
             self.compile(sig)

--- a/src/numba_cuda_mlir/mlir_compiler.py
+++ b/src/numba_cuda_mlir/mlir_compiler.py
@@ -452,6 +452,15 @@ def mlir_compiler_entry(
             argtypes.append(types.StarArgTuple.from_types(vararg_types))
             break
 
+        override_argtype = (
+            override_argtypes[i]
+            if override_argtypes is not None and i < len(override_argtypes)
+            else None
+        )
+        if isinstance(override_argtype, types.Literal):
+            argtypes.append(override_argtype)
+            continue
+
         annotation = param.annotation
 
         # If there's a Numba type annotation, use it directly
@@ -464,14 +473,14 @@ def mlir_compiler_entry(
                     argtypes.append(to_numba_type(annotation))
                 except (TypeError, NotImplementedError):
                     # Use override type if provided, otherwise infer from arg
-                    if override_argtypes is not None and i < len(override_argtypes):
-                        argtypes.append(override_argtypes[i])
+                    if override_argtype is not None:
+                        argtypes.append(override_argtype)
                     else:
                         argtypes.append(typeof(func_args_extended[i], Purpose.argument))
             else:
                 # Use override type if provided, otherwise infer from arg
-                if override_argtypes is not None and i < len(override_argtypes):
-                    argtypes.append(override_argtypes[i])
+                if override_argtype is not None:
+                    argtypes.append(override_argtype)
                 else:
                     argtypes.append(typeof(func_args_extended[i], Purpose.argument))
 

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for dispatcher launch metadata plumbing."""
 
+from concurrent.futures import ThreadPoolExecutor
 import threading
 from uuid import uuid4
 
@@ -12,12 +13,14 @@ from numba_cuda_mlir import descriptor as descriptor_mod
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.cuda.experimental import consteval, current_target_options
 from numba_cuda_mlir.descriptor import _ArgMarshaller
+from numba_cuda_mlir.errors import ForceLiteralArg
 from numba_cuda_mlir._launch_config import _LAUNCH_CONFIG_TRACKER_OPTION
 from numba_cuda_mlir._whole_function_planners import (
     _planner_registry,
     _RequireLaunchConfig,
 )
 from numba_cuda_mlir.numba_cuda import types, typing as cuda_typing
+from numba_cuda_mlir.numba_cuda.core import errors as cuda_errors
 
 
 class _Dispatcher:
@@ -261,6 +264,7 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
 
     def prepare_for_launch(
         args,
+        values,
         argtypes,
         launch_config,
         configured_launch_config,
@@ -271,6 +275,7 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
         prepare_calls.append(
             (
                 args,
+                values,
                 argtypes,
                 launch_config,
                 configured_launch_config,
@@ -322,6 +327,7 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
     assert marshaller() == "qualified"
     assert prepare_calls == [
         (
+            (),
             (),
             (),
             available_launch_config,
@@ -386,6 +392,7 @@ def test_arg_marshaller_rebinds_for_retained_launch_extension_snapshot(monkeypat
     assert marshaller() == "refreshed"
     assert prepare_calls == [
         (
+            (),
             (),
             (),
             launch_config,
@@ -764,6 +771,7 @@ def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
 
     prepared = dispatcher._prepare_for_launch(
         (),
+        (1,),
         (types.int32,),
         marshaller._available_launch_config,
         retained_launch_config,
@@ -820,6 +828,71 @@ def test_ready_launch_known_signature_avoids_lock_and_overload_iteration(monkeyp
     )
 
     assert marshaller() == "launched"
+
+
+def test_ready_launch_literal_signature_avoids_lock_and_overload_iteration(monkeypatch):
+    def kernel(selector):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher._literal_arg_positions = frozenset({0})
+
+    class ExactOnlyOverloads(dict):
+        def items(self):
+            pytest.fail("the unlocked readiness check must not iterate overloads")
+
+        def __iter__(self):
+            pytest.fail("the unlocked readiness check must not iterate overloads")
+
+    literal_type = types.literal(7)
+    compile_result = _CompileResult((literal_type,))
+    compile_result.metadata["required_dynamic_shared_memory"] = 1024
+    dispatcher.overloads = ExactOnlyOverloads({(literal_type,): compile_result})
+    monkeypatch.setattr(_planner_registry, "_planners", [object()])
+    monkeypatch.setattr(
+        descriptor_mod.global_compiler_lock,
+        "acquire",
+        lambda: pytest.fail("known literal signatures must not take the compiler lock"),
+    )
+
+    launches = []
+
+    def launch_configuration(
+        kernel_dispatcher,
+        griddim,
+        blockdim,
+        stream,
+        sharedmem,
+        cluster,
+    ):
+        launches.append((kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster))
+        return lambda selector: ("launched", selector)
+
+    monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
+    available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    marshaller = _ArgMarshaller(
+        lambda selector: pytest.fail("shared-memory adjustment must rebuild the launcher"),
+        dispatcher=dispatcher,
+        available_launch_config=available_launch_config,
+        kernel_dispatcher=dispatcher._c,
+    )
+
+    assert marshaller(7) == ("launched", 7)
+    assert launches == [
+        (
+            dispatcher._c,
+            (1, 1, 1),
+            (32, 1, 1),
+            None,
+            1024,
+            None,
+        )
+    ]
 
 
 def test_prelaunch_rechecks_readiness_after_global_compiler_lock(monkeypatch):
@@ -923,6 +996,56 @@ def test_ready_launch_validates_specialized_state():
         )
         is None
     )
+
+
+def test_arg_marshaller_keeps_top_level_values_separate_from_flat_abi_args():
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    kernel_dispatcher = object()
+    dispatcher = _Dispatcher()
+    dispatcher._literal_arg_positions = frozenset({0})
+    observed = []
+
+    def literalize_argtypes(argtypes, values, *, abi_arg_count=None):
+        assert values == ((1, 2),)
+        assert abi_arg_count == 2
+        return tuple(argtypes)
+
+    def prepare_for_launch(
+        args,
+        values,
+        argtypes,
+        available_launch_config,
+        configured_launch_config,
+        configured_kernel_dispatcher,
+        configured_launch_config_generation,
+    ):
+        observed.append((args, values, argtypes))
+        return (
+            configured_kernel_dispatcher,
+            configured_launch_config_generation,
+            configured_launch_config,
+            0,
+        )
+
+    dispatcher._get_ready_launch = lambda *args: None
+    dispatcher._literalize_argtypes = literalize_argtypes
+    dispatcher._prepare_for_launch = prepare_for_launch
+    marshaller = _ArgMarshaller(
+        lambda *args: args,
+        dispatcher=dispatcher,
+        available_launch_config=launch_config,
+        kernel_dispatcher=kernel_dispatcher,
+    )
+
+    assert marshaller((1, 2)) == (1, 2)
+    assert observed[0][0] == (1, 2)
+    assert observed[0][1] == ((1, 2),)
+    assert len(observed[0][2]) == 1
 
 
 def test_launch_config_configure_reports_invalid_sharedmem():
@@ -2155,6 +2278,231 @@ def test_compile_impl_discards_callbacks_from_duplicate_launch_compile(monkeypat
 
     assert dispatcher._compile_impl([1]) == (b"winner", "kernel", False)
     assert losing_setup_callback not in dispatcher._module_setup_callbacks
+
+
+def test_literalize_argtypes_matches_numba_scalar_literal_semantics():
+    def kernel(count, enabled):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher._literal_arg_positions = frozenset({0, 1})
+
+    literalized = dispatcher._literalize_argtypes(
+        (types.int64, types.boolean),
+        (7, True),
+        abi_arg_count=2,
+    )
+
+    assert literalized == (types.literal(7), types.literal(True))
+
+    with pytest.raises(TypeError, match="top-level Python int and bool"):
+        dispatcher._literalize_argtypes(
+            (types.float64, types.boolean),
+            (1.5, True),
+            abi_arg_count=2,
+        )
+
+
+def test_literalize_argtypes_rejects_flattened_extension_abi():
+    def kernel(value):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher._literal_arg_positions = frozenset({0})
+
+    with pytest.raises(TypeError, match=r"flattened launch arguments.*issue #60"):
+        dispatcher._literalize_argtypes(
+            (types.UniTuple(types.int32, 2),),
+            ((1, 2),),
+            abi_arg_count=2,
+        )
+
+
+def test_literal_prelaunch_only_rebinds_stale_native_dispatchers():
+    def kernel(value):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher._literal_arg_positions = frozenset({0})
+
+    assert not dispatcher._literal_dispatcher_needs_prelaunch(
+        None,
+        dispatcher._c,
+        None,
+    )
+    assert dispatcher._literal_dispatcher_needs_prelaunch(None, object(), None)
+
+
+def test_literal_retry_rebuild_preserves_debug_lock_and_serialized_state(monkeypatch):
+    native_calls = []
+
+    def kernel(output, selector):
+        pass
+
+    def kernel_dispatcher(compile_callback, constant_flags, context_callback, debug=False):
+        native = object()
+        native_calls.append((native, tuple(constant_flags), debug))
+        return native
+
+    monkeypatch.setattr(descriptor_mod, "_PY_GIL_DISABLED", True)
+    monkeypatch.setattr(descriptor_mod._cext, "KernelDispatcher", kernel_dispatcher)
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel,
+        targetoptions={"debug": True},
+    )
+    launch_lock = dispatcher._launch_lock
+    dispatcher.overloads[(types.int32, types.int32)] = _CompileResult((types.int32, types.int32))
+    dispatcher._configure_cache["cached"] = object()
+    generation = dispatcher._launch_config_generation
+
+    assert dispatcher._record_literal_arg_positions({1}, (object(), 7), 2) is True
+    assert dispatcher._literal_arg_positions == frozenset({1})
+    assert dispatcher._launch_config_generation == generation + 1
+    assert dispatcher._launch_lock is launch_lock
+    assert not dispatcher.overloads
+    assert not dispatcher._configure_cache
+    assert [call[1:] for call in native_calls] == [
+        ((False, False), True),
+        ((False, True), True),
+    ]
+
+    states = dispatcher._reduce_states()
+    assert states["literal_arg_positions"] == (1,)
+    states["uuid"] = str(uuid4())
+    rebuilt = descriptor_mod.MLIRDispatcher._rebuild(**states)
+    assert rebuilt._literal_arg_positions == frozenset({1})
+    assert native_calls[-1][1:] == ((False, True), True)
+
+    rebuilt_lock = rebuilt._launch_lock
+    rebuilt.recompile()
+    assert rebuilt._literal_arg_positions == frozenset({1})
+    assert rebuilt._launch_lock is rebuilt_lock
+    assert native_calls[-1][1:] == ((False, True), True)
+
+
+def test_concurrent_literal_requests_rebuild_native_dispatcher_once():
+    def kernel(selector):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    generation = dispatcher._launch_config_generation
+
+    def record(_):
+        return dispatcher._record_literal_arg_positions({0}, (7,), 1)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        changed = list(executor.map(record, range(32)))
+
+    assert changed.count(True) == 1
+    assert changed.count(False) == 31
+    assert dispatcher._literal_arg_positions == frozenset({0})
+    assert dispatcher._launch_config_generation == generation + 1
+
+
+def test_literal_retry_preserves_same_attempt_launch_promotion(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(selector):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": None,
+        "cluster": None,
+    }
+    compile_calls = []
+
+    class CompilerResult:
+        def __init__(self, argtype):
+            self.signature = cuda_typing.signature(types.none, argtype)
+            self.metadata = {
+                "cubin": f"literal-{argtype.literal_value}".encode(),
+                "func_name": "kernel",
+                "required_dynamic_shared_memory": 4096,
+            }
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        call = (tuple(func_args), tuple(override_argtypes), dict(targetoptions))
+        compile_calls.append(call)
+        if len(compile_calls) == 1:
+            tracker = targetoptions.pop(_LAUNCH_CONFIG_TRACKER_OPTION)
+            targetoptions["__launch_config__"] = tracker.require()
+            raise ForceLiteralArg({0})
+        [argtype] = override_argtypes
+        assert isinstance(argtype, types.Literal)
+        return CompilerResult(argtype)
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.values = (7,)
+    descriptor_mod._compile_arg_types.available_launch_config = available_launch_config
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ):
+        first = dispatcher._compile_impl([7])
+
+    descriptor_mod._compile_arg_types.values = (9,)
+    second = dispatcher._compile_impl([9])
+
+    normalized_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(normalized_launch_config)
+    literal7 = types.literal(7)
+    literal9 = types.literal(9)
+
+    assert first == (b"literal-7", "kernel", False)
+    assert second == (b"literal-9", "kernel", False)
+    assert [call[0] for call in compile_calls] == [(7,), (7,), (9,)]
+    assert [call[1] for call in compile_calls] == [
+        (types.int32,),
+        (literal7,),
+        (literal9,),
+    ]
+    assert "__launch_config__" not in compile_calls[0][2]
+    assert compile_calls[0][2][_LAUNCH_CONFIG_TRACKER_OPTION].required is True
+    assert all(
+        call[2].get("__launch_config__") == normalized_launch_config for call in compile_calls[1:]
+    )
+    assert dispatcher._literal_arg_positions == frozenset({0})
+    assert ((literal7,), launch_key) in dispatcher._launch_config_overloads
+    assert ((literal9,), launch_key) in dispatcher._launch_config_overloads
+    assert dispatcher._compile_result_for(
+        (literal7,), normalized_launch_config
+    ) is not dispatcher._compile_result_for((literal9,), normalized_launch_config)
+
+
+def test_literal_retry_rejects_flattened_values_and_repeated_requests(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(value):
+        pass
+
+    def request_literal(*args, **kwargs):
+        raise ForceLiteralArg({0})
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", request_literal)
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    descriptor_mod._compile_arg_types.types = (types.UniTuple(types.int32, 2),)
+    descriptor_mod._compile_arg_types.values = ((1, 2),)
+
+    with pytest.raises(TypeError, match=r"flattened launch arguments.*issue #60"):
+        dispatcher._compile_impl([1, 2])
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.values = (7,)
+
+    with pytest.raises(cuda_errors.CompilerError, match="Repeated literal typing request"):
+        dispatcher._compile_impl([7])
 
 
 def test_compile_impl_promotes_available_launch_config_in_current_attempt(monkeypatch):

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -2295,12 +2295,25 @@ def test_literalize_argtypes_matches_numba_scalar_literal_semantics():
 
     assert literalized == (types.literal(7), types.literal(True))
 
+    # Learned positions are conditional hints, not permanent restrictions on
+    # the signatures this dispatcher may compile.
+    assert dispatcher._literalize_argtypes(
+        (types.float64, types.boolean),
+        (1.5, True),
+        abi_arg_count=2,
+    ) == (types.float64, types.literal(True))
+
+    class IntSubclass(int):
+        pass
+
+    assert dispatcher._literalize_argtypes(
+        (types.int64, types.boolean),
+        (IntSubclass(7), True),
+        abi_arg_count=2,
+    ) == (types.int64, types.literal(True))
+
     with pytest.raises(TypeError, match="top-level Python int and bool"):
-        dispatcher._literalize_argtypes(
-            (types.float64, types.boolean),
-            (1.5, True),
-            abi_arg_count=2,
-        )
+        dispatcher._record_literal_arg_positions({0}, (1.5, True), 2)
 
 
 def test_literalize_argtypes_rejects_flattened_extension_abi():
@@ -2339,9 +2352,15 @@ def test_literal_retry_rebuild_preserves_debug_lock_and_serialized_state(monkeyp
     def kernel(output, selector):
         pass
 
-    def kernel_dispatcher(compile_callback, constant_flags, context_callback, debug=False):
+    def kernel_dispatcher(
+        compile_callback,
+        constant_flags,
+        context_callback,
+        debug=False,
+        literal_arg_flags=(),
+    ):
         native = object()
-        native_calls.append((native, tuple(constant_flags), debug))
+        native_calls.append((native, tuple(constant_flags), tuple(literal_arg_flags), debug))
         return native
 
     monkeypatch.setattr(descriptor_mod, "_PY_GIL_DISABLED", True)
@@ -2363,8 +2382,8 @@ def test_literal_retry_rebuild_preserves_debug_lock_and_serialized_state(monkeyp
     assert not dispatcher.overloads
     assert not dispatcher._configure_cache
     assert [call[1:] for call in native_calls] == [
-        ((False, False), True),
-        ((False, True), True),
+        ((False, False), (False, False), True),
+        ((False, False), (False, True), True),
     ]
 
     states = dispatcher._reduce_states()
@@ -2372,7 +2391,7 @@ def test_literal_retry_rebuild_preserves_debug_lock_and_serialized_state(monkeyp
     states["uuid"] = str(uuid4())
     rebuilt = descriptor_mod.MLIRDispatcher._rebuild(**states)
     assert rebuilt._literal_arg_positions == frozenset({1})
-    assert native_calls[-1][1:] == ((False, True), True)
+    assert native_calls[-1][1:] == ((False, False), (False, True), True)
     assert native_calls[-2][0] in rebuilt._old_dispatchers
     assert rebuilt._c is native_calls[-1][0]
 
@@ -2380,7 +2399,7 @@ def test_literal_retry_rebuild_preserves_debug_lock_and_serialized_state(monkeyp
     rebuilt.recompile()
     assert rebuilt._literal_arg_positions == frozenset({1})
     assert rebuilt._launch_lock is rebuilt_lock
-    assert native_calls[-1][1:] == ((False, True), True)
+    assert native_calls[-1][1:] == ((False, False), (False, True), True)
 
 
 def test_concurrent_literal_requests_rebuild_native_dispatcher_once():
@@ -2435,6 +2454,47 @@ def test_literal_retry_counts_concurrent_discovery_as_attempt_progress(monkeypat
     assert dispatcher._compile_impl([7]) == (b"literal-7", "kernel", False)
     assert compile_calls == [types.int32, types.literal(7)]
     assert dispatcher._literal_arg_positions == frozenset({0})
+
+
+def test_literal_retry_allows_later_generic_signature(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(selector):
+        pass
+
+    compile_calls = []
+
+    class CompilerResult:
+        def __init__(self, argtype):
+            self.signature = cuda_typing.signature(types.none, argtype)
+            self.metadata = {
+                "cubin": str(argtype).encode(),
+                "func_name": "kernel",
+            }
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        [argtype] = override_argtypes
+        compile_calls.append(argtype)
+        if argtype == types.int32:
+            raise ForceLiteralArg({0})
+        return CompilerResult(argtype)
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    monkeypatch.setattr(_planner_registry, "_planners", [object()])
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.values = (7,)
+    dispatcher._compile_impl([7])
+
+    descriptor_mod._compile_arg_types.types = (types.float64,)
+    descriptor_mod._compile_arg_types.values = (1.5,)
+    dispatcher._compile_impl([1.5])
+    descriptor_mod._compile_arg_types.values = (2.5,)
+    dispatcher._compile_impl([2.5])
+
+    assert compile_calls == [types.int32, types.literal(7), types.float64]
+    assert set(dispatcher.overloads) == {(types.literal(7),), (types.float64,)}
 
 
 def test_literal_retry_preserves_same_attempt_launch_promotion(monkeypatch):

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -2373,6 +2373,8 @@ def test_literal_retry_rebuild_preserves_debug_lock_and_serialized_state(monkeyp
     rebuilt = descriptor_mod.MLIRDispatcher._rebuild(**states)
     assert rebuilt._literal_arg_positions == frozenset({1})
     assert native_calls[-1][1:] == ((False, True), True)
+    assert native_calls[-2][0] in rebuilt._old_dispatchers
+    assert rebuilt._c is native_calls[-1][0]
 
     rebuilt_lock = rebuilt._launch_lock
     rebuilt.recompile()

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -2402,6 +2402,41 @@ def test_concurrent_literal_requests_rebuild_native_dispatcher_once():
     assert dispatcher._launch_config_generation == generation + 1
 
 
+def test_literal_retry_counts_concurrent_discovery_as_attempt_progress(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(selector):
+        pass
+
+    compile_calls = []
+
+    class CompilerResult:
+        def __init__(self, argtype):
+            self.signature = cuda_typing.signature(types.none, argtype)
+            self.metadata = {"cubin": b"literal-7", "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        [argtype] = override_argtypes
+        compile_calls.append(argtype)
+        if len(compile_calls) == 1:
+            # Model another compile publishing the requested position after
+            # this attempt selected its generic argument types.
+            assert dispatcher._record_literal_arg_positions({0}, (7,), 1) is True
+            raise ForceLiteralArg({0})
+        assert isinstance(argtype, types.Literal)
+        return CompilerResult(argtype)
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    monkeypatch.setattr(_planner_registry, "_planners", [object()])
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.values = (7,)
+
+    assert dispatcher._compile_impl([7]) == (b"literal-7", "kernel", False)
+    assert compile_calls == [types.int32, types.literal(7)]
+    assert dispatcher._literal_arg_positions == frozenset({0})
+
+
 def test_literal_retry_preserves_same_attempt_launch_promotion(monkeypatch):
     from numba_cuda_mlir import mlir_compiler
 
@@ -2482,13 +2517,91 @@ def test_literal_retry_preserves_same_attempt_launch_promotion(monkeypatch):
     ) is not dispatcher._compile_result_for((literal9,), normalized_launch_config)
 
 
-def test_literal_retry_rejects_flattened_values_and_repeated_requests(monkeypatch):
+def test_literal_retry_accumulates_staged_requests_with_launch_promotion(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(first, second):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": None,
+        "cluster": None,
+    }
+    compile_calls = []
+
+    class CompilerResult:
+        def __init__(self, argtypes):
+            self.signature = cuda_typing.signature(types.none, *argtypes)
+            self.metadata = {
+                "cubin": b"literal-7-11",
+                "func_name": "kernel",
+                "required_dynamic_shared_memory": 4096,
+            }
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        call = (tuple(func_args), tuple(override_argtypes), dict(targetoptions))
+        compile_calls.append(call)
+        if len(compile_calls) == 1:
+            # Planner A promotes launch metadata, then asks for its scalar.
+            targetoptions[_LAUNCH_CONFIG_TRACKER_OPTION].require()
+            raise ForceLiteralArg({0})
+        if len(compile_calls) == 2:
+            # Planner B is reached only after Planner A's request is satisfied.
+            raise ForceLiteralArg({1})
+        assert all(isinstance(argtype, types.Literal) for argtype in override_argtypes)
+        return CompilerResult(override_argtypes)
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    descriptor_mod._compile_arg_types.types = (types.int32, types.int32)
+    descriptor_mod._compile_arg_types.values = (7, 11)
+    descriptor_mod._compile_arg_types.available_launch_config = available_launch_config
+
+    with pytest.warns(
+        descriptor_mod.NumbaPerformanceWarning,
+        match="Persistent disk cache is disabled for launch-config-specialized compiles",
+    ):
+        result = dispatcher._compile_impl([7, 11])
+
+    normalized_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    launch_key = descriptor_mod._launch_config_key(normalized_launch_config)
+    literal7 = types.literal(7)
+    literal11 = types.literal(11)
+
+    assert result == (b"literal-7-11", "kernel", False)
+    assert [call[1] for call in compile_calls] == [
+        (types.int32, types.int32),
+        (literal7, types.int32),
+        (literal7, literal11),
+    ]
+    assert "__launch_config__" not in compile_calls[0][2]
+    assert compile_calls[0][2][_LAUNCH_CONFIG_TRACKER_OPTION].required is True
+    assert all(
+        call[2].get("__launch_config__") == normalized_launch_config for call in compile_calls[1:]
+    )
+    assert dispatcher._literal_arg_positions == frozenset({0, 1})
+    assert dispatcher._launch_config_generation == 2
+    compile_result = dispatcher._launch_config_overloads[((literal7, literal11), launch_key)]
+    assert compile_result.metadata["required_dynamic_shared_memory"] == 4096
+
+
+def test_literal_retry_rejects_flattened_values_and_no_progress(monkeypatch):
     from numba_cuda_mlir import mlir_compiler
 
     def kernel(value):
         pass
 
+    compile_calls = []
+
     def request_literal(*args, **kwargs):
+        compile_calls.append(tuple(kwargs["override_argtypes"]))
         raise ForceLiteralArg({0})
 
     monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", request_literal)
@@ -2499,12 +2612,16 @@ def test_literal_retry_rejects_flattened_values_and_repeated_requests(monkeypatc
     with pytest.raises(TypeError, match=r"flattened launch arguments.*issue #60"):
         dispatcher._compile_impl([1, 2])
 
+    compile_calls.clear()
     dispatcher = descriptor_mod.MLIRDispatcher(kernel)
     descriptor_mod._compile_arg_types.types = (types.int32,)
     descriptor_mod._compile_arg_types.values = (7,)
 
     with pytest.raises(cuda_errors.CompilerError, match="Repeated literal typing request"):
         dispatcher._compile_impl([7])
+
+    assert compile_calls == [(types.int32,), (types.literal(7),)]
+    assert dispatcher._literal_arg_positions == frozenset({0})
 
 
 def test_compile_impl_promotes_available_launch_config_in_current_attempt(monkeypatch):

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -792,6 +792,89 @@ def test_literal_retry_crosses_launch_config_and_dynamic_shared_memory(
 
 
 @pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_literal_retry_keeps_later_float_signature_generic(isolated_global_planners):
+    class IntegerLiteralPlanner(WholeFunctionPlanner):
+        def run(self):
+            if self.is_device_function:
+                return False
+            selector_type = self.state.args[1]
+            if isinstance(selector_type, types.Integer) and not isinstance(
+                selector_type, types.Literal
+            ):
+                raise ForceLiteralArg({1})
+            return False
+
+    register_planner(IntegerLiteralPlanner)
+
+    @cuda.jit
+    def kernel(output, selector):
+        output[0] = selector
+
+    native_compile_values = []
+    original_compile = kernel._compile
+
+    def counting_compile(args):
+        native_compile_values.append(args[1])
+        return original_compile(args)
+
+    # The first generic native dispatcher already owns its compile callback.
+    # Literal discovery rebuilds it with this wrapper, allowing the assertions
+    # below to distinguish native cache misses after discovery.
+    kernel._compile = counting_compile
+
+    output = np.zeros(1, dtype=np.float64)
+    kernel[1, 1](output, 7)
+    assert output[0] == 7
+
+    native_compile_values.clear()
+    kernel[1, 1](output, 1.5)
+    assert output[0] == 1.5
+    kernel[1, 1](output, 2.5)
+    assert output[0] == 2.5
+    kernel[1, 1](output, 9)
+    assert output[0] == 9
+
+    assert native_compile_values == [1.5, 9]
+    selector_types = {argtypes[1] for argtypes in kernel.overloads}
+    assert types.float64 in selector_types
+    assert {
+        selector_type.literal_value
+        for selector_type in selector_types
+        if isinstance(selector_type, types.Literal)
+    } == {7, 9}
+    assert len(selector_types) == 3
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_literal_retry_distinguishes_signed_and_unsigned_native_cache_keys(
+    isolated_global_planners,
+):
+    class IntegerLiteralPlanner(WholeFunctionPlanner):
+        def run(self):
+            if self.is_device_function:
+                return False
+            selector_type = self.state.args[1]
+            if isinstance(selector_type, types.Integer) and not isinstance(
+                selector_type, types.Literal
+            ):
+                raise ForceLiteralArg({1})
+            return False
+
+    register_planner(IntegerLiteralPlanner)
+
+    @cuda.jit
+    def kernel(output, selector):
+        output[0] = selector < 0
+
+    output = np.zeros(1, dtype=np.int32)
+    kernel[1, 1](output, -1)
+    assert output[0] == 1
+
+    kernel[1, 1](output, (1 << 64) - 1)
+    assert output[0] == 0
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
 def test_literal_retry_accumulates_requests_from_multiple_planners(
     isolated_global_planners,
 ):

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from numba_cuda_mlir import compiler, cuda, types
+from numba_cuda_mlir.errors import ForceLiteralArg
 from numba_cuda_mlir._whole_function_planners import (
     _WholeFunctionPlannerRegistry,
     _planner_registry,
@@ -716,3 +717,54 @@ def test_planner_dynamic_shared_memory_minimum_reaches_launch(
     assert output[0] == 42
     [compile_result] = kernel.overloads.values()
     assert compile_result.metadata["required_dynamic_shared_memory"] == required_bytes
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_literal_retry_crosses_launch_config_and_dynamic_shared_memory(
+    isolated_global_planners,
+):
+    required_bytes = 32 * 1024
+    last_scratch_index = required_bytes // np.dtype(np.int32).itemsize - 1
+    observed = []
+
+    class LiteralScratchPlanner(WholeFunctionPlanner):
+        def run(self):
+            if self.is_device_function:
+                return False
+            launch_config = require_launch_config(self.state)
+            set_required_dynamic_shared_memory(self.state, required_bytes)
+            selector_type = self.state.args[1]
+            observed.append((launch_config["block"], selector_type))
+            if not isinstance(selector_type, types.Literal):
+                raise ForceLiteralArg({1})
+            return False
+
+    register_planner(LiteralScratchPlanner)
+
+    @cuda.jit
+    def kernel(output, selector):
+        scratch = cuda.shared.array(0, dtype=types.int32)
+        if cuda.threadIdx.x == 0:
+            scratch[last_scratch_index] = selector
+            output[0] = scratch[last_scratch_index] + cuda.blockDim.x
+
+    selectors = (3, 7, True, False)
+    for block_size in (32, 64):
+        for selector in selectors:
+            output = np.zeros(1, dtype=np.int32)
+            kernel[1, block_size](output, selector)
+            assert output[0] == selector + block_size
+
+    assert kernel._requires_launch_config is True
+    assert kernel._literal_arg_positions == frozenset({1})
+    assert not kernel.overloads
+    assert {
+        (dict(launch_config_key)["block"], argtypes[1].literal_value)
+        for (argtypes, launch_config_key) in kernel._launch_config_overloads
+    } == {(block, selector) for block in ((32, 1, 1), (64, 1, 1)) for selector in selectors}
+    assert all(
+        compile_result.metadata["required_dynamic_shared_memory"] == required_bytes
+        for compile_result in kernel._launch_config_overloads.values()
+    )
+    assert any(not isinstance(selector_type, types.Literal) for _, selector_type in observed)
+    assert any(isinstance(selector_type, types.Literal) for _, selector_type in observed)

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -792,6 +792,58 @@ def test_literal_retry_crosses_launch_config_and_dynamic_shared_memory(
 
 
 @pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_literal_retry_accumulates_requests_from_multiple_planners(
+    isolated_global_planners,
+):
+    observed = []
+
+    class FirstLiteralPlanner(WholeFunctionPlanner):
+        def run(self):
+            if self.is_device_function:
+                return False
+            first_type = self.state.args[1]
+            observed.append(("first", first_type))
+            if not isinstance(first_type, types.Literal):
+                raise ForceLiteralArg({1})
+            return False
+
+    class SecondLiteralPlanner(WholeFunctionPlanner):
+        def run(self):
+            if self.is_device_function:
+                return False
+            second_type = self.state.args[2]
+            observed.append(("second", second_type))
+            if not isinstance(second_type, types.Literal):
+                raise ForceLiteralArg({2})
+            return False
+
+    register_planner(FirstLiteralPlanner)
+    register_planner(SecondLiteralPlanner)
+
+    @cuda.jit
+    def kernel(output, first, second):
+        output[0] = first + second
+
+    output = np.zeros(1, dtype=np.int32)
+    kernel[1, 1](output, 7, 9)
+
+    assert output[0] == 16
+    assert kernel._literal_arg_positions == frozenset({1, 2})
+    [(argtypes, _)] = kernel.overloads.items()
+    assert isinstance(argtypes[1], types.IntegerLiteral)
+    assert argtypes[1].literal_value == 7
+    assert isinstance(argtypes[2], types.IntegerLiteral)
+    assert argtypes[2].literal_value == 9
+    assert [name for name, _ in observed] == [
+        "first",
+        "first",
+        "second",
+        "first",
+        "second",
+    ]
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
 def test_literal_retry_overrides_partial_parameter_annotation(isolated_global_planners):
     class LiteralPlanner(WholeFunctionPlanner):
         def run(self):

--- a/tests/test_post_inline_planners.py
+++ b/tests/test_post_inline_planners.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from numba_cuda_mlir import compiler, cuda, types
+from numba_cuda_mlir.cuda.experimental import consteval
 from numba_cuda_mlir.errors import ForceLiteralArg
 from numba_cuda_mlir._whole_function_planners import (
     _WholeFunctionPlannerRegistry,
@@ -744,27 +745,73 @@ def test_literal_retry_crosses_launch_config_and_dynamic_shared_memory(
     @cuda.jit
     def kernel(output, selector):
         scratch = cuda.shared.array(0, dtype=types.int32)
+        type_bias = consteval(1000 if isinstance(selector, types.Boolean) else 0)
         if cuda.threadIdx.x == 0:
             scratch[last_scratch_index] = selector
-            output[0] = scratch[last_scratch_index] + cuda.blockDim.x
+            output[0] = scratch[last_scratch_index] + cuda.blockDim.x + type_bias
 
-    selectors = (3, 7, True, False)
-    for block_size in (32, 64):
+    # Alternate numerically equal int/bool pairs in both insertion orders. They
+    # share an integer launch parameter family but must retain distinct native
+    # constant-cache entries.
+    selector_orders = {
+        32: (1, True, 0, False, 3, 7),
+        64: (True, 1, False, 0, 3, 7),
+    }
+    for block_size, selectors in selector_orders.items():
         for selector in selectors:
             output = np.zeros(1, dtype=np.int32)
             kernel[1, block_size](output, selector)
-            assert output[0] == selector + block_size
+            type_bias = 1000 if isinstance(selector, bool) else 0
+            assert output[0] == selector + block_size + type_bias
 
     assert kernel._requires_launch_config is True
     assert kernel._literal_arg_positions == frozenset({1})
     assert not kernel.overloads
     assert {
-        (dict(launch_config_key)["block"], argtypes[1].literal_value)
+        (
+            dict(launch_config_key)["block"],
+            type(argtypes[1]),
+            argtypes[1].literal_value,
+        )
         for (argtypes, launch_config_key) in kernel._launch_config_overloads
-    } == {(block, selector) for block in ((32, 1, 1), (64, 1, 1)) for selector in selectors}
+    } == {
+        (
+            block,
+            types.BooleanLiteral if isinstance(selector, bool) else types.IntegerLiteral,
+            selector,
+        )
+        for block in ((32, 1, 1), (64, 1, 1))
+        for selector in selector_orders[32]
+    }
     assert all(
         compile_result.metadata["required_dynamic_shared_memory"] == required_bytes
         for compile_result in kernel._launch_config_overloads.values()
     )
     assert any(not isinstance(selector_type, types.Literal) for _, selector_type in observed)
     assert any(isinstance(selector_type, types.Literal) for _, selector_type in observed)
+
+
+@pytest.mark.skipif(not cuda.is_available(), reason="CUDA GPU required")
+def test_literal_retry_overrides_partial_parameter_annotation(isolated_global_planners):
+    class LiteralPlanner(WholeFunctionPlanner):
+        def run(self):
+            if self.is_device_function:
+                return False
+            if not isinstance(self.state.args[1], types.Literal):
+                raise ForceLiteralArg({1})
+            return False
+
+    register_planner(LiteralPlanner)
+
+    @cuda.jit
+    def kernel(output, selector: types.int64):
+        output[0] = selector
+
+    output = np.zeros(1, dtype=np.int64)
+    kernel[1, 1](output, 7)
+
+    assert output[0] == 7
+    assert kernel._literal_arg_positions == frozenset({1})
+    [(argtypes, _)] = kernel.overloads.items()
+    assert isinstance(argtypes[1], types.IntegerLiteral)
+    assert argtypes[1].literal_value == 7


### PR DESCRIPTION
## Summary

- Retry `ForceLiteralArg` requests by recompiling with exact Numba literal
  types for requested top-level Python `int` and `bool` arguments.
- Allow planners to discover literal requirements in stages, retrying only when
  each request adds at least one new argument position.
- Keep top-level launch values separate from flattened native ABI arguments so
  extension-facing positions continue to refer to the Python kernel signature.
- Compose literal specialization with planner-requested launch metadata and
  dynamic shared-memory requirements while keeping launch and literal progress
  accounting independent.
- Preserve exact overload reuse, serialization, `recompile()`, native
  dispatcher lifetime, and distinct cache identities for `True` / `1` and
  `False` / `0`.
- Reject literal requests for flattened extension arguments until #60 provides
  an unambiguous top-level-to-ABI mapping.

## Why this is needed

Whole-function extensions sometimes need a scalar value, not merely its runtime
type, to finish a compile-time plan. CUDA.coop group hierarchy is a concrete
case: `group_by(count, exhaustive=...)` needs both values while resolving the
static subgroup and selecting its provider, and the planner also needs the
configured block dimensions.

Before this change, `ForceLiteralArg` could reach `MLIRDispatcher`, but the
dispatcher had no path that rebuilt its native dispatcher and retried using the
actual top-level launch value as a literal. An extension therefore had to reject
a natural Python API, encode the choice in an artificial wrapper type, or leave
provider selection as a runtime branch.

Literal requirements may also emerge in stages. The group planner first asks
for `count`; only after that value is literal can it continue far enough to ask
for `exhaustive`. A fixed one-retry budget rejects that valid sequence.

This PR retries while the recorded literal-position set grows. Progress is
monotonic and bounded by the kernel's top-level parameters; a request that adds
no position is diagnosed instead of looping. Provider-oriented extensions can
therefore select LTO IR that is subsequently inlined while the user-facing
kernel arguments remain ordinary Python scalars.

## Concrete CUDA.coop use

With the small consumer-side hook shown below, CUDA.coop group operations can
accept both mapping choices as top-level kernel arguments:

```python
import numpy as np
from numba_cuda_mlir import cuda
import cuda.coop.numba_mlir as coop


@cuda.jit
def segmented_warp_sum(
    values,
    sums,
    lanes_per_group,
    exhaustive,
):
    tid = cuda.threadIdx.x
    group = coop.this_warp().group_by(
        lanes_per_group,
        exhaustive=exhaustive,
    )
    total = coop.reduce(group, values[tid])

    if group.rank() == 0:
        sums[tid // lanes_per_group] = total


values = np.arange(1, 129, dtype=np.int32)
sums8 = np.empty(16, dtype=np.int32)
sums16 = np.empty(8, dtype=np.int32)

segmented_warp_sum[1, 128](values, sums8, 8, True)
segmented_warp_sum[1, 128](values, sums16, 16, True)

np.testing.assert_array_equal(sums8, values.reshape(-1, 8).sum(axis=1))
np.testing.assert_array_equal(sums16, values.reshape(-1, 16).sum(axis=1))
```

`this_warp()`, `group_by()`, `reduce()`, and `rank()` are CUDA.coop
compile-time markers. The downstream group planner connects a top-level
argument to literal retry with this targeted change to its constant resolver:

```python
from numba_cuda_mlir import types
from numba_cuda_mlir.errors import ForceLiteralArg
from numba_cuda_mlir.numbair_transforms import ir


def _constant(self, value):
    definition = self._definition(value)
    if isinstance(definition, ir.Arg):
        position = definition.index
        argtype = self.state.args[position]
        if not isinstance(argtype, types.Literal):
            raise ForceLiteralArg({position})
        return argtype.literal_value

    # Existing handling for globals, free variables, constants, and groups.
    ...
```

On the first launch with `lanes_per_group=8` and `exhaustive=True`:

1. Generic typing promotes the exact block `(128, 1, 1)`, then the group
   planner requests top-level argument 2 (`lanes_per_group`).
2. The next attempt has the launch facts and `Literal[int](8)`. The planner
   consumes the width, advances to the keyword, and requests argument 3
   (`exhaustive`).
3. The final attempt has both `Literal[int](8)` and `Literal[bool](True)`, so
   the planner resolves the subgroup, selects its provider and scratch
   requirement, and erases the markers.

A launch with width 16 receives a separate exact overload. Launch-generation
retry accounting remains independent throughout the staged literal sequence.
Provider choice stays static, so its LTO IR can inline into the kernel instead
of leaving a runtime selection branch.

The resolver change is a CUDA.coop consumer follow-up. This PR supplies the
dispatcher retry and exact-overload machinery that it needs.

## Specialization contract

- A `ForceLiteralArg` request names zero-based positions in the top-level
  Python kernel signature and may request multiple positions at once or in
  stages.
- Each retry must add at least one previously unseen position. A no-progress
  request is diagnosed, and the finite argument list bounds the sequence.
- Supported runtime values are Python `int` and `bool`.
- Learned literal positions and launch sensitivity survive serialization and
  `recompile()`.
- Numerically equal Python booleans and integers retain distinct literal types
  and native constant-cache entries.
- A literal request may override a partial parameter annotation during lazy
  compilation; non-literal annotation precedence is unchanged.
- Planner-requested launch metadata remains active for each literal-qualified
  attempt, and launch-generation conflicts use independent retry accounting.
- The final exact compile result retains planner-required dynamic shared memory.
- Arguments that flatten into multiple native ABI fields are rejected until
  #60 provides an unambiguous top-level-to-ABI mapping.

## Stack

The prerequisite planner, launch-metadata, and dynamic-shared-memory changes
from #202, #203, and #238 are merged. This branch is based on current `main` at
`a9c1711a849128c7bf44090cee2fc18a73c9d83c` and contains only:

- `c42cdb5` Retry kernel compilation with scalar literals
- `7a06720` Retain generic dispatcher during literal rebuild
- `b3ca615` Fix scalar literal retry edge cases
- `65fd43a` Allow staged scalar literal retries

Exact range: `a9c1711..65fd43a`.

Related: #60.

Co-authored-by: Codex 5.6 Sol Ultra Fast
