### PR TITLE
Lower captured NumPy arrays to CUDA constant memory

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1260,7 +1260,7 @@ extern "C" __global__ void
                     self.incref(target_type, value_op)
                     self.store_var(target, value_op)
 
-    def lower_array_literal(self, value: np.ndarray) -> ir.Value:
+    def lower_array_literal(self, value: np.ndarray, numba_type) -> ir.Value:
         global constant_array_id
 
         array = np.ascontiguousarray(value)
@@ -1287,17 +1287,26 @@ extern "C" __global__ void
         ptr = llvm.addrspacecast(llvm.PointerType.get(), ptr)
         strides = [stride // array.itemsize for stride in array.strides]
         desc = self._build_memref_descriptor(ptr, array.shape, strides)
-        mr_type = T.memref(*array.shape, element_type=dtype)
+        if numba_type is not None:
+            dynamic_size = ir.ShapedType.get_dynamic_size()
+            mr_type = T.memref(*([dynamic_size] * array.ndim), element_type=dtype)
+        else:
+            mr_type = T.memref(*array.shape, element_type=dtype)
         return builtin.unrealized_conversion_cast([mr_type], [desc])
 
     def lower_literal_if_needed(self, value: ir.Value | np.ndarray, numba_type=None) -> ir.Value:
         match value:
             case types.Type() if isinstance(numba_type, types.DTypeSpec):
                 return self._materialize_type_token(numba_type)
+            case tuple() if isinstance(numba_type, types.BaseTuple):
+                return tuple(
+                    self.lower_literal_if_needed(element, element_type)
+                    for element, element_type in zip(value, numba_type.types)
+                )
             case tuple():
                 return tuple(map(self.lower_literal_if_needed, value))
             case np.ndarray():
-                return self.lower_array_literal(value)
+                return self.lower_array_literal(value, numba_type)
             case np.number() | np.bool_():
                 # np.bool_ is not an np.number but lowers the same way.
                 mlir_type = to_mlir_type(value.dtype)

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -94,6 +94,7 @@ KERNEL_ERROR_CODES = {
 }
 # MLIR LLVM dialect dynamic GEP sentinel, LLVM::GEPOp::kDynamicIndex / INT32_MIN.
 _GEP_DYNAMIC_INDEX = -2147483648
+constant_array_id = 0
 
 
 def get_mlir_module_str(metadata):
@@ -165,6 +166,7 @@ class MLIRLower(object):
         )
         self._seen_mlir_libraries = set()
         self._cloned_device_funcs: set[str] = set()
+        self._constant_array_globals = {}
         self._linked_external_items = set()
         self._linked_external_link_items = []
         self._linked_ltoirs = []
@@ -982,37 +984,14 @@ extern "C" __global__ void
             else:
                 self.store_var(target, free_var.value)
 
-    def lower_captured_array_to_memref(self, target, pyval):
-        """Build an MLIR memref value from __cuda_array_interface__ metadata.
-
-        Bakes the captured device array's pointer, shape, and strides as constants
-        into a memref descriptor struct, then casts to the target memref type.
-        Registers ``pyval`` on the active code library to keep the underlying
-        GPU memory alive while the compiled kernel exists.
-        """
-        self.context.active_code_library.referenced_objects[id(pyval)] = pyval
-        array = pyval.__cuda_array_interface__
-        memref_type = self.get_mlir_type(self.get_numba_type(target.name))
-        shape = array["shape"]
+    def _build_memref_descriptor(self, ptr, shape, strides):
         ndim = len(shape)
