### PR TITLE
ENH: expose LLVM IR inspection and NVVM input dumping

### DIFF
--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -54,7 +54,8 @@ struct LLVM70Options {
 
 /// Translate a gpu.module (containing LLVM dialect ops) to PTX.
 llvm::Expected<std::string> translateToPTX(mlir::gpu::GPUModuleOp gpuMod,
-                                           const LLVM70Options &opts);
+                                           const LLVM70Options &opts,
+                                           std::string *nvvmBitcode = nullptr);
 
 /// Lower-level: translate a gpu.module to old LLVM IR text (for debugging).
 llvm::Expected<std::string> translateToNVVMIR(mlir::gpu::GPUModuleOp gpuMod,

--- a/cext/mlir-llvm70/lib/CAPI.cpp
+++ b/cext/mlir-llvm70/lib/CAPI.cpp
@@ -41,13 +41,18 @@ int llvm70_translate_gpu_module_from_op(
     void *raw_op,
     const char *chip, const char *data_layout,
     const char *libllvm, const char *libnvvm, const char *libdevice,
-    int gen_lto, int opt_level, int gen_lineinfo,
+    int gen_lto, int gen_llvmir, int opt_level, int gen_lineinfo,
     int nvvm_ir_major, int nvvm_ir_minor, int nvvm_debug_major,
     int nvvm_debug_minor,
-    char **out, size_t *out_len, char **err_out) {
+    char **out, size_t *out_len, char **nvvm_out, size_t *nvvm_out_len,
+    char **err_out) {
 
   *out = nullptr;
   *out_len = 0;
+  if (nvvm_out)
+    *nvvm_out = nullptr;
+  if (nvvm_out_len)
+    *nvvm_out_len = 0;
   *err_out = nullptr;
 
   if (!raw_op) {
@@ -93,23 +98,40 @@ int llvm70_translate_gpu_module_from_op(
   llvm::install_fatal_error_handler(fatalErrorHandler, nullptr);
 
   try {
-    auto ptxOrErr = llvm70::translateToPTX(gpuMod, opts);
+    std::string nvvmBitcode;
+    bool captureNVVM = gen_llvmir == 0 && nvvm_out && nvvm_out_len;
+    auto outputOrErr = gen_llvmir != 0
+                           ? llvm70::translateToNVVMIR(gpuMod, opts)
+                           : llvm70::translateToPTX(
+                                 gpuMod, opts,
+                                 captureNVVM ? &nvvmBitcode : nullptr);
     llvm::remove_fatal_error_handler();
 
-    if (!ptxOrErr) {
-      std::string msg = llvm::toString(ptxOrErr.takeError());
+    if (captureNVVM && !nvvmBitcode.empty()) {
+      *nvvm_out = static_cast<char *>(malloc(nvvmBitcode.size()));
+      if (!*nvvm_out) {
+        *err_out = copyCString("malloc failed");
+        return 1;
+      }
+      memcpy(*nvvm_out, nvvmBitcode.data(), nvvmBitcode.size());
+      *nvvm_out_len = nvvmBitcode.size();
+    }
+
+    if (!outputOrErr) {
+      std::string msg = llvm::toString(outputOrErr.takeError());
       *err_out = copyCString(msg.c_str());
       return 1;
     }
 
-    const std::string &ptx = *ptxOrErr;
-    *out = static_cast<char *>(malloc(ptx.size()));
+    const std::string &output = *outputOrErr;
+    *out = static_cast<char *>(malloc(output.size()));
     if (!*out) {
       *err_out = copyCString("malloc failed");
       return 1;
     }
-    memcpy(*out, ptx.data(), ptx.size());
-    *out_len = ptx.size();
+    memcpy(*out, output.data(), output.size());
+    *out_len = output.size();
+
     return 0;
   } catch (const std::exception &e) {
     llvm::remove_fatal_error_handler();

--- a/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
@@ -653,7 +653,8 @@ LLVMMetadataRef LLVM70IRBuilder::createDIFile(const char *filename,
 }
 LLVMMetadataRef LLVM70IRBuilder::createDICompileUnit(LLVMMetadataRef file,
                                                      bool fullDebug) {
-  // DebugDirectivesOnly (3) emits .file/.loc without .target ..., debug
+  // LLVM 7 accepts DebugDirectivesOnly (3), but its IR printer leaves the
+  // emission-kind name empty.
   auto emissionKind = fullDebug ? LLVMDWARFEmissionFull
                                 : static_cast<LLVMDWARFEmissionKind>(3);
   return fnDIBuilderCreateCompileUnit(

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -27,12 +27,13 @@ using namespace mlir;
 // Public entry points
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<std::string> llvm70::translateToNVVMIR(gpu::GPUModuleOp gpuMod,
-                                                     const LLVM70Options &opts) {
+static llvm::Expected<std::unique_ptr<LLVM70IRBuilder>>
+translateToLLVM70Module(gpu::GPUModuleOp gpuMod,
+                        const LLVM70Options &opts) {
   auto builderOrErr = LLVM70IRBuilder::create(opts.libLLVMPath);
   if (!builderOrErr)
     return builderOrErr.takeError();
-  auto &builder = *builderOrErr;
+  auto builder = std::move(*builderOrErr);
 
   builder->setTarget(opts.triple.c_str());
   if (!opts.dataLayout.empty())
@@ -42,23 +43,24 @@ llvm::Expected<std::string> llvm70::translateToNVVMIR(gpu::GPUModuleOp gpuMod,
   if (auto err = translator.translate(gpuMod, opts.debugLevel, opts.genLTO, &opts))
     return std::move(err);
 
-  return builder->printModuleToString();
+  return std::move(builder);
+}
+
+llvm::Expected<std::string> llvm70::translateToNVVMIR(gpu::GPUModuleOp gpuMod,
+                                                       const LLVM70Options &opts) {
+  auto builderOrErr = translateToLLVM70Module(gpuMod, opts);
+  if (!builderOrErr)
+    return builderOrErr.takeError();
+  return (*builderOrErr)->printModuleToString();
 }
 
 llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
-                                                  const LLVM70Options &opts) {
-  auto builderOrErr = LLVM70IRBuilder::create(opts.libLLVMPath);
+                                                   const LLVM70Options &opts,
+                                                   std::string *nvvmBitcode) {
+  auto builderOrErr = translateToLLVM70Module(gpuMod, opts);
   if (!builderOrErr)
     return builderOrErr.takeError();
   auto &builder = *builderOrErr;
-
-  builder->setTarget(opts.triple.c_str());
-  if (!opts.dataLayout.empty())
-    builder->setDataLayout(opts.dataLayout.c_str());
-
-  MLIRToLLVM70 translator(*builder);
-  if (auto err = translator.translate(gpuMod, opts.debugLevel, opts.genLTO, &opts))
-    return std::move(err);
 
   LLVM_DEBUG({
     llvm::dbgs() << "=== Generated NVVM IR ===\n"
@@ -69,6 +71,8 @@ llvm::Expected<std::string> llvm70::translateToPTX(gpu::GPUModuleOp gpuMod,
   LLVMMemoryBufferRef buf = builder->writeBitcodeToMemoryBuffer();
   const char *bcData = builder->getBufferStart(buf);
   size_t bcSize = builder->getBufferSize(buf);
+  if (nvvmBitcode)
+    nvvmBitcode->assign(bcData, bcSize);
 
   // Collect modules: our bitcode + any link libraries
   llvm::SmallVector<std::pair<const char *, size_t>> modules;

--- a/cext/mlir-modern/ModernBridge.cpp
+++ b/cext/mlir-modern/ModernBridge.cpp
@@ -563,8 +563,8 @@ mlir_modern_to_nvvm_translate_for_libnvvm(
     const char *mlir_text, size_t mlir_text_len, int ctk_major, int ctk_minor,
     int nvvm_ir_major, int nvvm_ir_minor, int nvvm_debug_major,
     int nvvm_debug_minor,
-    int dump_llvmir, int emit_text_ir, char **out, size_t *out_len,
-    char **error_out) {
+    int dump_llvmir, int emit_text_ir, int inspect_llvmir, char **out,
+    size_t *out_len, char **error_out) {
     if (out)
         *out = nullptr;
     if (out_len)
@@ -621,6 +621,11 @@ mlir_modern_to_nvvm_translate_for_libnvvm(
 
     if (dump_llvmir && !dump_module_to_stderr(*llvm_module, error_out))
         return 1;
+
+    if (inspect_llvmir)
+        return serialize_module_as_text(*llvm_module, out, out_len, error_out)
+                   ? 0
+                   : 1;
 
     {
         std::lock_guard<std::mutex> guard(g_nvvm_ir_version_mutex);

--- a/cext/mlir-modern/ModernBridgeSmoke.cpp
+++ b/cext/mlir-modern/ModernBridgeSmoke.cpp
@@ -18,7 +18,7 @@ static int run_case(const char *name, const char *mlir, int ctk_major = 13,
     char *error = nullptr;
     int rc = mlir_modern_to_nvvm_translate_for_libnvvm(
         mlir, std::strlen(mlir), ctk_major, ctk_minor, 2, 0, 3, 2, 0,
-        emit_text_ir ? 1 : 0, &out, &out_len, &error);
+        emit_text_ir ? 1 : 0, 0, &out, &out_len, &error);
     if (rc != 0) {
         std::fprintf(stderr, "bridge smoke case '%s' failed: %s\n", name,
                      error ? error : "unknown error");
@@ -55,7 +55,7 @@ static int run_version_case(const char *mlir, int ir_major, int ir_minor,
     char *error = nullptr;
     int rc = mlir_modern_to_nvvm_translate_for_libnvvm(
         mlir, std::strlen(mlir), 13, 0, ir_major, ir_minor, debug_major,
-        debug_minor, 0, 1, &out, &out_len, &error);
+        debug_minor, 0, 1, 0, &out, &out_len, &error);
     if (rc != 0) {
         std::fprintf(stderr, "concurrent bridge case failed: %s\n",
                      error ? error : "unknown error");

--- a/cext/mlir-modern/include/ModernBridge.h
+++ b/cext/mlir-modern/include/ModernBridge.h
@@ -21,8 +21,8 @@ MLIR_MODERN_TO_NVVM_EXPORT int mlir_modern_to_nvvm_translate_for_libnvvm(
     const char *mlir_text, size_t mlir_text_len, int ctk_major, int ctk_minor,
     int nvvm_ir_major, int nvvm_ir_minor, int nvvm_debug_major,
     int nvvm_debug_minor,
-    int dump_llvmir, int emit_text_ir, char **out, size_t *out_len,
-    char **error_out);
+    int dump_llvmir, int emit_text_ir, int inspect_llvmir, char **out,
+    size_t *out_len, char **error_out);
 
 MLIR_MODERN_TO_NVVM_EXPORT void mlir_modern_to_nvvm_free(void *ptr);
 

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -2262,11 +2262,24 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             overloads[LaunchConfigInspectableKey(sig_args, launch_config_key)] = cres
         return overloads
 
-    def inspect_llvm(self, sig=None):
-        raise NotImplementedError(
-            "inspect_llvm is not supported. "
-            "Use inspect_mlir() to inspect the MLIR module or inspect_asm() to inspect the PTX."
-        )
+    def inspect_llvm(self, signature=None):
+        """Get architecture-natural LLVM IR.
+
+        With no signature, launch-specialized entries are keyed by
+        LaunchConfigInspectableKey and generic entries keep their argtypes tuple.
+        """
+        if signature is None:
+            return {sig: self.inspect_llvm(sig) for sig in self._inspectable_overloads()}
+        cres = self._find_overload(signature)
+        llvmir = cres.metadata.get("llvmir")
+        if llvmir is not None:
+            return llvmir
+
+        from numba_cuda_mlir.mlir_optimization import get_llvmir
+
+        llvmir = get_llvmir(cres)
+        cres.metadata["llvmir"] = llvmir
+        return llvmir
 
     def inspect_asm(self, signature=None):
         """Get generated PTX.

--- a/src/numba_cuda_mlir/lowering_utilities/llvm_utils.py
+++ b/src/numba_cuda_mlir/lowering_utilities/llvm_utils.py
@@ -73,6 +73,8 @@ def _get_capi():
     _capi.LLVMPrintModuleToString.argtypes = [ctypes.c_void_p]
     _capi.LLVMDisposeMessage.restype = None
     _capi.LLVMDisposeMessage.argtypes = [ctypes.c_void_p]
+    _capi.LLVMDisposeModule.restype = None
+    _capi.LLVMDisposeModule.argtypes = [ctypes.c_void_p]
     _capi.LLVMContextDispose.restype = None
     _capi.LLVMContextDispose.argtypes = [ctypes.c_void_p]
     return _capi
@@ -88,6 +90,7 @@ def _get_modern_to_nvvm_bridge():
     lib.mlir_modern_to_nvvm_translate_for_libnvvm.argtypes = [
         ctypes.c_char_p,
         ctypes.c_size_t,
+        ctypes.c_int,
         ctypes.c_int,
         ctypes.c_int,
         ctypes.c_int,
@@ -170,6 +173,7 @@ def translate_gpu_module_to_libnvvm_ir(
     nvvm_ir_version,
     dump=False,
     emit_text_ir=False,
+    inspect_llvmir=False,
 ):
     """Translate gpu.module text to libnvvm-compatible LLVM IR bytes."""
     lib = _get_modern_to_nvvm_bridge()
@@ -190,6 +194,7 @@ def translate_gpu_module_to_libnvvm_ir(
         nvvm_ir_version[3],
         int(bool(dump)),
         int(bool(emit_text_ir)),
+        int(bool(inspect_llvmir)),
         ctypes.byref(out),
         ctypes.byref(out_len),
         ctypes.byref(err_out),
@@ -221,3 +226,14 @@ def dump_llvmir(llvm_mod_ptr):
     result = ctypes.string_at(raw).decode("utf-8")
     capi.LLVMDisposeMessage(raw)
     return result
+
+
+def translate_to_llvmir_text(op):
+    """Translate an MLIR gpu.module operation to readable LLVM IR text."""
+    llvm_mod, llvm_ctx = translate_to_llvmir(op)
+    capi = _get_capi()
+    try:
+        return dump_llvmir(llvm_mod)
+    finally:
+        capi.LLVMDisposeModule(llvm_mod)
+        capi.LLVMContextDispose(llvm_ctx)

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -479,7 +479,12 @@ def get_llvmir(cres, target_options=None) -> str:
         cc = chip.replace("sm_", "")
 
         if _needs_llvm70_path(cc):
-            return _call_llvm70_capi(module, target_options, gen_llvmir=True).decode("utf-8")
+            return _call_llvm70_capi(
+                module,
+                target_options,
+                gen_lto=target_options.get("lto", False),
+                gen_llvmir=True,
+            ).decode("utf-8")
 
         gpu_mod = _get_single_gpu_module(module)
         gpu_mod.operation.attributes["llvm.data_layout"] = ir.StringAttr.get(NVPTX64_DATALAYOUT)
@@ -490,7 +495,11 @@ def get_llvmir(cres, target_options=None) -> str:
 
             ctk_major, ctk_minor = get_cuda_runtime_version()
             llvm_ir = translate_gpu_module_to_libnvvm_ir(
-                _operation_to_text(gpu_mod.operation),
+                _operation_to_text(
+                    gpu_mod.operation,
+                    preserve_debug_info=target_options.get("debug", False)
+                    or target_options.get("lineinfo", False),
+                ),
                 ctk_major,
                 ctk_minor,
                 _get_nvvm_ir_version(),

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -314,6 +314,8 @@ def _maybe_dump_nvvm(nvvm_ir: bytes) -> None:
         return
 
     is_bitcode = nvvm_ir[:4] == _BITCODE_MAGIC
+    if target.lower() in {"0", "false", "no", "off"}:
+        return
     if target.lower() in {"1", "true", "yes", "stderr"}:
         if is_bitcode:
             print(

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -3,8 +3,11 @@
 
 import ctypes
 import functools
+import itertools
 import os
+import sys
 from io import StringIO
+from pathlib import Path
 
 from numba_cuda_mlir._mlir.passmanager import PassManager
 from numba_cuda_mlir._mlir.dialects import llvm
@@ -20,6 +23,7 @@ from numba_cuda_mlir.lowering_utilities.llvm_utils import (
     NVPTX64_DATALAYOUT,
     NVPTX64_TRIPLE,
     translate_to_llvmir,
+    translate_to_llvmir_text,
     translate_gpu_module_to_libnvvm_ir,
     dump_llvmir,
 )
@@ -148,14 +152,17 @@ def _get_llvm70_capi():
         ctypes.c_char_p,  # libnvvm
         ctypes.c_char_p,  # libdevice
         ctypes.c_int,  # gen_lto
+        ctypes.c_int,  # gen_llvmir
         ctypes.c_int,  # opt_level
         ctypes.c_int,  # gen_lineinfo
         ctypes.c_int,  # nvvm_ir_major
         ctypes.c_int,  # nvvm_ir_minor
         ctypes.c_int,  # nvvm_dbg_major
         ctypes.c_int,  # nvvm_dbg_minor
-        ctypes.POINTER(ctypes.c_char_p),  # out
+        ctypes.POINTER(ctypes.c_void_p),  # out
         ctypes.POINTER(ctypes.c_size_t),  # out_len
+        ctypes.POINTER(ctypes.c_void_p),  # nvvm_out
+        ctypes.POINTER(ctypes.c_size_t),  # nvvm_out_len
         ctypes.POINTER(ctypes.c_char_p),  # err_out
     ]
     lib.llvm70_free.restype = None
@@ -180,19 +187,23 @@ def _get_op_ptr(op) -> ctypes.c_void_p:
     return ptr(capsule, b"numba_cuda_mlir._mlir.ir.Operation._CAPIPtr")
 
 
-def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
-    """Compile MLIR gpu.module via in-process LLVM70 C API (raw Operation*)."""
+def _get_single_gpu_module(module):
     from numba_cuda_mlir._mlir.dialects import gpu
+
+    gpu_modules = [op for op in module.body if isinstance(op, gpu.GPUModuleOp)]
+    if len(gpu_modules) != 1:
+        raise ValueError(f"Expected exactly one gpu.module, found {len(gpu_modules)}")
+    return gpu_modules[0]
+
+
+def _call_llvm70_capi(module, target_options, gen_lto=False, gen_llvmir=False) -> bytes:
+    """Compile MLIR gpu.module via in-process LLVM70 C API (raw Operation*)."""
     from numba_cuda_mlir.tools import get_gpu_compute_capability
     from numba_cuda_mlir.numba_cuda.cudadrv.libs import get_libdevice
 
     lib = _get_llvm70_capi()
     chip = target_options.get("chip", get_gpu_compute_capability())
-
-    gpu_modules = [op for op in module.body if isinstance(op, gpu.GPUModuleOp)]
-    if len(gpu_modules) != 1:
-        raise ValueError(f"Expected exactly one gpu.module, found {len(gpu_modules)}")
-    gpu_mod = gpu_modules[0]
+    gpu_mod = _get_single_gpu_module(module)
 
     if target_options.get("dump_mlir") or target_options.get("dump"):
         print(f"=============== LLVM70 MLIR Module ===============\n\n{gpu_mod}\n")
@@ -235,9 +246,14 @@ def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
         debug_level = 0
 
     nvvm_ir_version = _get_nvvm_ir_version()
-    out = ctypes.c_char_p()
+    out = ctypes.c_void_p()
     out_len = ctypes.c_size_t()
+    nvvm_out = ctypes.c_void_p()
+    nvvm_out_len = ctypes.c_size_t()
     err_out = ctypes.c_char_p()
+    from numba_cuda_mlir.numba_cuda import config
+
+    capture_nvvm = bool(config.CUDA_DUMP_NVVM) and not gen_llvmir
 
     rc = lib.llvm70_translate_gpu_module_from_op(
         raw_op,
@@ -247,6 +263,7 @@ def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
         libnvvm.encode(),
         libdevice.encode(),
         1 if gen_lto else 0,
+        1 if gen_llvmir else 0,
         opt_level,
         debug_level,
         nvvm_ir_version[0],
@@ -255,18 +272,69 @@ def _call_llvm70_capi(module, target_options, gen_lto=False) -> bytes:
         nvvm_ir_version[3],
         ctypes.byref(out),
         ctypes.byref(out_len),
+        ctypes.byref(nvvm_out) if capture_nvvm else None,
+        ctypes.byref(nvvm_out_len) if capture_nvvm else None,
         ctypes.byref(err_out),
     )
 
     if rc != 0:
         msg = err_out.value.decode() if err_out.value else "unknown error"
-        if err_out.value:
-            lib.llvm70_free(err_out)
+        try:
+            if nvvm_out.value:
+                _maybe_dump_nvvm(ctypes.string_at(nvvm_out.value, nvvm_out_len.value))
+        finally:
+            if err_out.value:
+                lib.llvm70_free(err_out)
+            if nvvm_out.value:
+                lib.llvm70_free(nvvm_out)
         raise RuntimeError(f"llvm70 translation failed: {msg}")
 
-    result = ctypes.string_at(out, out_len.value)
-    lib.llvm70_free(out)
-    return result
+    try:
+        result = ctypes.string_at(out.value, out_len.value)
+        if nvvm_out.value:
+            _maybe_dump_nvvm(ctypes.string_at(nvvm_out.value, nvvm_out_len.value))
+        return result
+    finally:
+        if out.value:
+            lib.llvm70_free(out)
+        if nvvm_out.value:
+            lib.llvm70_free(nvvm_out)
+
+
+_nvvm_dump_counter = itertools.count()
+_BITCODE_MAGIC = b"BC\xc0\xde"
+
+
+def _maybe_dump_nvvm(nvvm_ir: bytes) -> None:
+    """Dump the NVVM IR fed to libnvvm when configured."""
+    from numba_cuda_mlir.numba_cuda import config
+
+    target = config.CUDA_DUMP_NVVM
+    if not target:
+        return
+
+    is_bitcode = nvvm_ir[:4] == _BITCODE_MAGIC
+    if target.lower() in {"1", "true", "yes", "stderr"}:
+        if is_bitcode:
+            print(
+                f"=============== NVVM IR (bitcode, {len(nvvm_ir)} bytes) ===============\n"
+                "Set NUMBA_CUDA_MLIR_DUMP_NVVM=<file|dir> to write the bitcode to disk.\n",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"=============== NVVM IR ===============\n\n"
+                f"{nvvm_ir.decode('utf-8', errors='replace')}\n",
+                file=sys.stderr,
+            )
+        return
+
+    path = Path(target)
+    if path.exists() and path.is_dir():
+        extension = "bc" if is_bitcode else "ll"
+        path = path / f"nvvm-{os.getpid()}-{next(_nvvm_dump_counter)}.{extension}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(nvvm_ir)
 
 
 def _operation_to_text(operation, *, preserve_debug_info=False) -> str:
@@ -279,21 +347,16 @@ def _operation_to_text(operation, *, preserve_debug_info=False) -> str:
 
 def _prepare_llvm_ir(module, dump=False, preserve_debug_info=False) -> bytes:
     """Translate gpu.module to LLVM IR and apply libnvvm compatibility downgrades."""
-    from numba_cuda_mlir._mlir.dialects import gpu
     from numba_cuda_mlir.tools import get_cuda_runtime_version
 
-    gpu_modules = [op for op in module.body if isinstance(op, gpu.GPUModuleOp)]
-    if len(gpu_modules) != 1:
-        raise ValueError(f"Expected exactly one gpu.module, found {len(gpu_modules)}")
-
-    gpu_mod = gpu_modules[0]
+    gpu_mod = _get_single_gpu_module(module)
     gpu_mod.operation.attributes["llvm.data_layout"] = ir.StringAttr.get(NVPTX64_DATALAYOUT)
     gpu_mod.operation.attributes["llvm.target_triple"] = ir.StringAttr.get(NVPTX64_TRIPLE)
     ctk_major, ctk_minor = get_cuda_runtime_version()
     nvvm_ir_version = _get_nvvm_ir_version()
 
     if os.name == "nt":
-        return translate_gpu_module_to_libnvvm_ir(
+        nvvm_ir = translate_gpu_module_to_libnvvm_ir(
             _operation_to_text(gpu_mod.operation, preserve_debug_info=preserve_debug_info),
             ctk_major,
             ctk_minor,
@@ -301,6 +364,8 @@ def _prepare_llvm_ir(module, dump=False, preserve_debug_info=False) -> bytes:
             dump=dump,
             emit_text_ir=preserve_debug_info,
         )
+        _maybe_dump_nvvm(nvvm_ir)
+        return nvvm_ir
 
     from numba_cuda_mlir._cext import downgrade_for_libnvvm
 
@@ -309,7 +374,7 @@ def _prepare_llvm_ir(module, dump=False, preserve_debug_info=False) -> bytes:
     if dump:
         print(f"=============== LLVM IR ===============\n\n{dump_llvmir(llvm_mod)}\n\n")
 
-    return downgrade_for_libnvvm(
+    nvvm_ir = downgrade_for_libnvvm(
         llvm_mod,
         llvm_ctx,
         ctk_major,
@@ -320,6 +385,8 @@ def _prepare_llvm_ir(module, dump=False, preserve_debug_info=False) -> bytes:
         nvvm_ir_version[3],
         LLVM_C_LIB_PATH,
     )
+    _maybe_dump_nvvm(nvvm_ir)
+    return nvvm_ir
 
 
 def _nvvm_options(cc: str, target_options=None, **extra) -> dict:
@@ -393,6 +460,45 @@ def _get_ltoir(cres, target_options) -> bytes:
 
     cres.metadata["ltoir"] = ltoir
     return ltoir
+
+
+def get_llvmir(cres, target_options=None) -> str:
+    """Return architecture-natural LLVM IR lazily for inspection."""
+    if target_options is None:
+        target_options = cres.metadata["targetoptions"]
+
+    with context.get_context():
+        module = ir.Module.parse(cres.metadata["mlir_module_optimized"])
+        run_pre_codegen_patterns(module)
+
+        chip = target_options.get("chip")
+        if not chip:
+            from numba_cuda_mlir.tools import get_gpu_compute_capability
+
+            chip = get_gpu_compute_capability()
+        cc = chip.replace("sm_", "")
+
+        if _needs_llvm70_path(cc):
+            return _call_llvm70_capi(module, target_options, gen_llvmir=True).decode("utf-8")
+
+        gpu_mod = _get_single_gpu_module(module)
+        gpu_mod.operation.attributes["llvm.data_layout"] = ir.StringAttr.get(NVPTX64_DATALAYOUT)
+        gpu_mod.operation.attributes["llvm.target_triple"] = ir.StringAttr.get(NVPTX64_TRIPLE)
+
+        if os.name == "nt":
+            from numba_cuda_mlir.tools import get_cuda_runtime_version
+
+            ctk_major, ctk_minor = get_cuda_runtime_version()
+            llvm_ir = translate_gpu_module_to_libnvvm_ir(
+                _operation_to_text(gpu_mod.operation),
+                ctk_major,
+                ctk_minor,
+                _get_nvvm_ir_version(),
+                inspect_llvmir=True,
+            )
+            return llvm_ir.decode("utf-8")
+
+        return translate_to_llvmir_text(gpu_mod.operation)
 
 
 def get_ptx(cres, target_options=None) -> str:

--- a/src/numba_cuda_mlir/numba_cuda/core/config.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/config.py
@@ -463,6 +463,11 @@ class _EnvReloader:
         # vector type) stores: when set, force opt_level=0 on LTO links
         CUDA_DISABLE_LTO_OPT = _readenv("NUMBA_CUDA_MLIR_DISABLE_LTO_OPT", int, 0)
 
+        # Dump the NVVM IR fed to libnvvm before PTX/LTO generation. Set to
+        # "1"/"true"/"yes"/"stderr" to print to stderr, or to a file or
+        # existing directory path to write the IR to disk.
+        CUDA_DUMP_NVVM = _readenv("NUMBA_CUDA_MLIR_DUMP_NVVM", str, "")
+
         # Whether the default stream is the per-thread default stream
         CUDA_PER_THREAD_DEFAULT_STREAM = _readenv("NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM", int, 0)
 

--- a/tests/numba_cuda_tests/cudapy/test_debuginfo.py
+++ b/tests/numba_cuda_tests/cudapy/test_debuginfo.py
@@ -55,7 +55,6 @@ class TestCudaDebugInfo(NumbaCUDATestCase):
         def f(x):
             x[0] = 0
 
-    @pytest.mark.xfail(True, reason="debuginfo issues")
     def test_issue_9888(self):
         # Compiler created symbol should not be emitted in DILocalVariable
         # See Numba Issue #9888 https://github.com/numba/numba/pull/9888
@@ -74,7 +73,6 @@ class TestCudaDebugInfo(NumbaCUDATestCase):
         match = re.compile(pat).search(llvm_ir)
         self.assertIsNone(match, msg=llvm_ir)
 
-    @pytest.mark.xfail(True, reason="debuginfo issues")
     def test_bool_type(self):
         sig = (types.int32, types.int32)
 
@@ -326,7 +324,6 @@ class TestCudaDebugInfo(NumbaCUDATestCase):
         ir = foo.inspect_llvm()[sig]
         self.assertFileCheckMatches(ir, foo.__doc__)
 
-    @pytest.mark.xfail(True, reason="debuginfo issues")
     def test_no_user_var_alias(self):
         sig = (types.int32, types.int32)
 
@@ -340,7 +337,6 @@ class TestCudaDebugInfo(NumbaCUDATestCase):
         match = re.compile(pat).search(llvm_ir)
         self.assertIsNone(match, msg=llvm_ir)
 
-    @pytest.mark.xfail(True, reason="debuginfo issues")
     def test_no_literal_type(self):
         sig = (types.int32,)
 
@@ -596,7 +592,6 @@ class TestCudaDebugInfo(NumbaCUDATestCase):
             # Clean up linecache
             linecache.cache.pop(fake_filename, None)
 
-    @pytest.mark.xfail(True, reason="debuginfo issues")
     def test_no_if_op_bools_declared(self):
         @numba_cuda_mlir.cuda.jit(
             "int64(boolean, boolean)",
@@ -1030,7 +1025,6 @@ class TestCudaDebugInfo(NumbaCUDATestCase):
         match = re.search(pattern, llvm_ir)
         self.assertIsNotNone(match, f"No non-zero store to 'bar.N' with !dbg !{continue_dbg_id}")
 
-    @pytest.mark.xfail(True, reason="debuginfo issues")
     def test_arg_load_has_dbg_location(self):
         """Loads of arg-named variables must carry !dbg in the body.
 

--- a/tests/numba_cuda_tests/cudapy/test_inline.py
+++ b/tests/numba_cuda_tests/cudapy/test_inline.py
@@ -44,7 +44,6 @@ class TestCudaInline(NumbaCUDATestCase):
         # alwaysinline should not be in the IR when the inline kwarg is used
         self.assertNotIn("alwaysinline", llvm_ir)
 
-    @pytest.mark.xfail(True, reason="Uses inspect_llvm")
     def test_call_inline_always(self):
         self._test_call_inline("always", True)
 
@@ -52,7 +51,6 @@ class TestCudaInline(NumbaCUDATestCase):
     def test_call_inline_never(self):
         self._test_call_inline("never", False)
 
-    @pytest.mark.xfail(True, reason="Uses inspect_llvm")
     def test_call_inline_true(self):
         self._test_call_inline(True, True)
 
@@ -67,7 +65,6 @@ class TestCudaInline(NumbaCUDATestCase):
 
         self._test_call_inline(cost_model, False)
 
-    @pytest.mark.xfail(True, reason="Uses inspect_llvm")
     def test_call_inline_costmodel_true(self):
         def cost_model(expr, caller_info, callee_info):
             return True

--- a/tests/numba_cuda_tests/cudapy/test_lineinfo.py
+++ b/tests/numba_cuda_tests/cudapy/test_lineinfo.py
@@ -39,7 +39,9 @@ class TestCudaLineInfo(NumbaCUDATestCase):
             # afterwards.
             r"emissionKind:\s+"  # The emissionKind attribute followed by
             # whitespace.
-            r"DebugDirectivesOnly"  # The correct emissionKind.
+            # LLVM 7 prints DebugDirectivesOnly without a name, but it still
+            # emits the required .file/.loc directives.
+            r"(?:DebugDirectivesOnly|(?=,))"  # Correct emissionKind.
         )
         match = re.compile(pat).search(llvm)
         assertfn(match, msg=ptx)
@@ -82,7 +84,6 @@ class TestCudaLineInfo(NumbaCUDATestCase):
 
         self._check(foo, sig=(int32[:],), expect=False)
 
-    @pytest.mark.xfail(True, reason="Uses inspect_llvm")
     def test_lineinfo_in_asm(self):
         @numba_cuda_mlir.cuda.jit(lineinfo=True)
         def foo(x):

--- a/tests/numba_cuda_tests/cudapy/test_lineinfo.py
+++ b/tests/numba_cuda_tests/cudapy/test_lineinfo.py
@@ -75,7 +75,6 @@ class TestCudaLineInfo(NumbaCUDATestCase):
         match = re.compile(pat).search(ptx)
         self.assertIsNone(match, msg=ptx)
 
-    @pytest.mark.xfail(True, reason="Uses inspect_llvm")
     def test_no_lineinfo_in_asm(self):
         @numba_cuda_mlir.cuda.jit(lineinfo=False)
         def foo(x):
@@ -91,7 +90,6 @@ class TestCudaLineInfo(NumbaCUDATestCase):
 
         self._check(foo, sig=(int32[:],), expect=True)
 
-    @pytest.mark.xfail(True, reason="Uses inspect_llvm")
     def test_lineinfo_maintains_error_model(self):
         sig = (float32[::1], float32[::1])
 
@@ -107,7 +105,6 @@ class TestCudaLineInfo(NumbaCUDATestCase):
         # lineinfo is enabled) the device function always returns 0.
         self.assertNotIn("ret i32 1", llvm)
 
-    @pytest.mark.xfail(True, reason="Uses inspect_llvm")
     def test_no_lineinfo_in_device_function(self):
         # Ensure that no lineinfo is generated in device functions by default.
         @numba_cuda_mlir.cuda.jit

--- a/tests/numba_cuda_tests/cudapy/test_warp_ops.py
+++ b/tests/numba_cuda_tests/cudapy/test_warp_ops.py
@@ -145,7 +145,6 @@ class TestCudaWarpOperations(NumbaCUDATestCase):
         compiled[1, nelem](ary, xor)
         self.assertTrue(np.all(ary == exp))
 
-    @pytest.mark.xfail(True, reason="Uses inspect_llvm")
     def test_shfl_sync_const_mode_val(self):
         # Test `mode` argument is constant in shfl_sync calls.
         # Related to https://github.com/NVIDIA/numba-cuda/pull/231

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -1680,6 +1680,12 @@ def test_inspection_keys_keep_generic_overload_shape():
     assert dispatcher.get_metadata(launch_keys[0]) == {"ptx": "launch"}
     assert dispatcher.get_metadata()[launch_keys[0]] == {"ptx": "launch"}
 
+    dispatcher.overloads[generic_sig].metadata["llvmir"] = "generic llvm"
+    launch_result.metadata["llvmir"] = "launch llvm"
+    llvm_ir = dispatcher.inspect_llvm()
+    assert llvm_ir[generic_sig] == "generic llvm"
+    assert llvm_ir[launch_keys[0]] == "launch llvm"
+
     missing_key = descriptor_mod.LaunchConfigInspectableKey(
         launch_sig,
         descriptor_mod._launch_config_key(

--- a/tests/test_dump_nvvm.py
+++ b/tests/test_dump_nvvm.py
@@ -26,6 +26,14 @@ def test_dump_nvvm_disabled_is_noop(dump_nvvm, tmp_path, capsys):
     assert list(tmp_path.iterdir()) == []
 
 
+@pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+def test_dump_nvvm_false_values_are_noop(dump_nvvm, tmp_path, capsys, value):
+    dump_nvvm(value)
+    mlir_optimization._maybe_dump_nvvm(BITCODE)
+    assert capsys.readouterr().err == ""
+    assert list(tmp_path.iterdir()) == []
+
+
 @pytest.mark.parametrize(
     "value,contents",
     [

--- a/tests/test_dump_nvvm.py
+++ b/tests/test_dump_nvvm.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from numba_cuda_mlir import cuda, mlir_optimization, types
+from numba_cuda_mlir.numba_cuda import config
+
+
+BITCODE = b"BC\xc0\xde\x00\x01\x02\x03"
+TEXT_IR = b"; ModuleID = 'kernel'\ndefine void @foo() {\n  ret void\n}\n"
+
+
+@pytest.fixture
+def dump_nvvm(monkeypatch):
+    def set_dump_target(value):
+        monkeypatch.setattr(config, "CUDA_DUMP_NVVM", value)
+
+    return set_dump_target
+
+
+def test_dump_nvvm_disabled_is_noop(dump_nvvm, tmp_path, capsys):
+    dump_nvvm("")
+    mlir_optimization._maybe_dump_nvvm(BITCODE)
+    assert capsys.readouterr().err == ""
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "value,contents",
+    [
+        pytest.param("stderr", TEXT_IR.decode(), id="text"),
+        pytest.param("1", f"bitcode, {len(BITCODE)} bytes", id="bitcode"),
+    ],
+)
+def test_dump_nvvm_to_stderr(dump_nvvm, capsys, value, contents):
+    dump_nvvm(value)
+    mlir_optimization._maybe_dump_nvvm(TEXT_IR if value == "stderr" else BITCODE)
+    assert contents in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "contents,suffix",
+    [
+        pytest.param(BITCODE, ".bc", id="bitcode"),
+        pytest.param(TEXT_IR, ".ll", id="text"),
+    ],
+)
+def test_dump_nvvm_to_directory(dump_nvvm, tmp_path, contents, suffix):
+    dump_nvvm(str(tmp_path))
+    mlir_optimization._maybe_dump_nvvm(contents)
+    dumps = list(tmp_path.iterdir())
+    assert len(dumps) == 1
+    assert dumps[0].suffix == suffix
+    assert dumps[0].read_bytes() == contents
+
+
+def test_dump_nvvm_to_explicit_file(dump_nvvm, tmp_path):
+    target = tmp_path / "nested" / "out.bc"
+    dump_nvvm(str(target))
+    mlir_optimization._maybe_dump_nvvm(BITCODE)
+    assert target.read_bytes() == BITCODE
+
+
+def test_failed_llvm70_translation_dumps_nvvm_input(dump_nvvm, tmp_path, monkeypatch):
+    dump_nvvm(str(tmp_path))
+    monkeypatch.setattr(mlir_optimization, "_get_libnvvm_path", lambda: b"/missing/libnvvm.so")
+
+    @cuda.jit(device=True, chip="sm_90")
+    def foo(value):
+        return value + 1
+
+    with pytest.raises(RuntimeError, match="llvm70 translation failed"):
+        foo.compile((types.int32,))
+
+    dumps = list(tmp_path.iterdir())
+    assert len(dumps) == 1
+    assert dumps[0].suffix == ".bc"
+    assert dumps[0].read_bytes().startswith(mlir_optimization._BITCODE_MAGIC)
+
+
+@pytest.mark.parametrize("chip", ["sm_90", "sm_100"])
+@pytest.mark.parametrize("lto", [False, True], ids=["ptx", "lto"])
+def test_compilation_dumps_exact_nvvm_input(dump_nvvm, tmp_path, chip, lto):
+    dump_nvvm(str(tmp_path))
+
+    @cuda.jit(device=True, chip=chip, lto=lto)
+    def foo(value):
+        return value + 1
+
+    foo.compile((types.int32,))
+
+    dumps = list(tmp_path.iterdir())
+    assert len(dumps) == 1
+    contents = dumps[0].read_bytes()
+    is_bitcode = contents.startswith(mlir_optimization._BITCODE_MAGIC)
+    assert dumps[0].suffix == (".bc" if is_bitcode else ".ll")
+    if not is_bitcode:
+        assert b"target triple" in contents

--- a/tests/test_inspect_llvm.py
+++ b/tests/test_inspect_llvm.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from numba_cuda_mlir import cuda, types
+from numba_cuda_mlir.tools import generate_mangled_name
+
+
+@pytest.mark.parametrize(
+    "chip,source_filename,ptr_type",
+    [
+        pytest.param("sm_90", "llvm70_module", "i8*", id="typed-pointers"),
+        pytest.param("sm_100", "LLVMDialectModule", "ptr %0", id="opaque-pointers"),
+    ],
+)
+def test_inspect_llvm_uses_architecture_natural_ir(chip, source_filename, ptr_type):
+    @cuda.jit(device=True, chip=chip)
+    def foo(arr, value):
+        arr[0] = value
+
+    args = (types.int32[:], types.int32)
+    cres = foo.compile_device(args)
+    llvm_ir = foo.inspect_llvm(args)
+
+    function_name = generate_mangled_name(cres.fndesc.qualname, cres.fndesc.argtypes)
+    assert f'source_filename = "{source_filename}"' in llvm_ir
+    assert f"{function_name}({ptr_type}" in llvm_ir
+    assert foo.inspect_llvm()[args] == llvm_ir

--- a/tests/test_inspect_llvm.py
+++ b/tests/test_inspect_llvm.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 from numba_cuda_mlir import cuda, mlir_optimization, types
@@ -23,6 +25,8 @@ def test_inspect_llvm_uses_architecture_natural_ir(chip, source_filename, ptr_ty
     cres = foo.compile_device(args)
     llvm_ir = foo.inspect_llvm(args)
 
+    if os.name == "nt" and chip == "sm_100":
+        source_filename = "numba-cuda-mlir-gpu-module"
     function_name = generate_mangled_name(cres.fndesc.qualname, cres.fndesc.argtypes)
     assert f'source_filename = "{source_filename}"' in llvm_ir
     assert f"{function_name}({ptr_type}" in llvm_ir

--- a/tests/test_inspect_llvm.py
+++ b/tests/test_inspect_llvm.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from numba_cuda_mlir import cuda, types
+from numba_cuda_mlir import cuda, mlir_optimization, types
 from numba_cuda_mlir.tools import generate_mangled_name
 
 
@@ -27,3 +27,33 @@ def test_inspect_llvm_uses_architecture_natural_ir(chip, source_filename, ptr_ty
     assert f'source_filename = "{source_filename}"' in llvm_ir
     assert f"{function_name}({ptr_type}" in llvm_ir
     assert foo.inspect_llvm()[args] == llvm_ir
+
+
+@pytest.mark.parametrize("lto", [False, True])
+def test_inspect_llvm_preserves_llvm70_lto_debug_mode(lto):
+    @cuda.jit(device=True, chip="sm_90", debug=True, lto=lto, opt=False)
+    def foo(value):
+        return value + 1
+
+    llvm_ir = foo.inspect_llvm((types.int32,))
+    assert ("Debug Info Version" in llvm_ir) is not lto
+
+
+def test_inspect_llvm_windows_preserves_debug_info(monkeypatch):
+    @cuda.jit(device=True, chip="sm_100", debug=True, opt=False)
+    def foo(value):
+        return value + 1
+
+    foo.compile_device((types.int32,))
+    captured = {}
+
+    def translate(mlir_text, *args, **kwargs):
+        captured["mlir_text"] = mlir_text
+        assert kwargs["inspect_llvmir"]
+        return b"; LLVM IR"
+
+    monkeypatch.setattr(mlir_optimization.os, "name", "nt")
+    monkeypatch.setattr(mlir_optimization, "translate_gpu_module_to_libnvvm_ir", translate)
+
+    assert foo.inspect_llvm((types.int32,)) == "; LLVM IR"
+    assert "loc(" in captured["mlir_text"]


### PR DESCRIPTION
Add architecture-native `inspect_llvm()` support and a `NUMBA_CUDA_MLIR_DUMP_NVVM` debugging hook.

Generate readable LLVM IR lazily for inspection, using the LLVM70 path for pre-Blackwell targets and the modern bridge elsewhere. Keep it separate from the libnvvm preparation path, whose output may be serialized bitcode.

Capture NVVM input at the actual libnvvm boundary for both PTX and LTO, including failed LLVM70 translations. The dump preserves raw bitcode when applicable and only renders textual IR for inspection.

Cache inspected IR per compiled overload and retain launch-specialized inspection keys.

Why this matches the two PR designs:
- #145 (https://github.com/NVIDIA/numba-cuda-mlir/pull/145) established inspect_llvm() as a lazy, public inspection API: it should return readable, target-native LLVM IR without adding LLVM IR generation to the normal compilation state just for later inspection.
- #149 (https://github.com/NVIDIA/numba-cuda-mlir/pull/149) established that dumping belongs at the libnvvm input boundary, covering both PTX and LTO and preserving the actual artifact—even when it is binary bitcode.
- The staged patch keeps those concerns separate: inspect_llvm() explicitly requests text, while the dump captures the bytes used for libnvvm. That avoids decoding BC\xc0\xde bitcode as UTF-8 and makes the LLVM70 translation setup reusable for either result.