### PR TITLE
Initialize compiler extensions before compilation

### DIFF
--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -32,6 +32,36 @@ Numba-CUDA-MLIR's lowering callbacks receive an MLIR builder
 (:py:class:`numba_cuda_mlir.mlir_lowering.MLIRLower`) and emit MLIR through
 the bindings in :py:mod:`numba_cuda_mlir._mlir`.
 
+Installed extension initialization
+----------------------------------
+
+Packages that must register compiler hooks before compilation can publish one
+``init`` entry point in the ``numba_cuda_mlir_extensions`` group:
+
+.. code-block:: toml
+
+   [project.entry-points.numba_cuda_mlir_extensions]
+   init = "my_package.compiler_extension:initialize"
+
+The initializer takes no arguments. Numba-CUDA-MLIR discovers entry points
+lazily on the first compilation, runs them in deterministic distribution and
+module order, and initializes them only once per process. Concurrent compiler
+calls wait for the same initialization result. Recursive compilation from an
+initializer is rejected because it could observe partially registered hooks.
+
+An initializer failure rolls planner and rewrite registrations back to their
+pre-initialization state and is re-raised on later compilation attempts. An
+initializer should therefore raise a precise exception when its dependencies
+or compiler requirements are incompatible rather than silently leaving a
+partial registration behind.
+
+CUDA cooperative adapters can compare
+``numba_cuda_mlir.CUDA_COOP_EXTENSION_PROTOCOL`` with the protocol version they
+implement. Version ``1`` is the current contract; adapters should fail
+initialization with an actionable compatibility error when it does not match.
+The existing :py:mod:`numba_cuda_mlir.extending` namespace re-exports the same
+constant for extension-author convenience.
+
 Whole-function planning
 -----------------------
 

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -55,9 +55,9 @@ initializer should therefore raise a precise exception when its dependencies
 or compiler requirements are incompatible rather than silently leaving a
 partial registration behind.
 
-CUDA cooperative adapters can compare
-``numba_cuda_mlir.CUDA_COOP_EXTENSION_PROTOCOL`` with the protocol version they
-implement. Version ``1`` is the current contract; adapters should fail
+CUDA interop extensions can compare
+``numba_cuda_mlir.CUDA_INTEROP_EXTENSION_PROTOCOL`` with the protocol version
+they implement. Version ``1`` is the current contract; extensions should fail
 initialization with an actionable compatibility error when it does not match.
 The existing :py:mod:`numba_cuda_mlir.extending` namespace re-exports the same
 constant for extension-author convenience.

--- a/src/numba_cuda_mlir/__init__.py
+++ b/src/numba_cuda_mlir/__init__.py
@@ -5,7 +5,7 @@
 # imported, so their symbols cannot be preempted by another in-process
 # LLVM. See #170.
 _mlir_deepbind_handles = []
-CUDA_COOP_EXTENSION_PROTOCOL = 1
+CUDA_INTEROP_EXTENSION_PROTOCOL = 1
 
 
 def _preload_mlir_libs_with_deepbind():