-        itemsize = np.dtype(array["typestr"]).itemsize
-
-        byte_strides = array.get("strides")
-        if byte_strides:
-            strides = [s // itemsize for s in byte_strides]
-        else:
-            strides, s = [], 1
-            for d in reversed(shape):
-                strides.insert(0, s)
-                s *= d
-
         if ndim > 0:
             struct_type = ir.Type.parse(
                 f"!llvm.struct<(ptr, ptr, i64, array<{ndim} x i64>, array<{ndim} x i64>)>"
             )
         else:
             struct_type = ir.Type.parse("!llvm.struct<(ptr, ptr, i64)>")
-        ptr = llvm.inttoptr(llvm.PointerType.get(), arith.constant(T.i64(), array["data"][0]))
         i64c = lambda v: arith.constant(T.i64(), v)
         ins = lambda d, v, *p: llvm.insertvalue(
             container=d, value=v, position=ir.DenseI64ArrayAttr.get(list(p))
@@ -1026,6 +1005,34 @@ extern "C" __global__ void
             desc = ins(desc, i64c(s), 3, i)
         for i, s in enumerate(strides):
             desc = ins(desc, i64c(s), 4, i)
+
+        return desc
+
+    def lower_captured_array_to_memref(self, target, pyval):
+        """Build an MLIR memref value from __cuda_array_interface__ metadata.
+
+        Bakes the captured device array's pointer, shape, and strides as constants
+        into a memref descriptor struct, then casts to the target memref type.
+        Registers ``pyval`` on the active code library to keep the underlying
+        GPU memory alive while the compiled kernel exists.
+        """
+        self.context.active_code_library.referenced_objects[id(pyval)] = pyval
+        array = pyval.__cuda_array_interface__
+        memref_type = self.get_mlir_type(self.get_numba_type(target.name))
+        shape = array["shape"]
+        itemsize = np.dtype(array["typestr"]).itemsize
+
+        byte_strides = array.get("strides")
+        if byte_strides:
+            strides = [s // itemsize for s in byte_strides]
+        else:
+            strides, s = [], 1
+            for d in reversed(shape):
+                strides.insert(0, s)
+                s *= d
+
+        ptr = llvm.inttoptr(llvm.PointerType.get(), arith.constant(T.i64(), array["data"][0]))
+        desc = self._build_memref_descriptor(ptr, shape, strides)
 
         self.store_var(target, builtin.unrealized_conversion_cast([memref_type], [desc]))
 
@@ -1254,21 +1261,34 @@ extern "C" __global__ void
                     self.store_var(target, value_op)
 
     def lower_array_literal(self, value: np.ndarray) -> ir.Value:
-        from numba_cuda_mlir._mlir.dialects import tensor
-        from numba_cuda_mlir.lowering_utilities import tensor_to_memref
+        global constant_array_id
 
-        with self.alloca_insertion_point():
-            dtype_numba = to_numba_type(value.dtype)
-            dtype = self.get_storage_type(dtype_numba)
-            raveled = value.ravel()
-            elems = [
-                self.as_storage(dtype_numba, self.lower_literal_if_needed(e, dtype_numba))
-                for e in raveled
-            ]
-            mr_type = T.tensor(*value.shape, element_type=dtype)
-            mr = tensor.from_elements(mr_type, elems)
-            mr = tensor_to_memref(mr)
-            return mr
+        array = np.ascontiguousarray(value)
+        dtype_numba = to_numba_type(array.dtype)
+        dtype = self.get_storage_type(dtype_numba)
+        name = self._constant_array_globals.get(id(value))
+        if name is None:
+            name = f"constant_array_{constant_array_id}"
+            constant_array_id += 1
+            self._constant_array_globals[id(value)] = name
+            array_type = ir.Type.parse(f"!llvm.array<{array.nbytes} x i8>")
+            data = "".join(f"\\{byte:02X}" for byte in array.tobytes())
+            with ir.InsertionPoint.at_block_begin(self.mlir_gpu_module.bodyRegion.blocks[0]):
+                llvm.GlobalOp(
+                    array_type,
+                    name,
+                    ir.Attribute.parse("#llvm.linkage<internal>"),
+                    addr_space=4,
+                    constant=True,
+                    alignment=array.dtype.alignment,
+                    value=ir.Attribute.parse(f'"{data}"'),
+                )
+        ptr = llvm.mlir_addressof(llvm.PointerType.get(4), name)
+        ptr = llvm.addrspacecast(llvm.PointerType.get(), ptr)
+        strides = [stride // array.itemsize for stride in array.strides]
+        desc = self._build_memref_descriptor(ptr, array.shape, strides)
+        mr_type = T.memref(*array.shape, element_type=dtype)
+        return builtin.unrealized_conversion_cast([mr_type], [desc])
 
     def lower_literal_if_needed(self, value: ir.Value | np.ndarray, numba_type=None) -> ir.Value:
         match value:

--- a/tests/numba_cuda_tests/cudadrv/test_linker.py
+++ b/tests/numba_cuda_tests/cudadrv/test_linker.py
@@ -379,7 +379,6 @@ class TestLinker(NumbaCUDATestCase):
         compiled = cuda.jit(sig, max_registers=38)(func_with_lots_of_registers)
         self.assertLessEqual(compiled.get_regs_per_thread(), 38)
 
-    @pytest.mark.xfail(reason="const memory not supported")
     def test_get_const_mem_size(self):
         sig = void(float64[::1])
         compiled = cuda.jit(sig)(simple_const_mem)

--- a/tests/numba_cuda_tests/cudapy/test_constmem.py
+++ b/tests/numba_cuda_tests/cudapy/test_constmem.py
@@ -91,7 +91,6 @@ def cuconstAlign(z):
 
 
 class TestCudaConstantMemory(NumbaCUDATestCase):
-    @pytest.mark.xfail(True, reason="Regex doesn't match")
     def test_const_array(self):
         sig = (float64[:],)
         jcuconst = numba_cuda_mlir.cuda.jit(sig)(cuconst)
@@ -117,7 +116,6 @@ class TestCudaConstantMemory(NumbaCUDATestCase):
         jcuconstAlign[1, 3](A)
         self.assertTrue(np.all(A == (CONST3BYTES + CONST1D[:3])))
 
-    @pytest.mark.xfail(True, reason="Regex doesn't match")
     def test_const_array_2d(self):
         sig = (int32[:, :],)
         jcuconst2d = numba_cuda_mlir.cuda.jit(sig)(cuconst2d)

--- a/tests/numba_cuda_tests/cudapy/test_dispatcher.py
+++ b/tests/numba_cuda_tests/cudapy/test_dispatcher.py
@@ -597,7 +597,6 @@ class TestDispatcherKernelProperties(NumbaCUDATestCase):
         self.assertEqual(const_mem_size_all[sig_i64.args], const_mem_size_i64)
         self.assertEqual(const_mem_size_all[sig_f64.args], const_mem_size_f64)
 
-    @pytest.mark.xfail(True, reason="Incorrect result")
     def test_get_const_mem_specialized(self):
         arr = np.arange(32, dtype=np.int64)
         sig = void(int64[::1])

--- a/tests/test_captured_array_constants.py
+++ b/tests/test_captured_array_constants.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+from numba_cuda_mlir import cuda
+
+
+def test_host_array_capture_uses_constant_memory():
+    table = np.arange(64, dtype=np.int64)
+
+    @cuda.jit(cache=False)
+    def kernel(out):
+        i = cuda.grid(1)
+        if i < out.shape[0]:
+            out[i] = table[i % table.shape[0]]
+
+    out = cuda.device_array(128, dtype=np.int64)
+    for _ in range(150):
+        kernel[1, 128](out)
+    cuda.synchronize()
+
+    np.testing.assert_array_equal(out.copy_to_host()[:64], table)
+    ptx = "\n".join(kernel.inspect_asm().values())
+    assert ".const" in ptx
+    assert "malloc" not in ptx
+
+
+def test_host_array_capture_materializes_noncontiguous_input():
+    table = np.arange(12, dtype=np.int32)[::2]
+
+    @cuda.jit
+    def kernel(out):
+        i = cuda.grid(1)
+        if i < out.shape[0]:
+            out[i] = table[i]
+
+    out = cuda.device_array(table.shape, dtype=table.dtype)
+    kernel[1, table.size](out)
+
+    np.testing.assert_array_equal(out.copy_to_host(), table)

--- a/tests/test_captured_array_constants.py
+++ b/tests/test_captured_array_constants.py
@@ -39,3 +39,99 @@ def test_host_array_capture_materializes_noncontiguous_input():
     kernel[1, table.size](out)
 
     np.testing.assert_array_equal(out.copy_to_host(), table)
+
+
+def test_host_array_capture_column_slice():
+    table = np.arange(12, dtype=np.int64).reshape(3, 4)
+
+    @cuda.jit
+    def kernel(out):
+        col = table[:, 2]
+        for i in range(col.shape[0]):
+            out[i] = col[i]
+
+    out = cuda.device_array(3, dtype=table.dtype)
+    kernel[1, 1](out)
+
+    np.testing.assert_array_equal(out.copy_to_host(), table[:, 2])
+
+
+def test_host_array_tuple_capture_column_slice():
+    tables = (
+        np.arange(12, dtype=np.int64).reshape(3, 4),
+        np.arange(12, 24, dtype=np.int64).reshape(3, 4),
+    )
+
+    @cuda.jit
+    def kernel(out, table_index):
+        col = tables[table_index][:, 2]
+        for i in range(col.shape[0]):
+            out[i] = col[i]
+
+    out = cuda.device_array(3, dtype=tables[1].dtype)
+    kernel[1, 1](out, 1)
+
+    np.testing.assert_array_equal(out.copy_to_host(), tables[1][:, 2])
+
+
+def test_host_array_capture_f_layout_column_slice_and_reduction():
+    table = np.asfortranarray(np.arange(12, dtype=np.int64).reshape(3, 4))
+
+    @cuda.jit
+    def kernel(out, any_out):
+        col = table[:, 2]
+        for i in range(col.shape[0]):
+            out[i] = col[i]
+        any_out[0] = np.any(table)
+
+    out = cuda.device_array(table.shape[0], dtype=table.dtype)
+    any_out = cuda.device_array(1, dtype=np.bool_)
+    kernel[1, 1](out, any_out)
+
+    np.testing.assert_array_equal(out.copy_to_host(), table[:, 2])
+    np.testing.assert_array_equal(any_out.copy_to_host(), [np.any(table)])
+
+
+def test_host_array_capture_ravel():
+    table = np.arange(12, dtype=np.int64).reshape(3, 4)
+
+    @cuda.jit
+    def kernel(out):
+        flat = table.ravel()
+        for i in range(flat.shape[0]):
+            out[i] = flat[i]
+
+    out = cuda.device_array(table.size, dtype=table.dtype)
+    kernel[1, 1](out)
+
+    np.testing.assert_array_equal(out.copy_to_host(), table.ravel())
+
+
+def test_host_array_capture_transpose():
+    table = np.arange(12, dtype=np.int64).reshape(3, 4).T
+
+    @cuda.jit
+    def kernel(out):
+        for i in range(table.shape[0]):
+            for j in range(table.shape[1]):
+                out[i, j] = table[i, j]
+
+    out = cuda.device_array(table.shape, dtype=table.dtype)
+    kernel[1, 1](out)
+
+    np.testing.assert_array_equal(out.copy_to_host(), table)
+
+
+def test_host_array_capture_multidimensional_negative_stride():
+    table = np.arange(12, dtype=np.int64).reshape(3, 4)[::-1, ::-1]
+
+    @cuda.jit
+    def kernel(out):
+        for i in range(table.shape[0]):
+            for j in range(table.shape[1]):
+                out[i, j] = table[i, j]
+
+    out = cuda.device_array(table.shape, dtype=table.dtype)
+    kernel[1, 1](out)
+
+    np.testing.assert_array_equal(out.copy_to_host(), table)


### PR DESCRIPTION
Materialize host array captures as aligned addrspace-4 LLVM globals and reconstruct their memref descriptors without device-heap allocation.

Reuse the descriptor builder for host and device array captures. Add repeated launch and noncontiguous-capture regressions, and remove stale constant-memory xfail markers.

This closes #247.