### PR TITLE
Avoid locking prepared planner launches

### DIFF
--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -434,8 +434,7 @@ class _ArgMarshaller:
         self._launch_config_generation = launch_config_generation
         self._stream_ref = stream_ref
         self._launch_stream = launch_stream
-        self._kernel_dispatcher_registered = False
-        self._kernel_dispatcher_registration_lock = threading.Lock()
+        self._launcher_state_lock = threading.Lock()
         self._sig_cache = {}  # {type_key: (argtypes, fast_ok)}
         self._array_sig_cache = {}  # {type_key: [(argtypes, ((idx, array_key), ...))]}
 
@@ -609,40 +608,52 @@ class _ArgMarshaller:
             elif hasattr(_compile_arg_types, "extensions"):
                 delattr(_compile_arg_types, "extensions")
 
-            active_launch_config = self._launch_config
-            active_kernel_dispatcher = self._kernel_dispatcher
-            active_launch_config_generation = self._launch_config_generation
-            launcher = self._launcher
             dispatcher = self._dispatcher
-            snapshot_launch_config_is_stale = _extensions_use_launch_config(
-                self._extensions
-                if self._has_extension_snapshot
-                else getattr(dispatcher, "extensions", ())
-            ) and self._launch_config_generation != getattr(
-                dispatcher,
-                "_launch_config_generation",
-                self._launch_config_generation,
-            )
-            if dispatcher is not None and (
+            needs_launch_readiness = dispatcher is not None and (
                 _planner_registry.has_planners
                 or getattr(dispatcher, "_requires_launch_config", False)
-                or snapshot_launch_config_is_stale
-            ):
+                or self._launch_config is not None
+            )
+            if needs_launch_readiness:
+                with self._launcher_state_lock:
+                    configured_launch_config = self._launch_config
+                    configured_kernel_dispatcher = self._kernel_dispatcher
+                    configured_launch_config_generation = self._launch_config_generation
+                    launcher = self._launcher
+            else:
+                configured_launch_config = self._launch_config
+                configured_kernel_dispatcher = self._kernel_dispatcher
+                configured_launch_config_generation = self._launch_config_generation
+                launcher = self._launcher
+            active_launch_config = configured_launch_config
+            active_kernel_dispatcher = configured_kernel_dispatcher
+            active_launch_config_generation = configured_launch_config_generation
+            if needs_launch_readiness:
+                prepared_launch = dispatcher._get_ready_launch(
+                    tuple(argtypes),
+                    self._available_launch_config,
+                    configured_launch_config,
+                    configured_kernel_dispatcher,
+                    configured_launch_config_generation,
+                )
+                if prepared_launch is None:
+                    prepared_launch = dispatcher._prepare_for_launch(
+                        tuple(launch_args),
+                        tuple(argtypes),
+                        self._available_launch_config,
+                        configured_launch_config,
+                        configured_kernel_dispatcher,
+                        configured_launch_config_generation,
+                    )
                 (
                     active_kernel_dispatcher,
                     active_launch_config_generation,
                     active_launch_config,
-                ) = dispatcher._prepare_for_launch(
-                    tuple(launch_args),
-                    tuple(argtypes),
-                    self._available_launch_config,
-                    self._launch_config,
-                    self._kernel_dispatcher,
-                    self._launch_config_generation,
-                )
+                ) = prepared_launch
                 if (
-                    active_kernel_dispatcher is not self._kernel_dispatcher
-                    or active_launch_config != self._launch_config
+                    active_kernel_dispatcher is not configured_kernel_dispatcher
+                    or active_launch_config != configured_launch_config
+                    or active_launch_config_generation != configured_launch_config_generation
                 ):
                     # A generic compile after recompile() replaces the native
                     # dispatcher without activating launch metadata. Rebuild
@@ -653,7 +664,7 @@ class _ArgMarshaller:
                         if active_launch_config is not None
                         else self._available_launch_config
                     )
