### PR TITLE
Avoid force-pushing documentation deployments

### DIFF
--- a/.github/actions/doc_preview/action.yml
+++ b/.github/actions/doc_preview/action.yml
@@ -29,6 +29,7 @@ runs:
         folder: ${{ inputs.source-folder }}
         target-folder: pr-preview/pr-${{ inputs.pr-number }}/
         commit-message: "Deploy doc preview for PR ${{ inputs.pr-number }} (${{ github.sha }})"
+        force: false
 
     - name: Leave a comment after deployment
       if: ${{ github.ref_name != 'main' && !startsWith(github.ref_name, 'release/') }}
@@ -51,6 +52,7 @@ runs:
         folder: ${{ inputs.source-folder }}
         target-folder: pr-preview/pr-${{ inputs.pr-number }}/
         commit-message: "Clean up doc preview for PR ${{ inputs.pr-number }} (${{ github.sha }})"
+        force: false
 
     - name: Leave a comment after removal
       if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -160,3 +160,4 @@ jobs:
           target-folder: /
           commit-message: "Deploy ${{ (inputs.is-release && 'release') || 'latest' }} docs: ${{ env.COMMIT_HASH }}"
           clean: false
+          force: false


### PR DESCRIPTION
## Summary

- set `force: false` for PR-preview deployment and cleanup
- set `force: false` for main and release documentation deployment
- retain the deploy action’s built-in rebase-and-retry behavior for concurrent updates

## Why this is needed

The documentation build itself succeeds, but the deployment action defaults to a force-push. The current `gh-pages` repository rule rejects that update with `GH013: Cannot force-push to this branch`. A concrete example is PR #238 CI job [89565291332](https://github.com/NVIDIA/numba-cuda-mlir/actions/runs/30118133382/job/89565291332): all docs were built and uploaded before the preview deployment failed at the final push.

`JamesIves/github-pages-deploy-action` documents `force: false` as the mode that rebases simultaneous deployments. Using it explicitly keeps preview folders composable while complying with the protected `gh-pages` branch. Applying the same setting to preview cleanup and main/release publication prevents the same repository-rule failure on those paths.

## Validation

- changed-file pre-commit: passed
- YAML parse of both changed files: passed
- `git diff --check`: passed
- CodeRabbit uncommitted review: 0 issues
- RoboRev commit review job 3316: no issues
- Exact-head [docs job 89571963468](https://github.com/NVIDIA/numba-cuda-mlir/actions/runs/30120198348/job/89571963468): passed, including the protected `gh-pages` preview deployment
- Exact-head GitHub Actions run [30120198348](https://github.com/NVIDIA/numba-cuda-mlir/actions/runs/30120198348): 124 successful jobs and 4 skipped; complete PR rollup 128 passed and 4 skipped

Co-authored-by: Codex 5.6 Sol Ultra Fast