@@ -46,7 +46,7 @@ from numba_cuda_mlir.numba_cuda.np.numpy_support import carray, farray  # noqa: 
 make_nanobind_metaclass_inheritable()
 
 __all__ = [
-    "CUDA_COOP_EXTENSION_PROTOCOL",
+    "CUDA_INTEROP_EXTENSION_PROTOCOL",
     "cuda",
     "carray",
     "farray",

--- a/src/numba_cuda_mlir/__init__.py
+++ b/src/numba_cuda_mlir/__init__.py
@@ -5,6 +5,7 @@
 # imported, so their symbols cannot be preempted by another in-process
 # LLVM. See #170.
 _mlir_deepbind_handles = []
+CUDA_COOP_EXTENSION_PROTOCOL = 1
 
 
 def _preload_mlir_libs_with_deepbind():
@@ -44,4 +45,10 @@ from numba_cuda_mlir.numba_cuda.np.numpy_support import carray, farray  # noqa: 
 
 make_nanobind_metaclass_inheritable()
 
-__all__ = ["cuda", "carray", "farray", "__version__"]
+__all__ = [
+    "CUDA_COOP_EXTENSION_PROTOCOL",
+    "cuda",
+    "carray",
+    "farray",
+    "__version__",
+]

--- a/src/numba_cuda_mlir/_extension_bootstrap.py
+++ b/src/numba_cuda_mlir/_extension_bootstrap.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lazy, process-wide initialization for compiler extensions."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from importlib import metadata as importlib_metadata
+from typing import Any, cast
+
+
+_ENTRY_POINT_GROUP = "numba_cuda_mlir_extensions"
+_ENTRY_POINT_NAME = "init"
+_UNINITIALIZED = object()
+
+logger = logging.getLogger(__name__)
+_initialization_lock = threading.RLock()
+_initializing_thread: int | None = None
+_initialization: object = _UNINITIALIZED
+
+
+class ExtensionInitializationError(RuntimeError):
+    """Report a compiler extension that could not be initialized."""
+
+
+@dataclass(frozen=True)
+class _FailedInitialization:
+    error: ExtensionInitializationError
+
+
+@dataclass(frozen=True)
+class _RegistrationSnapshot:
+    planners: tuple[type, ...]
+    rewrites: dict[str, tuple[type, ...]]
+
+
+def _snapshot_registrations() -> _RegistrationSnapshot:
+    """Snapshot compiler-owned registries populated by extension imports."""
+
+    from numba_cuda_mlir._whole_function_planners import _planner_registry
+    from numba_cuda_mlir.numba_cuda.core.rewrites import rewrite_registry
+
+    with _planner_registry._lock:
+        planners = tuple(_planner_registry._planners)
+    rewrites = {
+        kind: tuple(rewrite_classes) for kind, rewrite_classes in rewrite_registry.rewrites.items()
+    }
+    return _RegistrationSnapshot(planners=planners, rewrites=rewrites)
+
+
+def _restore_registrations(snapshot: _RegistrationSnapshot) -> None:
+    """Roll compiler-owned registries back to *snapshot*."""
+
+    from numba_cuda_mlir._whole_function_planners import _planner_registry
+    from numba_cuda_mlir.numba_cuda.core.rewrites import rewrite_registry
+
+    with _planner_registry._lock:
+        _planner_registry._planners[:] = snapshot.planners
+    rewrite_registry.rewrites.clear()
+    for kind, rewrite_classes in snapshot.rewrites.items():
+        rewrite_registry.rewrites[kind].extend(rewrite_classes)
+
+
+def _entry_point_identity(entry_point: Any) -> tuple[str, str, str]:
+    distribution = getattr(entry_point, "dist", None)
+    distribution_name = getattr(distribution, "name", "") or ""
+    module = getattr(entry_point, "module", "") or ""
+    value = getattr(entry_point, "value", "") or module
+    return str(distribution_name), str(module), str(value)
+
+
+def _entry_point_sort_key(entry_point: Any) -> tuple[str, str, str]:
+    return tuple(part.casefold() for part in _entry_point_identity(entry_point))
+
+
+def _discover_entry_points() -> tuple[Any, ...]:
+    entry_points = importlib_metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        selected = entry_points.select(group=_ENTRY_POINT_GROUP, name=_ENTRY_POINT_NAME)
+    else:
+        selected = (
+            entry_point
+            for entry_point in entry_points.get(_ENTRY_POINT_GROUP, ())
+            if entry_point.name == _ENTRY_POINT_NAME
+        )
+    return tuple(sorted(selected, key=_entry_point_sort_key))
+
+
+def _format_entry_point(entry_point: Any) -> str:
+    distribution, module, value = _entry_point_identity(entry_point)
+    source = distribution or module or "unknown distribution"
+    target = value or "unknown initializer"
+    return f"{source!r} ({target})"
+
+
+def _initialization_error(
+    entry_point: Any | None,
+    exc: BaseException,
+    stage: str,
+) -> ExtensionInitializationError:
+    if entry_point is None:
+        location = stage
+    else:
+        location = f"extension {_format_entry_point(entry_point)}"
+    return ExtensionInitializationError(
+        f"Numba-CUDA-MLIR {location} failed with {type(exc).__name__}: {exc}"
+    )
+
+
+def initialize_extensions() -> tuple[str, ...]:
+    """Initialize installed compiler extensions exactly once.
+
+    Discovery is deferred until the first compilation route calls this
+    function. Initialization is serialized across threads. A recursive compile
+    from an initializer is rejected, and an initialization failure rolls back
+    compiler-owned planner and rewrite registrations before the same failure is
+    cached for later callers.
+    """
+
+    global _initialization
+    global _initializing_thread
+
+    initialization = _initialization
+    if isinstance(initialization, _FailedInitialization):
+        raise initialization.error
+    if initialization is not _UNINITIALIZED:
+        return cast(tuple[str, ...], initialization)
+
+    with _initialization_lock:
+        if isinstance(_initialization, _FailedInitialization):
+            raise _initialization.error
+        if _initialization is not _UNINITIALIZED:
+            return cast(tuple[str, ...], _initialization)
+
+        current_thread = threading.get_ident()
+        if _initializing_thread == current_thread:
+            raise RuntimeError(
+                "recursive Numba-CUDA-MLIR extension initialization attempted "
+                "compilation before extension registration completed"
+            )
+
+        _initializing_thread = current_thread
+        snapshot = None
+        entry_point = None
+        stage = "registration snapshot"
+        try:
+            try:
+                snapshot = _snapshot_registrations()
+                stage = "entry-point discovery"
+                entry_points = _discover_entry_points()
+                initialized = []
+                for entry_point in entry_points:
+                    logger.debug("Loading extension: %s", entry_point)
+                    initializer = entry_point.load()
+                    if not callable(initializer):
+                        raise TypeError(
+                            f"extension initializer {_format_entry_point(entry_point)} "
+                            "is not callable"
+                        )
+                    initializer()
+                    initialized.append(_format_entry_point(entry_point))
+            except BaseException as exc:
+                if snapshot is not None:
+                    _restore_registrations(snapshot)
+                if not isinstance(exc, Exception):
+                    _initialization = _UNINITIALIZED
+                    raise
+                error = _initialization_error(entry_point, exc, stage)
+                _initialization = _FailedInitialization(error)
+                raise error from exc
+
+            result = tuple(initialized)
+            _initialization = result
+            return result
+        finally:
+            _initializing_thread = None
+
+
+__all__: list[str] = []

--- a/src/numba_cuda_mlir/compiler.py
+++ b/src/numba_cuda_mlir/compiler.py
@@ -19,6 +19,7 @@ from numba_cuda_mlir.numba_cuda.compiler import sigutils
 from numba_cuda_mlir.descriptor import mlir_target
 from numba_cuda_mlir.numba_cuda.core import funcdesc
 from numba_cuda_mlir.logging import trace
+from numba_cuda_mlir._extension_bootstrap import initialize_extensions
 from numba_cuda_mlir.typing.externals import (
     ExternMLIRLibrary,
     ExternMLIRLibraryFunction,
@@ -267,11 +268,13 @@ class CompileResult:
 
 
 def _compile_and_optimize(pyfunc, sig=None, targetoptions=None):
+    initialize_extensions()
     return _compile(pyfunc, sig, targetoptions, optimized=True)
 
 
 def _compile_only(pyfunc, sig=None, targetoptions=None):
     """Compile to MLIR without running the optimization pipeline."""
+    initialize_extensions()
     from numba_cuda_mlir.cuda import jit
     from numba_cuda_mlir import mlir_compiler
     from numba_cuda_mlir._whole_function_planners import _RequireLaunchConfig
@@ -304,6 +307,7 @@ def _compile_only(pyfunc, sig=None, targetoptions=None):
 
 
 def _compile(pyfunc, sig=None, targetoptions=None, optimized=True):
+    initialize_extensions()
     from numba_cuda_mlir.cuda import jit
 
     dispatcher = pyfunc
@@ -335,6 +339,7 @@ def _compile(pyfunc, sig=None, targetoptions=None, optimized=True):
 
 
 def compile_for(func, *args):
+    initialize_extensions()
     from numba_cuda_mlir.numba_cuda.typing.typeof import typeof
 
     sig = typing.signature(types.none, *[typeof(arg) for arg in args])
@@ -374,6 +379,74 @@ def compile_ptx(
     )
 
 
+def compile_for_current_device(
+    pyfunc,
+    sig,
+    debug=None,
+    lineinfo=False,
+    device=True,
+    fastmath=False,
+    opt=None,
+    abi="c",
+    abi_info=None,
+    output="ptx",
+    forceinline=False,
+    launch_bounds=None,
+):
+    """Compile for the current device through the MLIR compiler pipeline."""
+
+    initialize_extensions()
+    from numba_cuda_mlir.numba_cuda import get_current_device
+
+    return compile(
+        pyfunc,
+        sig,
+        debug=debug,
+        lineinfo=lineinfo,
+        device=device,
+        fastmath=fastmath,
+        cc=get_current_device().compute_capability,
+        opt=opt,
+        abi=abi,
+        abi_info=abi_info,
+        output=output,
+        forceinline=forceinline,
+        launch_bounds=launch_bounds,
+    )
+
+
+def compile_ptx_for_current_device(
+    pyfunc,
+    sig,
+    debug=None,
+    lineinfo=False,
+    device=False,
+    fastmath=False,
+    opt=None,
+    abi="numba",
+    abi_info=None,
+    forceinline=False,
+    launch_bounds=None,
+):
+    """Compile PTX for the current device through the MLIR compiler pipeline."""
+
+    initialize_extensions()
+    return compile_for_current_device(
+        pyfunc,
+        sig,
+        debug=debug,
+        lineinfo=lineinfo,
+        device=device,
+        fastmath=fastmath,
+        opt=opt,
+        abi=abi,
+        abi_info=abi_info,
+        output="ptx",
+        forceinline=forceinline,
+        launch_bounds=launch_bounds,
+    )
+
+
 def compile(
     pyfunc,
     sig,
@@ -390,6 +463,7 @@ def compile(
     launch_bounds=None,
 ):
     """Compile a Python function to PTX or LTO-IR (numba-cuda compatible API)."""
+    initialize_extensions()
     # Validate output type
     if output not in ("ptx", "ltoir"):
         raise NotImplementedError(f"Unsupported output type: {output}")
@@ -446,10 +520,12 @@ def compile_all(*args, **kwargs):
 
 def compile_result(pyfunc, sig=None):
     """Compile and return full CompileResult for internal use."""
+    initialize_extensions()
     return _compile_and_optimize(pyfunc, sig)
 
 
 def compile_mlir(pyfunc, sig, optimized=False, **targetoptions):
+    initialize_extensions()
     if optimized:
         cres = _compile_and_optimize(pyfunc, sig, targetoptions)
         return cres.metadata["mlir_module_optimized"]
@@ -463,6 +539,7 @@ def compile_mlir(pyfunc, sig, optimized=False, **targetoptions):
 
 
 def compile_cubin(pyfunc, sig, **targetoptions):
+    initialize_extensions()
     cres = _compile_and_optimize(pyfunc, sig, targetoptions)
     return cres.metadata["cubin"]
 

--- a/src/numba_cuda_mlir/cuda/__init__.py
+++ b/src/numba_cuda_mlir/cuda/__init__.py
@@ -20,6 +20,8 @@ from numba_cuda_mlir.decorators import mlir_jit as jit
 from numba_cuda_mlir.compiler import (
     compile,
     compile_ptx,
+    compile_for_current_device,
+    compile_ptx_for_current_device,
     compile_all,
     compile_mlir,
     compile_for,

--- a/src/numba_cuda_mlir/decorators.py
+++ b/src/numba_cuda_mlir/decorators.py
@@ -13,6 +13,7 @@ import sys
 from textwrap import dedent
 from dataclasses import dataclass
 from numba_cuda_mlir.tools import format_arch
+from numba_cuda_mlir._extension_bootstrap import initialize_extensions
 
 
 @dataclass
@@ -467,6 +468,15 @@ def _extract_signature_from_annotations(func):
     return typing.signature(return_type, *argtypes)
 
 
+def _has_complete_parameter_annotations(func):
+    """Whether *func* has a potentially eager annotation signature."""
+
+    parameters = tuple(inspect.signature(func).parameters.values())
+    return bool(parameters) and all(
+        parameter.annotation != inspect.Parameter.empty for parameter in parameters
+    )
+
+
 def _get_signatures(func_or_sig):
     if sigutils.is_signature(func_or_sig):
         return [func_or_sig]
@@ -616,7 +626,8 @@ def mlir_jit(func_or_sig=None, **kws):
         _maybe_enable_experimental(func)
 
         # Check for conflicting signature sources
-        if annotations_as_signatures:
+        if annotations_as_signatures and _has_complete_parameter_annotations(func):
+            initialize_extensions()
             annotation_sig = _extract_signature_from_annotations(func)
             if annotation_sig is not None:
                 raise TypeError(
@@ -652,7 +663,10 @@ def mlir_jit(func_or_sig=None, **kws):
     def _jit_with_annotations(func):
         """JIT using type annotations as the signature if available."""
         _maybe_enable_experimental(func)
-        sig = _extract_signature_from_annotations(func)
+        sig = None
+        if _has_complete_parameter_annotations(func):
+            initialize_extensions()
+            sig = _extract_signature_from_annotations(func)
 
         disp = MLIRDispatcher(func, targetoptions=targetoptions)
 

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -45,6 +45,7 @@ from numba_cuda_mlir._whole_function_planners import (
     _RequireLaunchConfig,
     _planner_registry,
 )
+from numba_cuda_mlir._extension_bootstrap import initialize_extensions
 from numba_cuda_mlir._launch_config import (
     _LAUNCH_CONFIG_TRACKER_OPTION,
     _LaunchConfigTracker,
@@ -780,6 +781,7 @@ class _ArgMarshaller:
             return self._call_impl(*args)
 
     def _call_impl(self, *args):
+        initialize_extensions()
         nargs = len(args)
         has_ext = bool(self._extensions)
 
@@ -2146,6 +2148,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         Reduce state stores signatures, not runtime argument values, so override_argtypes
         drives compilation while placeholder values satisfy the dispatch entry point.
         """
+        initialize_extensions()
         argtypes, _return_type = sigutils.normalize_signature(sig)
         launch_config = _launch_config_dict_from_key(launch_config_key)
         launch_config_key = _launch_config_key(launch_config)
@@ -2708,6 +2711,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         configured_kernel_dispatcher,
         configured_launch_config_generation,
     ):
+        initialize_extensions()
+
         def active_launch_config():
             if self._requires_launch_config:
                 return _normalize_available_launch_config(available_launch_config)
@@ -2871,6 +2876,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 print(f"Profile saved to: {profile_opt}", file=sys.stderr)
 
     def _compile(self, args):
+        initialize_extensions()
         with global_compiler_lock:
             cubin, func_name, cooperative = self._compile_impl(args)
             if self._module_setup_callbacks or self._module_teardown_callbacks:
@@ -2882,6 +2888,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         args,
         launch_config_retry_budget=_CONFIGURE_CACHE_STALE_RETRY_LIMIT,
     ):
+        initialize_extensions()
         from numba_cuda_mlir import mlir_compiler
         from numba_cuda_mlir.compiler import CompileResult
 
@@ -3163,6 +3170,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         return _result(wrapped)
 
     def compile(self, sig, abi_info=None, output=None):
+        initialize_extensions()
         self._ensure_dispatcher_state()
         launch_lock = self._launch_lock
         if launch_lock is None:
@@ -3171,6 +3179,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             return self._compile_public(sig, abi_info=abi_info, output=output)
 
     def _compile_public(self, sig, abi_info=None, output=None):
+        initialize_extensions()
         from numba_cuda_mlir.mlir_optimization import optimize
         from numba_cuda_mlir import mlir_compiler
         from numba_cuda_mlir.compiler import CompileResult
@@ -3247,6 +3256,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         return wrapped
 
     def compile_for(self, *args):
+        initialize_extensions()
         return_type = types.none
         args = [a if isinstance(a, types.Type) else typeof(a) for a in args]
         sig = typing.signature(return_type, *args)
@@ -3259,6 +3269,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         eagerly finalizing every callee to cubin only adds linker work and
         retained cubin metadata that the parent compilation does not use.
         """
+        initialize_extensions()
         from numba_cuda_mlir import mlir_compiler
         from numba_cuda_mlir.compiler import CompileResult
 
@@ -3302,6 +3313,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
 
     def _compile_as_device_callee(self, sig):
         """Compile this dispatcher through the lightweight device-callee path."""
+        initialize_extensions()
         opts = self.targetoptions.copy()
         opts["device"] = True
         opts["lto"] = False
@@ -3345,6 +3357,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
 
     def specialize(self, *args):
         """Create a new instance specialized for the given *args*."""
+        initialize_extensions()
         from numba_cuda_mlir.numba_cuda import get_current_device
 
         cc = get_current_device().compute_capability
@@ -3459,6 +3472,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
     def compile_device(self, sig):
         """Compile as a device function, injecting device=True if needed
         so that the function is not treated as a kernel."""
+        initialize_extensions()
         opts = self.targetoptions.copy()
         opts["device"] = True
         opts["lto"] = False
@@ -3477,6 +3491,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         """Resolve return type when this dispatcher is called from another
         jit function. Always compile as a device function so we don't
         emit kernel metadata for callees."""
+        initialize_extensions()
         pysig, args = self._compiler.fold_argument_types(args, kws)
         kws = {}
         if self._can_compile:

--- a/src/numba_cuda_mlir/extending/__init__.py
+++ b/src/numba_cuda_mlir/extending/__init__.py
@@ -3,7 +3,7 @@
 import functools
 from types import MappingProxyType
 
-from numba_cuda_mlir import CUDA_COOP_EXTENSION_PROTOCOL
+from numba_cuda_mlir import CUDA_INTEROP_EXTENSION_PROTOCOL
 from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir.numba_cuda.datamodel.registry import register
 from numba_cuda_mlir.numba_cuda.typing.asnumbatype import as_numba_type
@@ -41,7 +41,7 @@ register_model = functools.partial(register, mlir_data_manager)
 
 __all__ = [
     "ArgumentHandler",
-    "CUDA_COOP_EXTENSION_PROTOCOL",
+    "CUDA_INTEROP_EXTENSION_PROTOCOL",
     "WholeFunctionPlanner",
     "intrinsic",
     "lowering_registry",

--- a/src/numba_cuda_mlir/extending/__init__.py
+++ b/src/numba_cuda_mlir/extending/__init__.py
@@ -3,6 +3,7 @@
 import functools
 from types import MappingProxyType
 
+from numba_cuda_mlir import CUDA_COOP_EXTENSION_PROTOCOL
 from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir.numba_cuda.datamodel.registry import register
 from numba_cuda_mlir.numba_cuda.typing.asnumbatype import as_numba_type
@@ -40,6 +41,7 @@ register_model = functools.partial(register, mlir_data_manager)
 
 __all__ = [
     "ArgumentHandler",
+    "CUDA_COOP_EXTENSION_PROTOCOL",
     "WholeFunctionPlanner",
     "intrinsic",
     "lowering_registry",

--- a/src/numba_cuda_mlir/mlir_compiler.py
+++ b/src/numba_cuda_mlir/mlir_compiler.py
@@ -66,6 +66,7 @@ from numba_cuda_mlir.errors import (
     UserFacingInternalCompilerError,
     handle_lowering_error,
 )
+from numba_cuda_mlir._extension_bootstrap import initialize_extensions
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
@@ -307,6 +308,7 @@ def get_compiler_class(
 
 @global_compiler_lock
 def compile_mlir(pyfunc, return_type, args, targetoptions: Dict[str, Any]):
+    initialize_extensions()
     from numba_cuda_mlir.install_registry import register_lowering
     from numba_cuda_mlir.tools import resolve_gpu_target
 
@@ -425,6 +427,7 @@ def mlir_compiler_entry(
     :return: (code, resty): The compiled code and inferred return type
     :rtype: tuple
     """
+    initialize_extensions()
     if abi not in ("numba", "c"):
         raise NotImplementedError(f"Unsupported ABI: {abi}")
 

--- a/src/numba_cuda_mlir/numba_cuda/core/entrypoints.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/entrypoints.py
@@ -1,50 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import logging
-import warnings
-
-from importlib import metadata as importlib_metadata
-
-_already_initialized = False
-logger = logging.getLogger(__name__)
-
 
 def init_all():
     """Execute all `numba_cuda_mlir_extensions` entry points with the name `init`
 
-    If extensions have already been initialized, this function does nothing.
+    This compatibility entry point delegates to the compiler-owned, lazy,
+    process-wide extension bootstrap.
     """
 
-    global _already_initialized
-    if _already_initialized:
-        return
+    from numba_cuda_mlir._extension_bootstrap import initialize_extensions
 
-    # Must put this here to avoid extensions re-triggering initialization
-    _already_initialized = True
-
-    def load_ep(entry_point):
-        """Loads a given entry point. Warns and logs on failure."""
-        logger.debug("Loading extension: %s", entry_point)
-        try:
-            func = entry_point.load()
-            func()
-        except Exception as e:
-            msg = (
-                f"numba_cuda_mlir extension module '{entry_point.module}' "
-                f"failed to load due to '{type(e).__name__}({str(e)})'."
-            )
-            warnings.warn(msg, stacklevel=3)
-            logger.debug("Extension loading failed for: %s", entry_point)
-
-    eps = importlib_metadata.entry_points()
-    # Split, Python 3.10+ and importlib_metadata 3.6+ have the "selectable"
-    # interface, versions prior to that do not. See "compatibility note" in:
-    # https://docs.python.org/3.10/library/importlib.metadata.html#entry-points
-    if hasattr(eps, "select"):
-        for entry_point in eps.select(group="numba_cuda_mlir_extensions", name="init"):
-            load_ep(entry_point)
-    else:
-        for entry_point in eps.get("numba_cuda_mlir_extensions", ()):
-            if entry_point.name == "init":
-                load_ep(entry_point)
+    return initialize_extensions()

--- a/src/numba_cuda_mlir/numba_cuda/dispatcher.py
+++ b/src/numba_cuda_mlir/numba_cuda/dispatcher.py
@@ -41,7 +41,8 @@ from numba_cuda_mlir.numba_cuda.compiler import (
     compile_ir,
 )
 from numba_cuda_mlir.numba_cuda import compiler
-from numba_cuda_mlir.numba_cuda.core import sigutils, config, entrypoints
+from numba_cuda_mlir.numba_cuda.core import sigutils, config
+from numba_cuda_mlir._extension_bootstrap import initialize_extensions
 from numba_cuda_mlir.numba_cuda.flags import Flags
 from numba_cuda_mlir.numba_cuda.cudadrv import driver, nvvm
 from numba_cuda_mlir.numba_cuda.locks import module_init_lock
@@ -837,7 +838,7 @@ class _DispatcherBase:  # (_dispatcher.Dispatcher):
         that the compiler knows about additional externally defined types etc
         before it does anything.
         """
-        entrypoints.init_all()
+        initialize_extensions()
 
     def _reset_overloads(self):
         self._clear()

--- a/tests/test_extension_bootstrap.py
+++ b/tests/test_extension_bootstrap.py
@@ -1,0 +1,444 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for lazy compiler-extension initialization."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def bootstrap_module(monkeypatch):
+    module = importlib.import_module("numba_cuda_mlir._extension_bootstrap")
+    module = importlib.reload(module)
+    monkeypatch.setattr(module, "_snapshot_registrations", lambda: object())
+    monkeypatch.setattr(module, "_restore_registrations", lambda _snapshot: None)
+    return module
+
+
+@dataclass(frozen=True)
+class _Distribution:
+    name: str
+
+
+class _EntryPoint:
+    name = "init"
+
+    def __init__(self, distribution, module, initializer):
+        self.dist = _Distribution(distribution)
+        self.module = module
+        self.value = f"{module}:init"
+        self._initializer = initializer
+
+    def load(self):
+        return self._initializer
+
+
+class _EntryPoints(tuple):
+    def select(self, *, group, name):
+        assert group == "numba_cuda_mlir_extensions"
+        return tuple(entry_point for entry_point in self if entry_point.name == name)
+
+
+def _install_entry_points(monkeypatch, bootstrap_module, entry_points):
+    discoveries = []
+
+    def discover():
+        discoveries.append(None)
+        return _EntryPoints(entry_points)
+
+    monkeypatch.setattr(bootstrap_module.importlib_metadata, "entry_points", discover)
+    return discoveries
+
+
+def test_import_does_not_discover_extensions(monkeypatch):
+    from importlib import metadata
+
+    module_name = "numba_cuda_mlir._extension_bootstrap"
+    sys.modules.pop(module_name, None)
+
+    def unexpected_discovery():
+        raise AssertionError("extension metadata was discovered during import")
+
+    monkeypatch.setattr(metadata, "entry_points", unexpected_discovery)
+    try:
+        assert importlib.import_module(module_name) is not None
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_no_entry_points_is_cached(bootstrap_module, monkeypatch):
+    discoveries = _install_entry_points(monkeypatch, bootstrap_module, ())
+
+    assert bootstrap_module.initialize_extensions() == ()
+    assert bootstrap_module.initialize_extensions() == ()
+    assert len(discoveries) == 1
+
+
+def test_entry_point_discovery_failure_is_cached(bootstrap_module, monkeypatch):
+    discoveries = []
+
+    def discover():
+        discoveries.append(None)
+        raise ValueError("metadata is unavailable")
+
+    monkeypatch.setattr(bootstrap_module.importlib_metadata, "entry_points", discover)
+
+    with pytest.raises(
+        bootstrap_module.ExtensionInitializationError,
+        match="entry-point discovery failed with ValueError: metadata is unavailable",
+    ) as first:
+        bootstrap_module.initialize_extensions()
+    with pytest.raises(bootstrap_module.ExtensionInitializationError) as second:
+        bootstrap_module.initialize_extensions()
+
+    assert first.value is second.value
+    assert len(discoveries) == 1
+
+
+def test_registration_snapshot_failure_is_cached_and_clears_recursion_state(
+    bootstrap_module,
+    monkeypatch,
+):
+    attempts = []
+
+    def snapshot():
+        attempts.append(None)
+        raise ValueError("registry is unavailable")
+
+    monkeypatch.setattr(bootstrap_module, "_snapshot_registrations", snapshot)
+
+    with pytest.raises(
+        bootstrap_module.ExtensionInitializationError,
+        match="registration snapshot failed with ValueError: registry is unavailable",
+    ) as first:
+        bootstrap_module.initialize_extensions()
+    with pytest.raises(bootstrap_module.ExtensionInitializationError) as second:
+        bootstrap_module.initialize_extensions()
+
+    assert first.value is second.value
+    assert bootstrap_module._initializing_thread is None
+    assert attempts == [None]
+
+
+def test_entry_points_initialize_once_in_deterministic_order(
+    bootstrap_module,
+    monkeypatch,
+):
+    initialized = []
+    entry_points = (
+        _EntryPoint("zeta", "zeta_extension", lambda: initialized.append("zeta")),
+        _EntryPoint("Alpha", "alpha_extension", lambda: initialized.append("alpha")),
+    )
+    discoveries = _install_entry_points(monkeypatch, bootstrap_module, entry_points)
+
+    result = bootstrap_module.initialize_extensions()
+
+    assert initialized == ["alpha", "zeta"]
+    assert result == (
+        "'Alpha' (alpha_extension:init)",
+        "'zeta' (zeta_extension:init)",
+    )
+    assert bootstrap_module.initialize_extensions() is result
+    assert len(discoveries) == 1
+
+
+def test_concurrent_initialization_waits_for_one_initializer(
+    bootstrap_module,
+    monkeypatch,
+):
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    def initialize():
+        calls.append(threading.get_ident())
+        entered.set()
+        assert release.wait(timeout=5)
+
+    _install_entry_points(
+        monkeypatch,
+        bootstrap_module,
+        (_EntryPoint("extension", "extension", initialize),),
+    )
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(bootstrap_module.initialize_extensions) for _ in range(4)]
+        assert entered.wait(timeout=5)
+        release.set()
+        results = [future.result(timeout=5) for future in futures]
+
+    assert len(calls) == 1
+    assert results == [("'extension' (extension:init)",)] * 4
+
+
+def test_recursive_initialization_is_rejected_and_failure_is_cached(
+    bootstrap_module,
+    monkeypatch,
+):
+    calls = []
+
+    def initialize():
+        calls.append(None)
+        bootstrap_module.initialize_extensions()
+
+    _install_entry_points(
+        monkeypatch,
+        bootstrap_module,
+        (_EntryPoint("recursive", "recursive_extension", initialize),),
+    )
+
+    with pytest.raises(
+        bootstrap_module.ExtensionInitializationError,
+        match="recursive Numba-CUDA-MLIR extension initialization",
+    ) as first:
+        bootstrap_module.initialize_extensions()
+    with pytest.raises(bootstrap_module.ExtensionInitializationError) as second:
+        bootstrap_module.initialize_extensions()
+
+    assert calls == [None]
+    assert first.value is second.value
+    assert isinstance(first.value.__cause__, RuntimeError)
+
+
+def test_failure_rolls_back_registrations_and_is_cached(monkeypatch):
+    bootstrap = importlib.reload(importlib.import_module("numba_cuda_mlir._extension_bootstrap"))
+    from numba_cuda_mlir._whole_function_planners import (
+        WholeFunctionPlanner,
+        _planner_registry,
+    )
+    from numba_cuda_mlir.numba_cuda.core.rewrites import Rewrite, rewrite_registry
+
+    with _planner_registry._lock:
+        planners_before = tuple(_planner_registry._planners)
+    rewrites_before = {
+        kind: tuple(rewrites) for kind, rewrites in rewrite_registry.rewrites.items()
+    }
+    calls = []
+
+    def initialize():
+        calls.append(None)
+
+        class FailedPlanner(WholeFunctionPlanner):
+            def run(self):
+                return False
+
+        class FailedRewrite(Rewrite):
+            pass
+
+        _planner_registry.register(FailedPlanner)
+        rewrite_registry.register("before-inference")(FailedRewrite)
+        raise ValueError("registration failed")
+
+    monkeypatch.setattr(
+        bootstrap.importlib_metadata,
+        "entry_points",
+        lambda: _EntryPoints((_EntryPoint("broken", "broken_extension", initialize),)),
+    )
+
+    with pytest.raises(
+        bootstrap.ExtensionInitializationError,
+        match="broken_extension:init.*ValueError: registration failed",
+    ) as first:
+        bootstrap.initialize_extensions()
+    with pytest.raises(bootstrap.ExtensionInitializationError) as second:
+        bootstrap.initialize_extensions()
+
+    with _planner_registry._lock:
+        assert tuple(_planner_registry._planners) == planners_before
+    assert {
+        kind: tuple(rewrites) for kind, rewrites in rewrite_registry.rewrites.items()
+    } == rewrites_before
+    assert calls == [None]
+    assert first.value is second.value
+    importlib.reload(bootstrap)
+
+
+def test_legacy_entry_point_loader_delegates(monkeypatch):
+    from numba_cuda_mlir import _extension_bootstrap
+    from numba_cuda_mlir.numba_cuda.core import entrypoints
+
+    report = object()
+    monkeypatch.setattr(_extension_bootstrap, "initialize_extensions", lambda: report)
+
+    assert entrypoints.init_all() is report
+
+
+def test_cuda_coop_extension_protocol_is_public():
+    import numba_cuda_mlir
+    from numba_cuda_mlir import extending
+
+    assert numba_cuda_mlir.CUDA_COOP_EXTENSION_PROTOCOL == 1
+    assert "CUDA_COOP_EXTENSION_PROTOCOL" in numba_cuda_mlir.__all__
+    assert extending.CUDA_COOP_EXTENSION_PROTOCOL == 1
+    assert "CUDA_COOP_EXTENSION_PROTOCOL" in extending.__all__
+
+
+class _BootstrapReached(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    "invoke",
+    [
+        lambda dispatcher: dispatcher._compile_launch_config_signature(None, None),
+        lambda dispatcher: dispatcher._prepare_for_launch(
+            None, None, None, None, None, None, None
+        ),
+        lambda dispatcher: dispatcher._compile(None),
+        lambda dispatcher: dispatcher._compile_impl([]),
+        lambda dispatcher: dispatcher.compile(None),
+        lambda dispatcher: dispatcher._compile_public(None),
+        lambda dispatcher: dispatcher._compile_device_callee(None),
+        lambda dispatcher: dispatcher._compile_as_device_callee(None),
+        lambda dispatcher: dispatcher.compile_device(None),
+        lambda dispatcher: dispatcher.compile_for(None),
+        lambda dispatcher: dispatcher.specialize(None),
+        lambda dispatcher: dispatcher.get_call_template(None, None),
+    ],
+)
+def test_dispatcher_compile_and_cache_roots_bootstrap_first(monkeypatch, invoke):
+    from numba_cuda_mlir import descriptor
+
+    def bootstrap():
+        raise _BootstrapReached
+
+    monkeypatch.setattr(descriptor, "initialize_extensions", bootstrap)
+    dispatcher = object.__new__(descriptor.MLIRDispatcher)
+
+    with pytest.raises(_BootstrapReached):
+        invoke(dispatcher)
+
+
+def test_launch_marshalling_bootstraps_before_type_discovery(monkeypatch):
+    from numba_cuda_mlir import descriptor
+
+    monkeypatch.setattr(
+        descriptor,
+        "initialize_extensions",
+        lambda: (_ for _ in ()).throw(_BootstrapReached()),
+    )
+    marshaller = object.__new__(descriptor._ArgMarshaller)
+
+    with pytest.raises(_BootstrapReached):
+        marshaller._call_impl(object())
+
+
+@pytest.mark.parametrize(
+    "invoke",
+    [
+        lambda compiler: compiler._compile_and_optimize(None),
+        lambda compiler: compiler._compile_only(None),
+        lambda compiler: compiler._compile(None),
+        lambda compiler: compiler.compile_for(None, object()),
+        lambda compiler: compiler.compile(None, None),
+        lambda compiler: compiler.compile_for_current_device(None, None),
+        lambda compiler: compiler.compile_ptx_for_current_device(None, None),
+        lambda compiler: compiler.compile_result(None),
+        lambda compiler: compiler.compile_mlir(None, None),
+        lambda compiler: compiler.compile_cubin(None, None),
+    ],
+)
+def test_direct_compiler_apis_bootstrap_first(monkeypatch, invoke):
+    from numba_cuda_mlir import compiler
+
+    monkeypatch.setattr(
+        compiler,
+        "initialize_extensions",
+        lambda: (_ for _ in ()).throw(_BootstrapReached()),
+    )
+
+    with pytest.raises(_BootstrapReached):
+        invoke(compiler)
+
+
+@pytest.mark.parametrize(
+    "invoke",
+    [
+        lambda compiler: compiler.compile_mlir(None, None, (), {}),
+        lambda compiler: compiler.mlir_compiler_entry(None, [], {}),
+    ],
+)
+def test_low_level_compile_roots_bootstrap_first(monkeypatch, invoke):
+    from numba_cuda_mlir import mlir_compiler
+
+    monkeypatch.setattr(
+        mlir_compiler,
+        "initialize_extensions",
+        lambda: (_ for _ in ()).throw(_BootstrapReached()),
+    )
+
+    with pytest.raises(_BootstrapReached):
+        invoke(mlir_compiler)
+
+
+def test_inherited_compilation_hook_uses_shared_bootstrap(monkeypatch):
+    from numba_cuda_mlir.numba_cuda import dispatcher
+
+    calls = []
+    monkeypatch.setattr(dispatcher, "initialize_extensions", lambda: calls.append(None))
+
+    dispatcher._DispatcherBase._compilation_chain_init_hook(object())
+
+    assert calls == [None]
+
+
+@pytest.mark.parametrize("explicit_signature", [False, True])
+def test_eager_annotation_paths_bootstrap_before_extraction(
+    monkeypatch,
+    explicit_signature,
+):
+    from numba_cuda_mlir import decorators
+
+    events = []
+
+    def extract(_func):
+        events.append("extract")
+        raise _BootstrapReached
+
+    monkeypatch.setattr(decorators, "initialize_extensions", lambda: events.append("bootstrap"))
+    monkeypatch.setattr(decorators, "_extract_signature_from_annotations", extract)
+
+    if explicit_signature:
+        signature = decorators.typing.signature(
+            decorators.numba_types.none,
+            decorators.numba_types.int32,
+        )
+        decorate = decorators.mlir_jit(signature)
+    else:
+        decorate = decorators.mlir_jit()
+
+    def annotated(value: int):
+        pass
+
+    with pytest.raises(_BootstrapReached):
+        decorate(annotated)
+
+    assert events == ["bootstrap", "extract"]
+
+
+def test_lazy_unannotated_decorator_does_not_initialize_extensions(monkeypatch):
+    from numba_cuda_mlir import decorators
+
+    calls = []
+    monkeypatch.setattr(decorators, "initialize_extensions", lambda: calls.append(None))
+
+    dispatcher = decorators.mlir_jit(lambda value: None)
+
+    assert dispatcher.signatures == []
+    assert calls == []
+
+
+def test_cuda_current_device_helpers_use_mlir_compiler_wrappers():
+    from numba_cuda_mlir import compiler, cuda
+
+    assert cuda.compile_for_current_device is compiler.compile_for_current_device
+    assert cuda.compile_ptx_for_current_device is compiler.compile_ptx_for_current_device

--- a/tests/test_extension_bootstrap.py
+++ b/tests/test_extension_bootstrap.py
@@ -290,9 +290,7 @@ class _BootstrapReached(Exception):
     "invoke",
     [
         lambda dispatcher: dispatcher._compile_launch_config_signature(None, None),
-        lambda dispatcher: dispatcher._prepare_for_launch(
-            None, None, None, None, None, None, None
-        ),
+        lambda dispatcher: dispatcher._prepare_for_launch(None, None, None, None, None, None, None),
         lambda dispatcher: dispatcher._compile(None),
         lambda dispatcher: dispatcher._compile_impl([]),
         lambda dispatcher: dispatcher.compile(None),

--- a/tests/test_extension_bootstrap.py
+++ b/tests/test_extension_bootstrap.py
@@ -272,14 +272,14 @@ def test_legacy_entry_point_loader_delegates(monkeypatch):
     assert entrypoints.init_all() is report
 
 
-def test_cuda_coop_extension_protocol_is_public():
+def test_cuda_interop_extension_protocol_is_public():
     import numba_cuda_mlir
     from numba_cuda_mlir import extending
 
-    assert numba_cuda_mlir.CUDA_COOP_EXTENSION_PROTOCOL == 1
-    assert "CUDA_COOP_EXTENSION_PROTOCOL" in numba_cuda_mlir.__all__
-    assert extending.CUDA_COOP_EXTENSION_PROTOCOL == 1
-    assert "CUDA_COOP_EXTENSION_PROTOCOL" in extending.__all__
+    assert numba_cuda_mlir.CUDA_INTEROP_EXTENSION_PROTOCOL == 1
+    assert "CUDA_INTEROP_EXTENSION_PROTOCOL" in numba_cuda_mlir.__all__
+    assert extending.CUDA_INTEROP_EXTENSION_PROTOCOL == 1
+    assert "CUDA_INTEROP_EXTENSION_PROTOCOL" in extending.__all__
 
 
 class _BootstrapReached(Exception):


### PR DESCRIPTION
## What changed

- discover `numba_cuda_mlir_extensions` entry points lazily at the first compilation boundary
- initialize extensions once in deterministic order, with concurrency and recursion handling
- roll compiler-owned planner and rewrite registrations back after initialization failures
- expose CUDA interop extension protocol version 1 and document the entry-point contract
- route public, dispatcher, device-callee, eager-signature, and low-level compile paths through the shared bootstrap

## Why this is needed

Installed CUDA interoperability providers can already publish registration entry points, but normal Numba-CUDA-MLIR compilation does not reliably invoke them before typing and lowering begin. That leaves providers dependent on an explicit provider import or another import-order side effect.

The compiler needs to own extension activation so any installed provider can register its planners and rewrites before the first compilation. Numba-CUDA-MLIR remains unaware of each provider's package, API, and implementation, and optional providers stay out of normal package import time.

This PR is intentionally limited to the extension-loader contract. It starts from current `main` at `c25b253e`, including the merged scalar-literal retry from #239; it does not carry the superseded local retry implementation. Structured extension arguments and LLVM-backed aggregate dtypes will be proposed separately.

## Validation

- `uvx --from pre-commit pre-commit run --from-ref origin/main --to-ref 8c4e4723`
- `uvx --from pre-commit pre-commit run --files docs/source/extending/low-level.rst src/numba_cuda_mlir/__init__.py src/numba_cuda_mlir/extending/__init__.py tests/test_extension_bootstrap.py`
- `python -m pytest -q tests/test_extension_bootstrap.py tests/test_descriptor_launch_config.py tests/test_post_inline_planners.py tests/test_argument_handler_extensions.py tests/test_compiler_public_api.py` (`161 passed, 8 warnings`)
- `git diff --check origin/main..HEAD`

The test environment was built against the CPython 3.12 LLVM artifacts from successful current-main CI run `31043285806`.