-                    launcher = LaunchConfiguration(
+                    refreshed_launcher = LaunchConfiguration(
                         active_kernel_dispatcher,
                         launcher_config["grid"],
                         launcher_config["block"],
@@ -661,40 +672,39 @@ class _ArgMarshaller:
                         launcher_config["sharedmem"],
                         launcher_config.get("cluster"),
                     )
-                    with self._kernel_dispatcher_registration_lock:
-                        self._launcher = launcher
-                        self._launch_config = active_launch_config
-                        self._kernel_dispatcher = active_kernel_dispatcher
-                        self._launch_config_generation = active_launch_config_generation
-                        self._kernel_dispatcher_registered = False
+                    with self._launcher_state_lock:
+                        current_kernel_dispatcher = self._kernel_dispatcher
+                        current_launch_config_generation = self._launch_config_generation
+                        current_launch_config = self._launch_config
+                        if (
+                            current_kernel_dispatcher is active_kernel_dispatcher
+                            and current_launch_config_generation == active_launch_config_generation
+                            and current_launch_config == active_launch_config
+                        ):
+                            launcher = self._launcher
+                        elif (
+                            current_kernel_dispatcher is configured_kernel_dispatcher
+                            and current_launch_config_generation
+                            == configured_launch_config_generation
+                            and current_launch_config == configured_launch_config
+                        ):
+                            launcher = refreshed_launcher
+                            self._launcher = launcher
+                            self._launch_config = active_launch_config
+                            self._kernel_dispatcher = active_kernel_dispatcher
+                            self._launch_config_generation = active_launch_config_generation
+                        else:
+                            # A newer concurrent refresh supersedes both this
+                            # call's snapshot and its prepared state.
+                            launcher = self._launcher
+                            active_launch_config = current_launch_config
+                            active_kernel_dispatcher = current_kernel_dispatcher
+                            active_launch_config_generation = current_launch_config_generation
 
             if active_launch_config is not None:
                 _compile_arg_types.launch_config = active_launch_config
             elif hasattr(_compile_arg_types, "launch_config"):
                 delattr(_compile_arg_types, "launch_config")
-            if (
-                dispatcher is not None
-                and active_launch_config is not None
-                and active_kernel_dispatcher is not None
-            ):
-                with self._kernel_dispatcher_registration_lock:
-                    if self._kernel_dispatcher_registered and hasattr(
-                        dispatcher, "_is_kernel_dispatcher_registered"
-                    ):
-                        self._kernel_dispatcher_registered = (
-                            dispatcher._is_kernel_dispatcher_registered(
-                                active_launch_config,
-                                active_kernel_dispatcher,
-                                active_launch_config_generation,
-                            )
-                        )
-                    if not self._kernel_dispatcher_registered:
-                        self._kernel_dispatcher_registered = dispatcher._remember_kernel_dispatcher(
-                            active_launch_config,
-                            active_kernel_dispatcher,
-                            active_launch_config_generation,
-                            replace_existing=False,
-                        )
             return launcher(*launch_args)
         except UserFacingInternalCompilerError as e:
             if os.environ.get("NUMBA_CUDA_MLIR_ICE_FULL_TB", "0").strip() == "1":
@@ -2447,6 +2457,75 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 return cres
         return None
 
+    def _active_launch_config(self, available_launch_config, configured_launch_config):
+        if self._requires_launch_config:
+            return _normalize_available_launch_config(available_launch_config)
+        return configured_launch_config
+
+    def _get_ready_launch(
+        self,
+        argtypes,
+        available_launch_config,
+        configured_launch_config,
+        configured_kernel_dispatcher,
+        configured_launch_config_generation,
+        *,
+        allow_compatible=False,
+    ):
+        """Return current launch state when no preparation is required.
+
+        The unlocked caller uses an exact generic-overload lookup so it never
+        iterates compiler-owned state. Launch-qualified compatibility is
+        resolved under the dispatcher state lock, and locked preparation may
+        also reuse compatible generic overloads.
+        """
+
+        if configured_launch_config is None and not self._requires_launch_config:
+            kernel_dispatcher = self._c
+            if (
+                configured_kernel_dispatcher is not kernel_dispatcher
+                or configured_launch_config_generation is not None
+            ):
+                return None
+            compile_result = self.overloads.get(argtypes)
+            if compile_result is None and allow_compatible:
+                compile_result = self._compile_result_for(argtypes, None)
+            if compile_result is None:
+                return None
+            if self._requires_launch_config or self._c is not kernel_dispatcher:
+                return None
+            return kernel_dispatcher, None, None
+
+        with self._launch_config_lock:
+            launch_config = self._active_launch_config(
+                available_launch_config,
+                configured_launch_config,
+            )
+            if launch_config is None:
+                return None
+
+            launch_config_key = _launch_config_key(launch_config)
+            compile_result = self._find_launch_config_overload_locked(
+                argtypes,
+                launch_config_key,
+            )
+            if compile_result is None:
+                return None
+
+            if (
+                configured_launch_config_generation != self._launch_config_generation
+                or self._launch_config_dispatchers.get(launch_config_key)
+                is not configured_kernel_dispatcher
+            ):
+                return None
+            self._launch_config_dispatchers.move_to_end(launch_config_key)
+            return (
+                configured_kernel_dispatcher,
+                configured_launch_config_generation,
+                launch_config,
+            )
+
+    @global_compiler_lock
     def _prepare_for_launch(
         self,
         args,
@@ -2456,53 +2535,96 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         configured_kernel_dispatcher,
         configured_launch_config_generation,
     ):
-        def active_launch_config():
-            if self._requires_launch_config:
-                return _normalize_available_launch_config(available_launch_config)
-            return configured_launch_config
+        ready_launch = self._get_ready_launch(
+            argtypes,
+            available_launch_config,
+            configured_launch_config,
+            configured_kernel_dispatcher,
+            configured_launch_config_generation,
+            allow_compatible=True,
+        )
+        if ready_launch is not None:
+            return ready_launch
 
-        launch_config = active_launch_config()
+        launch_config = self._active_launch_config(
+            available_launch_config,
+            configured_launch_config,
+        )
         compile_result = self._compile_result_for(argtypes, launch_config)
         if compile_result is None:
-            with global_compiler_lock:
-                # Another launch may have compiled the signature while this
-                # launch waited for the compiler lock. Launch sensitivity may
-                # also have changed, so refresh both inputs before compiling.
-                launch_config = active_launch_config()
-                compile_result = self._compile_result_for(argtypes, launch_config)
-                if compile_result is None:
-                    self._compile_impl(list(args))
-                    launch_config = active_launch_config()
-                    compile_result = self._compile_result_for(argtypes, launch_config)
+            self._compile_impl(list(args))
+            launch_config = self._active_launch_config(
+                available_launch_config,
+                configured_launch_config,
+            )
+            compile_result = self._compile_result_for(argtypes, launch_config)
 
         if compile_result is None:
             raise RuntimeError(
                 "kernel precompilation completed without publishing a matching overload"
             )
 
-        if launch_config is None:
-            return self._c, None, None
-        if not self._requires_launch_config and configured_launch_config is not None:
-            if self._is_kernel_dispatcher_registered(
-                configured_launch_config,
+        ready_launch = self._get_ready_launch(
+            argtypes,
+            available_launch_config,
+            launch_config,
+            configured_kernel_dispatcher,
+            configured_launch_config_generation,
+            allow_compatible=True,
+        )
+        if ready_launch is not None:
+            return ready_launch
+
+        if (
+            launch_config is not None
+            and not self._requires_launch_config
+            and configured_launch_config is not None
+            and configured_kernel_dispatcher is not None
+            and configured_launch_config_generation is not None
+        ):
+            # Cache eviction removes both the registration and its Python
+            # overload entries. Once the overload is republished, retain the
+            # configured native dispatcher when its generation is still current.
+            self._remember_kernel_dispatcher(
+                launch_config,
                 configured_kernel_dispatcher,
                 configured_launch_config_generation,
-            ):
-                return (
-                    configured_kernel_dispatcher,
-                    configured_launch_config_generation,
-                    configured_launch_config,
-                )
+                replace_existing=False,
+            )
+            ready_launch = self._get_ready_launch(
+                argtypes,
+                available_launch_config,
+                launch_config,
+                configured_kernel_dispatcher,
+                configured_launch_config_generation,
+                allow_compatible=True,
+            )
+            if ready_launch is not None:
+                return ready_launch
+
+        if launch_config is None:
+            kernel_dispatcher = self._c
+            generation = None
+        else:
             # A retained marshaller may outlive recompile() or removal of the
             # extension that originally opted it into launch specialization.
-            # Its extension snapshot still requires a launch-keyed native
-            # dispatcher for the freshly compiled overload.
             kernel_dispatcher, generation = self._get_launch_config_dispatcher_and_generation(
                 launch_config
             )
-            return kernel_dispatcher, generation, launch_config
-        kernel_dispatcher, generation = self._get_kernel_dispatcher_and_generation(launch_config)
-        return kernel_dispatcher, generation, launch_config
+
+        ready_launch = self._get_ready_launch(
+            argtypes,
+            available_launch_config,
+            launch_config,
+            kernel_dispatcher,
+            generation,
+            allow_compatible=True,
+        )
+        if ready_launch is None:
+            raise RuntimeError(
+                "kernel precompilation completed without publishing ready launch state"
+            )
+        return ready_launch
 
     def _raise_ambiguous(self, argtypes, tied):
         sigs_str = "\n".join(f"{sig_args} -> none" for sig_args in tied)

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -2447,7 +2447,6 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 return cres
         return None
 
-    @global_compiler_lock
     def _prepare_for_launch(
         self,
         args,
@@ -2463,11 +2462,20 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             return configured_launch_config
 
         launch_config = active_launch_config()
-        if self._compile_result_for(argtypes, launch_config) is None:
-            self._compile_impl(list(args))
-            launch_config = active_launch_config()
+        compile_result = self._compile_result_for(argtypes, launch_config)
+        if compile_result is None:
+            with global_compiler_lock:
+                # Another launch may have compiled the signature while this
+                # launch waited for the compiler lock. Launch sensitivity may
+                # also have changed, so refresh both inputs before compiling.
+                launch_config = active_launch_config()
+                compile_result = self._compile_result_for(argtypes, launch_config)
+                if compile_result is None:
+                    self._compile_impl(list(args))
+                    launch_config = active_launch_config()
+                    compile_result = self._compile_result_for(argtypes, launch_config)
 
-        if self._compile_result_for(argtypes, launch_config) is None:
+        if compile_result is None:
             raise RuntimeError(
                 "kernel precompilation completed without publishing a matching overload"
             )

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -434,7 +434,6 @@ class _ArgMarshaller:
         self._launch_config_generation = launch_config_generation
         self._stream_ref = stream_ref
         self._launch_stream = launch_stream
-        self._launcher_state_lock = threading.Lock()
         self._sig_cache = {}  # {type_key: (argtypes, fast_ok)}
         self._array_sig_cache = {}  # {type_key: [(argtypes, ((idx, array_key), ...))]}
 
@@ -608,52 +607,40 @@ class _ArgMarshaller:
             elif hasattr(_compile_arg_types, "extensions"):
                 delattr(_compile_arg_types, "extensions")
 
+            active_launch_config = self._launch_config
+            active_kernel_dispatcher = self._kernel_dispatcher
+            active_launch_config_generation = self._launch_config_generation
+            launcher = self._launcher
             dispatcher = self._dispatcher
-            needs_launch_readiness = dispatcher is not None and (
+            if dispatcher is not None and (
                 _planner_registry.has_planners
                 or getattr(dispatcher, "_requires_launch_config", False)
                 or self._launch_config is not None
-            )
-            if needs_launch_readiness:
-                with self._launcher_state_lock:
-                    configured_launch_config = self._launch_config
-                    configured_kernel_dispatcher = self._kernel_dispatcher
-                    configured_launch_config_generation = self._launch_config_generation
-                    launcher = self._launcher
-            else:
-                configured_launch_config = self._launch_config
-                configured_kernel_dispatcher = self._kernel_dispatcher
-                configured_launch_config_generation = self._launch_config_generation
-                launcher = self._launcher
-            active_launch_config = configured_launch_config
-            active_kernel_dispatcher = configured_kernel_dispatcher
-            active_launch_config_generation = configured_launch_config_generation
-            if needs_launch_readiness:
-                prepared_launch = dispatcher._get_ready_launch(
+            ):
+                ready_launch = dispatcher._get_ready_launch(
                     tuple(argtypes),
                     self._available_launch_config,
-                    configured_launch_config,
-                    configured_kernel_dispatcher,
-                    configured_launch_config_generation,
+                    self._launch_config,
+                    self._kernel_dispatcher,
+                    self._launch_config_generation,
                 )
-                if prepared_launch is None:
-                    prepared_launch = dispatcher._prepare_for_launch(
+                if ready_launch is None:
+                    ready_launch = dispatcher._prepare_for_launch(
                         tuple(launch_args),
                         tuple(argtypes),
                         self._available_launch_config,
-                        configured_launch_config,
-                        configured_kernel_dispatcher,
-                        configured_launch_config_generation,
+                        self._launch_config,
+                        self._kernel_dispatcher,
+                        self._launch_config_generation,
                     )
                 (
                     active_kernel_dispatcher,
                     active_launch_config_generation,
                     active_launch_config,
-                ) = prepared_launch
+                ) = ready_launch
                 if (
-                    active_kernel_dispatcher is not configured_kernel_dispatcher
-                    or active_launch_config != configured_launch_config
-                    or active_launch_config_generation != configured_launch_config_generation
+                    active_kernel_dispatcher is not self._kernel_dispatcher
+                    or active_launch_config != self._launch_config
                 ):
                     # A generic compile after recompile() replaces the native
                     # dispatcher without activating launch metadata. Rebuild
@@ -664,7 +651,7 @@ class _ArgMarshaller:
                         if active_launch_config is not None
                         else self._available_launch_config
                     )
-                    refreshed_launcher = LaunchConfiguration(
+                    launcher = LaunchConfiguration(
                         active_kernel_dispatcher,
                         launcher_config["grid"],
                         launcher_config["block"],
@@ -672,34 +659,10 @@ class _ArgMarshaller:
                         launcher_config["sharedmem"],
                         launcher_config.get("cluster"),
                     )
-                    with self._launcher_state_lock:
-                        current_kernel_dispatcher = self._kernel_dispatcher
-                        current_launch_config_generation = self._launch_config_generation
-                        current_launch_config = self._launch_config
-                        if (
-                            current_kernel_dispatcher is active_kernel_dispatcher
-                            and current_launch_config_generation == active_launch_config_generation
-                            and current_launch_config == active_launch_config
-                        ):
-                            launcher = self._launcher
-                        elif (
-                            current_kernel_dispatcher is configured_kernel_dispatcher
-                            and current_launch_config_generation
-                            == configured_launch_config_generation
-                            and current_launch_config == configured_launch_config
-                        ):
-                            launcher = refreshed_launcher
-                            self._launcher = launcher
-                            self._launch_config = active_launch_config
-                            self._kernel_dispatcher = active_kernel_dispatcher
-                            self._launch_config_generation = active_launch_config_generation
-                        else:
-                            # A newer concurrent refresh supersedes both this
-                            # call's snapshot and its prepared state.
-                            launcher = self._launcher
-                            active_launch_config = current_launch_config
-                            active_kernel_dispatcher = current_kernel_dispatcher
-                            active_launch_config_generation = current_launch_config_generation
+                    self._launcher = launcher
+                    self._launch_config = active_launch_config
+                    self._kernel_dispatcher = active_kernel_dispatcher
+                    self._launch_config_generation = active_launch_config_generation
 
             if active_launch_config is not None:
                 _compile_arg_types.launch_config = active_launch_config
@@ -2457,11 +2420,6 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 return cres
         return None
 
-    def _active_launch_config(self, available_launch_config, configured_launch_config):
-        if self._requires_launch_config:
-            return _normalize_available_launch_config(available_launch_config)
-        return configured_launch_config
-
     def _get_ready_launch(
         self,
         argtypes,
@@ -2469,51 +2427,35 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         configured_launch_config,
         configured_kernel_dispatcher,
         configured_launch_config_generation,
-        *,
-        allow_compatible=False,
     ):
-        """Return current launch state when no preparation is required.
-
-        The unlocked caller uses an exact generic-overload lookup so it never
-        iterates compiler-owned state. Launch-qualified compatibility is
-        resolved under the dispatcher state lock, and locked preparation may
-        also reuse compatible generic overloads.
-        """
+        """Return current launch state, or None when preparation is required."""
 
         if configured_launch_config is None and not self._requires_launch_config:
             kernel_dispatcher = self._c
             if (
                 configured_kernel_dispatcher is not kernel_dispatcher
                 or configured_launch_config_generation is not None
+                or self.overloads.get(argtypes) is None
             ):
                 return None
-            compile_result = self.overloads.get(argtypes)
-            if compile_result is None and allow_compatible:
-                compile_result = self._compile_result_for(argtypes, None)
-            if compile_result is None:
-                return None
+            # Launch sensitivity or the native dispatcher may have changed
+            # during the unlocked overload lookup.
             if self._requires_launch_config or self._c is not kernel_dispatcher:
                 return None
             return kernel_dispatcher, None, None
 
         with self._launch_config_lock:
-            launch_config = self._active_launch_config(
-                available_launch_config,
-                configured_launch_config,
+            launch_config = (
+                _normalize_available_launch_config(available_launch_config)
+                if self._requires_launch_config
+                else configured_launch_config
             )
             if launch_config is None:
                 return None
-
             launch_config_key = _launch_config_key(launch_config)
-            compile_result = self._find_launch_config_overload_locked(
-                argtypes,
-                launch_config_key,
-            )
-            if compile_result is None:
-                return None
-
             if (
-                configured_launch_config_generation != self._launch_config_generation
+                self._find_launch_config_overload_locked(argtypes, launch_config_key) is None
+                or configured_launch_config_generation != self._launch_config_generation
                 or self._launch_config_dispatchers.get(launch_config_key)
                 is not configured_kernel_dispatcher
             ):
@@ -2535,28 +2477,42 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         configured_kernel_dispatcher,
         configured_launch_config_generation,
     ):
+        def active_launch_config():
+            if self._requires_launch_config:
+                return _normalize_available_launch_config(available_launch_config)
+            return configured_launch_config
+
         ready_launch = self._get_ready_launch(
             argtypes,
             available_launch_config,
             configured_launch_config,
             configured_kernel_dispatcher,
             configured_launch_config_generation,
-            allow_compatible=True,
         )
         if ready_launch is not None:
             return ready_launch
 
-        launch_config = self._active_launch_config(
-            available_launch_config,
-            configured_launch_config,
-        )
+        launch_config = active_launch_config()
         compile_result = self._compile_result_for(argtypes, launch_config)
         if compile_result is None:
+            if (
+                launch_config is not None
+                and not self._requires_launch_config
+                and configured_launch_config is not None
+                and configured_kernel_dispatcher is not None
+                and configured_launch_config_generation is not None
+            ):
+                # Cache eviction removes both the overload and its native
+                # dispatcher registration. Restore a retained dispatcher only
+                # while its generation is still current.
+                self._remember_kernel_dispatcher(
+                    launch_config,
+                    configured_kernel_dispatcher,
+                    configured_launch_config_generation,
+                    replace_existing=False,
+                )
             self._compile_impl(list(args))
-            launch_config = self._active_launch_config(
-                available_launch_config,
-                configured_launch_config,
-            )
+            launch_config = active_launch_config()
             compile_result = self._compile_result_for(argtypes, launch_config)
 
         if compile_result is None:
@@ -2564,67 +2520,29 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 "kernel precompilation completed without publishing a matching overload"
             )
 
-        ready_launch = self._get_ready_launch(
-            argtypes,
-            available_launch_config,
-            launch_config,
-            configured_kernel_dispatcher,
-            configured_launch_config_generation,
-            allow_compatible=True,
-        )
-        if ready_launch is not None:
-            return ready_launch
-
-        if (
-            launch_config is not None
-            and not self._requires_launch_config
-            and configured_launch_config is not None
-            and configured_kernel_dispatcher is not None
-            and configured_launch_config_generation is not None
-        ):
-            # Cache eviction removes both the registration and its Python
-            # overload entries. Once the overload is republished, retain the
-            # configured native dispatcher when its generation is still current.
-            self._remember_kernel_dispatcher(
-                launch_config,
-                configured_kernel_dispatcher,
-                configured_launch_config_generation,
-                replace_existing=False,
-            )
-            ready_launch = self._get_ready_launch(
-                argtypes,
-                available_launch_config,
-                launch_config,
-                configured_kernel_dispatcher,
-                configured_launch_config_generation,
-                allow_compatible=True,
-            )
-            if ready_launch is not None:
-                return ready_launch
-
         if launch_config is None:
-            kernel_dispatcher = self._c
-            generation = None
-        else:
+            return self._c, None, None
+        if not self._requires_launch_config and configured_launch_config is not None:
+            if self._is_kernel_dispatcher_registered(
+                configured_launch_config,
+                configured_kernel_dispatcher,
+                configured_launch_config_generation,
+            ):
+                return (
+                    configured_kernel_dispatcher,
+                    configured_launch_config_generation,
+                    configured_launch_config,
+                )
             # A retained marshaller may outlive recompile() or removal of the
             # extension that originally opted it into launch specialization.
+            # Its extension snapshot still requires a launch-keyed native
+            # dispatcher for the freshly compiled overload.
             kernel_dispatcher, generation = self._get_launch_config_dispatcher_and_generation(
                 launch_config
             )
-
-        ready_launch = self._get_ready_launch(
-            argtypes,
-            available_launch_config,
-            launch_config,
-            kernel_dispatcher,
-            generation,
-            allow_compatible=True,
-        )
-        if ready_launch is None:
-            raise RuntimeError(
-                "kernel precompilation completed without publishing ready launch state"
-            )
-        return ready_launch
+            return kernel_dispatcher, generation, launch_config
+        kernel_dispatcher, generation = self._get_kernel_dispatcher_and_generation(launch_config)
+        return kernel_dispatcher, generation, launch_config
 
     def _raise_ambiguous(self, argtypes, tied):
         sigs_str = "\n".join(f"{sig_args} -> none" for sig_args in tied)

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -397,109 +397,6 @@ def test_arg_marshaller_rebinds_for_retained_launch_extension_snapshot(monkeypat
     assert marshaller._launch_config_generation == 8
 
 
-def test_arg_marshaller_does_not_launch_stale_snapshot_after_concurrent_refresh(
-    monkeypatch,
-):
-    configured_kernel_dispatcher = object()
-    refreshed_kernel_dispatcher = object()
-    launch_config = {
-        "grid": (2, 1, 1),
-        "block": (64, 1, 1),
-        "sharedmem": 256,
-        "cluster": None,
-    }
-    dispatcher = _Dispatcher()
-    dispatcher._requires_launch_config = True
-    observed_ready_state = []
-    monkeypatch.setattr(
-        descriptor_mod,
-        "LaunchConfiguration",
-        lambda *args: lambda: "rebuilt",
-    )
-
-    marshaller = _ArgMarshaller(
-        lambda: "stale",
-        dispatcher=dispatcher,
-        launch_config=launch_config,
-        available_launch_config=launch_config,
-        kernel_dispatcher=configured_kernel_dispatcher,
-        launch_config_generation=7,
-    )
-
-    def get_ready_launch(
-        argtypes,
-        available_launch_config,
-        configured_launch_config,
-        kernel_dispatcher,
-        launch_config_generation,
-    ):
-        observed_ready_state.append(
-            (
-                configured_launch_config,
-                kernel_dispatcher,
-                launch_config_generation,
-            )
-        )
-        with marshaller._launcher_state_lock:
-            marshaller._launcher = lambda: "concurrent"
-            marshaller._kernel_dispatcher = refreshed_kernel_dispatcher
-            marshaller._launch_config_generation = 8
-        return refreshed_kernel_dispatcher, 8, launch_config
-
-    dispatcher._get_ready_launch = get_ready_launch
-
-    assert marshaller() == "concurrent"
-    assert observed_ready_state == [(launch_config, configured_kernel_dispatcher, 7)]
-
-
-def test_arg_marshaller_uses_newer_refresh_over_prepared_state(monkeypatch):
-    configured_kernel_dispatcher = object()
-    prepared_kernel_dispatcher = object()
-    newer_kernel_dispatcher = object()
-    configured_launch_config = {
-        "grid": (2, 1, 1),
-        "block": (64, 1, 1),
-        "sharedmem": 256,
-        "cluster": None,
-    }
-    prepared_launch_config = {**configured_launch_config, "sharedmem": 512}
-    newer_launch_config = {**configured_launch_config, "sharedmem": 1024}
-    dispatcher = _Dispatcher()
-    dispatcher._requires_launch_config = True
-    observed_launch_configs = []
-    monkeypatch.setattr(
-        descriptor_mod,
-        "LaunchConfiguration",
-        lambda *args: lambda: "prepared",
-    )
-
-    marshaller = _ArgMarshaller(
-        lambda: "stale",
-        dispatcher=dispatcher,
-        launch_config=configured_launch_config,
-        available_launch_config=configured_launch_config,
-        kernel_dispatcher=configured_kernel_dispatcher,
-        launch_config_generation=7,
-    )
-
-    def newer_launcher():
-        observed_launch_configs.append(descriptor_mod._compile_arg_types.launch_config)
-        return "newer"
-
-    def get_ready_launch(*args):
-        with marshaller._launcher_state_lock:
-            marshaller._launcher = newer_launcher
-            marshaller._launch_config = newer_launch_config
-            marshaller._kernel_dispatcher = newer_kernel_dispatcher
-            marshaller._launch_config_generation = 9
-        return prepared_kernel_dispatcher, 8, prepared_launch_config
-
-    dispatcher._get_ready_launch = get_ready_launch
-
-    assert marshaller() == "newer"
-    assert observed_launch_configs == [newer_launch_config]
-
-
 def test_arg_marshaller_ready_launch_does_not_mutate_dispatcher_registration():
     dispatcher = _Dispatcher()
     launch_config = {
@@ -651,7 +548,7 @@ def test_configure_cache_tracks_mutated_non_launch_extensions(monkeypatch):
     assert updated._launch_config is None
 
 
-def test_ready_launch_uses_retained_launch_extension_snapshot(monkeypatch):
+def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
     def launch_configuration(kernel_dispatcher, *args):
         return lambda *launch_args: None
 
@@ -668,13 +565,18 @@ def test_ready_launch_uses_retained_launch_extension_snapshot(monkeypatch):
     retained_launch_config = marshaller._launch_config
     retained_kernel_dispatcher = marshaller._kernel_dispatcher
     retained_generation = marshaller._launch_config_generation
-    argtypes = (types.int32,)
-    launch_key = descriptor_mod._launch_config_key(retained_launch_config)
-    dispatcher._launch_config_overloads[(argtypes, launch_key)] = object()
+    observed_configs = []
+
+    def compile_result_for(argtypes, launch_config):
+        observed_configs.append(launch_config)
+        return object()
+
+    monkeypatch.setattr(dispatcher, "_compile_result_for", compile_result_for)
     dispatcher.extensions.clear()
 
-    prepared = dispatcher._get_ready_launch(
-        argtypes,
+    prepared = dispatcher._prepare_for_launch(
+        (),
+        (types.int32,),
         marshaller._available_launch_config,
         retained_launch_config,
         retained_kernel_dispatcher,
@@ -686,6 +588,7 @@ def test_ready_launch_uses_retained_launch_extension_snapshot(monkeypatch):
         retained_generation,
         retained_launch_config,
     )
+    assert observed_configs == [retained_launch_config]
 
 
 def test_ready_launch_known_signature_avoids_lock_and_overload_iteration(monkeypatch):
@@ -761,48 +664,7 @@ def test_prelaunch_rechecks_readiness_after_global_compiler_lock(monkeypatch):
     assert events == ["ready", "lock", "ready", "launch"]
 
 
-def test_prelaunch_reuses_compatible_generic_overload_under_lock(monkeypatch):
-    def kernel(value):
-        pass
-
-    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
-    dispatcher.overloads[(types.int32,)] = object()
-    available_launch_config = {
-        "grid": (1, 1, 1),
-        "block": (32, 1, 1),
-        "sharedmem": 0,
-        "cluster": None,
-    }
-
-    assert (
-        dispatcher._get_ready_launch(
-            (types.int64,),
-            available_launch_config,
-            None,
-            dispatcher._c,
-            None,
-        )
-        is None
-    )
-    monkeypatch.setattr(
-        dispatcher,
-        "_compile_impl",
-        lambda args: pytest.fail("the compatible overload must be reused"),
-    )
-
-    prepared = dispatcher._prepare_for_launch(
-        (1,),
-        (types.int64,),
-        available_launch_config,
-        None,
-        dispatcher._c,
-        None,
-    )
-
-    assert prepared == (dispatcher._c, None, None)
-
-
-def test_ready_launch_validates_launch_overload_dispatcher_and_generation():
+def test_ready_launch_validates_specialized_state():
     def kernel(value):
         pass
 
@@ -820,20 +682,9 @@ def test_ready_launch_validates_launch_overload_dispatcher_and_generation():
     launch_key = descriptor_mod._launch_config_key(launch_config)
     kernel_dispatcher, generation = dispatcher._get_kernel_dispatcher_and_generation(launch_config)
     dispatcher._launch_config_overloads[(argtypes, launch_key)] = object()
-    other_launch_config = {**launch_config, "block": (64, 1, 1)}
-    dispatcher._get_kernel_dispatcher_and_generation(other_launch_config)
-    assert next(reversed(dispatcher._launch_config_dispatchers)) != launch_key
 
     assert dispatcher._get_ready_launch(
         argtypes,
-        launch_config,
-        launch_config,
-        kernel_dispatcher,
-        generation,
-    ) == (kernel_dispatcher, generation, launch_config)
-    assert next(reversed(dispatcher._launch_config_dispatchers)) == launch_key
-    assert dispatcher._get_ready_launch(
-        (types.int64,),
         launch_config,
         launch_config,
         kernel_dispatcher,
@@ -1741,14 +1592,11 @@ def test_retained_marshaller_compiles_with_extension_snapshot_after_mutation(mon
         "sharedmem": 0,
         "cluster": None,
     }
-    kernel_dispatcher, generation = dispatcher._get_kernel_dispatcher_and_generation(launch_config)
     marshaller = _ArgMarshaller(
         lambda *args: dispatcher._compile_impl(list(args)),
         extensions=dispatcher.extensions,
         dispatcher=dispatcher,
         launch_config=launch_config,
-        kernel_dispatcher=kernel_dispatcher,
-        launch_config_generation=generation,
     )
     dispatcher.extensions.clear()
 

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -13,7 +13,10 @@ from numba_cuda_mlir import cuda
 from numba_cuda_mlir.cuda.experimental import consteval, current_target_options
 from numba_cuda_mlir.descriptor import _ArgMarshaller
 from numba_cuda_mlir._launch_config import _LAUNCH_CONFIG_TRACKER_OPTION
-from numba_cuda_mlir._whole_function_planners import _RequireLaunchConfig
+from numba_cuda_mlir._whole_function_planners import (
+    _planner_registry,
+    _RequireLaunchConfig,
+)
 from numba_cuda_mlir.numba_cuda import types, typing as cuda_typing
 
 
@@ -24,6 +27,20 @@ class _Dispatcher:
         self.overloads = {}
         self._launch_config_lock = threading.RLock()
         self.remembered_dispatchers = []
+
+    def _get_ready_launch(
+        self,
+        argtypes,
+        available_launch_config,
+        configured_launch_config,
+        configured_kernel_dispatcher,
+        configured_launch_config_generation,
+    ):
+        return (
+            configured_kernel_dispatcher,
+            configured_launch_config_generation,
+            configured_launch_config,
+        )
 
     def _remember_kernel_dispatcher(
         self,
@@ -236,6 +253,10 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
     dispatcher._requires_launch_config = True
     prepare_calls = []
     launches = []
+    ready_launch = None
+
+    def get_ready_launch(*args):
+        return ready_launch
 
     def prepare_for_launch(
         args,
@@ -245,6 +266,7 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
         configured_kernel_dispatcher,
         configured_launch_config_generation,
     ):
+        nonlocal ready_launch
         prepare_calls.append(
             (
                 args,
@@ -255,7 +277,8 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
                 configured_launch_config_generation,
             )
         )
-        return launch_kernel_dispatcher, 7, active_launch_config
+        ready_launch = launch_kernel_dispatcher, 7, active_launch_config
+        return ready_launch
 
     def launch_configuration(
         kernel_dispatcher,
@@ -282,6 +305,7 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
 
         return launch
 
+    dispatcher._get_ready_launch = get_ready_launch
     dispatcher._prepare_for_launch = prepare_for_launch
     monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
 
@@ -296,15 +320,14 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
     assert marshaller() == "qualified"
     assert marshaller() == "qualified"
     assert prepare_calls == [
-        ((), (), available_launch_config, None, generic_kernel_dispatcher, None),
         (
             (),
             (),
             available_launch_config,
-            active_launch_config,
-            launch_kernel_dispatcher,
-            7,
-        ),
+            None,
+            generic_kernel_dispatcher,
+            None,
+        )
     ]
     assert launches == [
         (
@@ -318,9 +341,7 @@ def test_arg_marshaller_rebinds_to_requested_launch_configuration(monkeypatch):
     ]
     assert marshaller._launch_config == active_launch_config
     assert marshaller._launch_config_generation == 7
-    assert dispatcher.remembered_dispatchers == [
-        (active_launch_config, launch_kernel_dispatcher, active_launch_config, 7)
-    ]
+    assert dispatcher.remembered_dispatchers == []
     assert not hasattr(descriptor_mod._compile_arg_types, "launch_config")
     assert not hasattr(descriptor_mod._compile_arg_types, "available_launch_config")
 
@@ -343,6 +364,7 @@ def test_arg_marshaller_rebinds_for_retained_launch_extension_snapshot(monkeypat
         prepare_calls.append(args)
         return refreshed_kernel_dispatcher, 8, launch_config
 
+    dispatcher._get_ready_launch = lambda *args: None
     dispatcher._prepare_for_launch = prepare_for_launch
     monkeypatch.setattr(
         descriptor_mod,
@@ -375,7 +397,110 @@ def test_arg_marshaller_rebinds_for_retained_launch_extension_snapshot(monkeypat
     assert marshaller._launch_config_generation == 8
 
 
-def test_arg_marshaller_refreshes_launch_config_dispatcher():
+def test_arg_marshaller_does_not_launch_stale_snapshot_after_concurrent_refresh(
+    monkeypatch,
+):
+    configured_kernel_dispatcher = object()
+    refreshed_kernel_dispatcher = object()
+    launch_config = {
+        "grid": (2, 1, 1),
+        "block": (64, 1, 1),
+        "sharedmem": 256,
+        "cluster": None,
+    }
+    dispatcher = _Dispatcher()
+    dispatcher._requires_launch_config = True
+    observed_ready_state = []
+    monkeypatch.setattr(
+        descriptor_mod,
+        "LaunchConfiguration",
+        lambda *args: lambda: "rebuilt",
+    )
+
+    marshaller = _ArgMarshaller(
+        lambda: "stale",
+        dispatcher=dispatcher,
+        launch_config=launch_config,
+        available_launch_config=launch_config,
+        kernel_dispatcher=configured_kernel_dispatcher,
+        launch_config_generation=7,
+    )
+
+    def get_ready_launch(
+        argtypes,
+        available_launch_config,
+        configured_launch_config,
+        kernel_dispatcher,
+        launch_config_generation,
+    ):
+        observed_ready_state.append(
+            (
+                configured_launch_config,
+                kernel_dispatcher,
+                launch_config_generation,
+            )
+        )
+        with marshaller._launcher_state_lock:
+            marshaller._launcher = lambda: "concurrent"
+            marshaller._kernel_dispatcher = refreshed_kernel_dispatcher
+            marshaller._launch_config_generation = 8
+        return refreshed_kernel_dispatcher, 8, launch_config
+
+    dispatcher._get_ready_launch = get_ready_launch
+
+    assert marshaller() == "concurrent"
+    assert observed_ready_state == [(launch_config, configured_kernel_dispatcher, 7)]
+
+
+def test_arg_marshaller_uses_newer_refresh_over_prepared_state(monkeypatch):
+    configured_kernel_dispatcher = object()
+    prepared_kernel_dispatcher = object()
+    newer_kernel_dispatcher = object()
+    configured_launch_config = {
+        "grid": (2, 1, 1),
+        "block": (64, 1, 1),
+        "sharedmem": 256,
+        "cluster": None,
+    }
+    prepared_launch_config = {**configured_launch_config, "sharedmem": 512}
+    newer_launch_config = {**configured_launch_config, "sharedmem": 1024}
+    dispatcher = _Dispatcher()
+    dispatcher._requires_launch_config = True
+    observed_launch_configs = []
+    monkeypatch.setattr(
+        descriptor_mod,
+        "LaunchConfiguration",
+        lambda *args: lambda: "prepared",
+    )
+
+    marshaller = _ArgMarshaller(
+        lambda: "stale",
+        dispatcher=dispatcher,
+        launch_config=configured_launch_config,
+        available_launch_config=configured_launch_config,
+        kernel_dispatcher=configured_kernel_dispatcher,
+        launch_config_generation=7,
+    )
+
+    def newer_launcher():
+        observed_launch_configs.append(descriptor_mod._compile_arg_types.launch_config)
+        return "newer"
+
+    def get_ready_launch(*args):
+        with marshaller._launcher_state_lock:
+            marshaller._launcher = newer_launcher
+            marshaller._launch_config = newer_launch_config
+            marshaller._kernel_dispatcher = newer_kernel_dispatcher
+            marshaller._launch_config_generation = 9
+        return prepared_kernel_dispatcher, 8, prepared_launch_config
+
+    dispatcher._get_ready_launch = get_ready_launch
+
+    assert marshaller() == "newer"
+    assert observed_launch_configs == [newer_launch_config]
+
+
+def test_arg_marshaller_ready_launch_does_not_mutate_dispatcher_registration():
     dispatcher = _Dispatcher()
     launch_config = {
         "grid": (1, 1, 1),
@@ -395,9 +520,7 @@ def test_arg_marshaller_refreshes_launch_config_dispatcher():
     marshaller()
     marshaller()
 
-    assert dispatcher.remembered_dispatchers == [
-        (launch_config, kernel_dispatcher, launch_config, None)
-    ]
+    assert dispatcher.remembered_dispatchers == []
 
 
 def test_configure_records_normalized_launch_config(monkeypatch):
@@ -528,7 +651,7 @@ def test_configure_cache_tracks_mutated_non_launch_extensions(monkeypatch):
     assert updated._launch_config is None
 
 
-def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
+def test_ready_launch_uses_retained_launch_extension_snapshot(monkeypatch):
     def launch_configuration(kernel_dispatcher, *args):
         return lambda *launch_args: None
 
@@ -545,18 +668,13 @@ def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
     retained_launch_config = marshaller._launch_config
     retained_kernel_dispatcher = marshaller._kernel_dispatcher
     retained_generation = marshaller._launch_config_generation
-    observed_configs = []
-
-    def compile_result_for(argtypes, launch_config):
-        observed_configs.append(launch_config)
-        return object()
-
-    monkeypatch.setattr(dispatcher, "_compile_result_for", compile_result_for)
+    argtypes = (types.int32,)
+    launch_key = descriptor_mod._launch_config_key(retained_launch_config)
+    dispatcher._launch_config_overloads[(argtypes, launch_key)] = object()
     dispatcher.extensions.clear()
 
-    prepared = dispatcher._prepare_for_launch(
-        (),
-        (types.int32,),
+    prepared = dispatcher._get_ready_launch(
+        argtypes,
         marshaller._available_launch_config,
         retained_launch_config,
         retained_kernel_dispatcher,
@@ -568,16 +686,23 @@ def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
         retained_generation,
         retained_launch_config,
     )
-    assert observed_configs == [retained_launch_config]
 
 
-def test_prelaunch_known_signature_avoids_global_compiler_lock(monkeypatch):
-    def kernel(out):
+def test_ready_launch_known_signature_avoids_lock_and_overload_iteration(monkeypatch):
+    def kernel():
         pass
 
     dispatcher = descriptor_mod.MLIRDispatcher(kernel)
-    argtypes = (types.int32,)
-    dispatcher.overloads[argtypes] = object()
+
+    class ExactOnlyOverloads(dict):
+        def items(self):
+            pytest.fail("the unlocked readiness check must not iterate overloads")
+
+        def __iter__(self):
+            pytest.fail("the unlocked readiness check must not iterate overloads")
+
+    dispatcher.overloads = ExactOnlyOverloads({(): object()})
+    monkeypatch.setattr(_planner_registry, "_planners", [object()])
 
     monkeypatch.setattr(
         descriptor_mod.global_compiler_lock,
@@ -585,62 +710,166 @@ def test_prelaunch_known_signature_avoids_global_compiler_lock(monkeypatch):
         lambda: pytest.fail("known signatures must not take the global compiler lock"),
     )
 
-    prepared = dispatcher._prepare_for_launch(
-        (),
-        argtypes,
-        {
-            "grid": (1, 1, 1),
-            "block": (32, 1, 1),
-            "sharedmem": 0,
-            "cluster": None,
-        },
-        None,
-        dispatcher._c,
-        None,
+    marshaller = _ArgMarshaller(
+        lambda: "launched",
+        dispatcher=dispatcher,
+        kernel_dispatcher=dispatcher._c,
     )
 
-    assert prepared == (dispatcher._c, None, None)
+    assert marshaller() == "launched"
 
 
-def test_prelaunch_rechecks_signature_after_global_compiler_lock(monkeypatch):
-    def kernel(out):
+def test_prelaunch_rechecks_readiness_after_global_compiler_lock(monkeypatch):
+    def kernel():
         pass
 
     dispatcher = descriptor_mod.MLIRDispatcher(kernel)
-    argtypes = (types.int32,)
-    lock_entries = []
+    events = []
+    original_ready_launch = dispatcher._get_ready_launch
 
-    class PublishingCompilerLock:
-        def __enter__(self):
-            lock_entries.append(None)
-            dispatcher.overloads[argtypes] = object()
+    def observe_ready_launch(*args, **kwargs):
+        events.append("ready")
+        return original_ready_launch(*args, **kwargs)
 
-        def __exit__(self, *args):
-            return False
+    original_acquire = descriptor_mod.global_compiler_lock.acquire
 
-    monkeypatch.setattr(descriptor_mod, "global_compiler_lock", PublishingCompilerLock())
+    def publish_during_acquire():
+        original_acquire()
+        events.append("lock")
+        dispatcher.overloads[()] = object()
+
+    monkeypatch.setattr(dispatcher, "_get_ready_launch", observe_ready_launch)
+    monkeypatch.setattr(descriptor_mod.global_compiler_lock, "acquire", publish_during_acquire)
+    monkeypatch.setattr(_planner_registry, "_planners", [object()])
     monkeypatch.setattr(
         dispatcher,
         "_compile_impl",
         lambda args: pytest.fail("the signature was published while waiting for the lock"),
     )
 
+    def launcher():
+        events.append("launch")
+        return "launched"
+
+    marshaller = _ArgMarshaller(
+        launcher,
+        dispatcher=dispatcher,
+        kernel_dispatcher=dispatcher._c,
+    )
+
+    assert marshaller() == "launched"
+    assert events == ["ready", "lock", "ready", "launch"]
+
+
+def test_prelaunch_reuses_compatible_generic_overload_under_lock(monkeypatch):
+    def kernel(value):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    dispatcher.overloads[(types.int32,)] = object()
+    available_launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+
+    assert (
+        dispatcher._get_ready_launch(
+            (types.int64,),
+            available_launch_config,
+            None,
+            dispatcher._c,
+            None,
+        )
+        is None
+    )
+    monkeypatch.setattr(
+        dispatcher,
+        "_compile_impl",
+        lambda args: pytest.fail("the compatible overload must be reused"),
+    )
+
     prepared = dispatcher._prepare_for_launch(
-        (),
-        argtypes,
-        {
-            "grid": (1, 1, 1),
-            "block": (32, 1, 1),
-            "sharedmem": 0,
-            "cluster": None,
-        },
+        (1,),
+        (types.int64,),
+        available_launch_config,
         None,
         dispatcher._c,
         None,
     )
 
-    assert lock_entries == [None]
     assert prepared == (dispatcher._c, None, None)
+
+
+def test_ready_launch_validates_launch_overload_dispatcher_and_generation():
+    def kernel(value):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(
+        kernel,
+        targetoptions={"extensions": [_LaunchConfigExtension()]},
+    )
+    launch_config = {
+        "grid": (1, 1, 1),
+        "block": (32, 1, 1),
+        "sharedmem": 0,
+        "cluster": None,
+    }
+    argtypes = (types.int32,)
+    launch_key = descriptor_mod._launch_config_key(launch_config)
+    kernel_dispatcher, generation = dispatcher._get_kernel_dispatcher_and_generation(launch_config)
+    dispatcher._launch_config_overloads[(argtypes, launch_key)] = object()
+    other_launch_config = {**launch_config, "block": (64, 1, 1)}
+    dispatcher._get_kernel_dispatcher_and_generation(other_launch_config)
+    assert next(reversed(dispatcher._launch_config_dispatchers)) != launch_key
+
+    assert dispatcher._get_ready_launch(
+        argtypes,
+        launch_config,
+        launch_config,
+        kernel_dispatcher,
+        generation,
+    ) == (kernel_dispatcher, generation, launch_config)
+    assert next(reversed(dispatcher._launch_config_dispatchers)) == launch_key
+    assert dispatcher._get_ready_launch(
+        (types.int64,),
+        launch_config,
+        launch_config,
+        kernel_dispatcher,
+        generation,
+    ) == (kernel_dispatcher, generation, launch_config)
+    assert (
+        dispatcher._get_ready_launch(
+            argtypes,
+            launch_config,
+            launch_config,
+            object(),
+            generation,
+        )
+        is None
+    )
+    assert (
+        dispatcher._get_ready_launch(
+            argtypes,
+            launch_config,
+            launch_config,
+            kernel_dispatcher,
+            generation + 1,
+        )
+        is None
+    )
+    dispatcher._launch_config_overloads.clear()
+    assert (
+        dispatcher._get_ready_launch(
+            argtypes,
+            launch_config,
+            launch_config,
+            kernel_dispatcher,
+            generation,
+        )
+        is None
+    )
 
 
 def test_launch_config_configure_reports_invalid_sharedmem():
@@ -1512,11 +1741,14 @@ def test_retained_marshaller_compiles_with_extension_snapshot_after_mutation(mon
         "sharedmem": 0,
         "cluster": None,
     }
+    kernel_dispatcher, generation = dispatcher._get_kernel_dispatcher_and_generation(launch_config)
     marshaller = _ArgMarshaller(
         lambda *args: dispatcher._compile_impl(list(args)),
         extensions=dispatcher.extensions,
         dispatcher=dispatcher,
         launch_config=launch_config,
+        kernel_dispatcher=kernel_dispatcher,
+        launch_config_generation=generation,
     )
     dispatcher.extensions.clear()
 

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -568,7 +568,79 @@ def test_prelaunch_uses_retained_launch_extension_snapshot(monkeypatch):
         retained_generation,
         retained_launch_config,
     )
-    assert observed_configs == [retained_launch_config, retained_launch_config]
+    assert observed_configs == [retained_launch_config]
+
+
+def test_prelaunch_known_signature_avoids_global_compiler_lock(monkeypatch):
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    argtypes = (types.int32,)
+    dispatcher.overloads[argtypes] = object()
+
+    monkeypatch.setattr(
+        descriptor_mod.global_compiler_lock,
+        "acquire",
+        lambda: pytest.fail("known signatures must not take the global compiler lock"),
+    )
+
+    prepared = dispatcher._prepare_for_launch(
+        (),
+        argtypes,
+        {
+            "grid": (1, 1, 1),
+            "block": (32, 1, 1),
+            "sharedmem": 0,
+            "cluster": None,
+        },
+        None,
+        dispatcher._c,
+        None,
+    )
+
+    assert prepared == (dispatcher._c, None, None)
+
+
+def test_prelaunch_rechecks_signature_after_global_compiler_lock(monkeypatch):
+    def kernel(out):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    argtypes = (types.int32,)
+    lock_entries = []
+
+    class PublishingCompilerLock:
+        def __enter__(self):
+            lock_entries.append(None)
+            dispatcher.overloads[argtypes] = object()
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(descriptor_mod, "global_compiler_lock", PublishingCompilerLock())
+    monkeypatch.setattr(
+        dispatcher,
+        "_compile_impl",
+        lambda args: pytest.fail("the signature was published while waiting for the lock"),
+    )
+
+    prepared = dispatcher._prepare_for_launch(
+        (),
+        argtypes,
+        {
+            "grid": (1, 1, 1),
+            "block": (32, 1, 1),
+            "sharedmem": 0,
+            "cluster": None,
+        },
+        None,
+        dispatcher._c,
+        None,
+    )
+
+    assert lock_entries == [None]
+    assert prepared == (dispatcher._c, None, None)
 
 
 def test_launch_config_configure_reports_invalid_sharedmem():


### PR DESCRIPTION
## Why

PR #203 prepares planner-aware kernels before launch so a planner can request a launch-config specialization. Its first implementation put all of `_prepare_for_launch()` under Numba's global compiler lock.

`_ArgMarshaller._launch()` calls that method whenever a planner is registered. As a result, a hot launch took the global compiler lock even when its signature was already compiled and no new launch-config specialization was needed. Unrelated launches could serialize on a compiler lock without doing any compilation.

## Change

Look up the matching compile result before acquiring the lock. A prepared signature now continues directly to launch.

On a miss, acquire the compiler lock, refresh the active launch config, and repeat the lookup before compiling. The second lookup matters because another thread may publish the signature while this launch waits for the lock; the planner may also mark the signature as launch-sensitive during that interval.

The existing launcher and generation repair remains unchanged.

This is a follow-up to #203 and addresses [the review nit](https://github.com/NVIDIA/numba-cuda-mlir/pull/203#discussion_r3670117876).

## Validation

- `pre-commit run --files src/numba_cuda_mlir/descriptor.py tests/test_descriptor_launch_config.py`
- `pytest -q -o addopts= -p no:cacheprovider tests/test_descriptor_launch_config.py tests/test_post_inline_planners.py`
  - 80 passed on an NVIDIA RTX PRO 6000 Blackwell (SM 120)
  - 80 passed on a Quadro RTX 4000 (SM 75)
