### PR TITLE
Fix out-of-bounds read in extract_cuda_args for flattened tuple args

### DIFF
--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -1415,7 +1415,13 @@ Status extract_cuda_args(PyObject* const* pyargs, size_t num_pyargs,
     helper.cuda_context = nullptr;
     for (size_t i = 0; i < num_pyargs; ++i) {
         PyObject* pyobj = pyargs[i];
-        bool is_constant = constant_arg_flags[i];
+        // constant_arg_flags is sized to the number of Python-level kernel
+        // parameters, but pyargs may contain more entries because tuple/list
+        // arguments are flattened before reaching the C++ launcher (see
+        // _flatten_arg in descriptor.py).  Flags beyond the original parameter
+        // count default to false (non-constant), matching the behaviour of
+        // PythonArgProfile::maybe_init_fast_path above.
+        bool is_constant = i < constant_arg_flags.size() && constant_arg_flags[i];
 
         switch (arg_kinds[i]) {
         case PythonArgKind::TorchTensorDlpack:


### PR DESCRIPTION
Tuple/list arguments are flattened by `_flatten_arg` in `descriptor.py` before reaching the C++ launcher, so the number of flat args can exceed the number of kernel parameters. `constant_arg_flags` is sized to the original parameter count, so indexing it with the flat arg index goes out of bounds on `std::vector<bool>`.

The fast path (`PythonArgProfile::maybe_init_fast_path`) already guards with a bounds check. Add the same guard to `extract_cuda_args`.

Without this fix, any kernel launch that passes a tuple argument alongside a device array aborts when the extension is built with `_GLIBCXX_ASSERTIONS` (as Linux distribution packages typically are). The pip wheel is unaffected because it is built without assertions, so the out-of-bounds read silently returns garbage.

<!--

Thank you for contributing to numba-cuda-mlir :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->