### PR TITLE
Support structured extension arguments and local arrays

### DIFF
--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -705,12 +705,12 @@ std::vector<bool> effective_constant_arg_flags(
         const std::vector<PyTypeObject*>& arg_types) {
     assert(constant_arg_flags.size() == literal_arg_flags.size());
 
-    // Tuple/list arguments are flattened before the native launch, while the
-    // flags describe top-level Python parameters. Literal retry rejects that
-    // ABI today, but every profile still needs one safe flag per native arg.
+    // Tuple/list and extension-owned arguments can be flattened before the
+    // native launch, while the flags describe top-level Python parameters.
+    // No flag can be mapped safely unless both arities still match exactly.
     std::vector<bool> effective_flags(arg_types.size(), false);
-    const size_t represented_arg_count = std::min(arg_types.size(), constant_arg_flags.size());
-    for (size_t i = 0; i < represented_arg_count; ++i) {
+    if (arg_types.size() != constant_arg_flags.size()) return effective_flags;
+    for (size_t i = 0; i < arg_types.size(); ++i) {
         // Numba literal typing accepts exact built-in int/bool values, not
         // int subclasses, IntEnum members, or NumPy integer scalars.
         bool literal_eligible = arg_types[i] == &PyLong_Type || arg_types[i] == &PyBool_Type;

--- a/cext/launcher/kernel.cpp
+++ b/cext/launcher/kernel.cpp
@@ -39,6 +39,7 @@ PyObject* g_data_pyunicode;
 PyObject* g_strides_pyunicode;
 PyObject* g___dlpack___pyunicode;
 PyObject* g_int64_pyunicode;
+PyObject* g__dispatch_token_pyunicode;
 
 PyTypeObject* g_torch_Tensor_type;
 PyTypeObject* g_torch_cuda_Stream_type;
@@ -307,6 +308,30 @@ struct ConstantArg {
     }
 };
 
+size_t hash_constant_arg(const ConstantArg& arg) {
+    switch (arg.type) {
+    case ConstantArgType::INT64:
+        return std::hash<int64_t>{}(arg.value.i64);
+    case ConstantArgType::UINT64:
+        return std::hash<uint64_t>{}(arg.value.u64)
+             ^ (static_cast<size_t>(ConstantArgType::UINT64) << 1);
+    case ConstantArgType::BOOL:
+        // Shift the BOOL tag past the 0/1 payload bit before mixing it into
+        // the integer hash, so BOOL values do not just swap INT64 0/1 hashes.
+        return std::hash<int64_t>{}(arg.value.i64)
+             ^ (static_cast<size_t>(ConstantArgType::BOOL) << 1);
+    case ConstantArgType::FLOAT64: {
+        uint64_t float_bits;
+        std::memcpy(&float_bits, &arg.value.f64, sizeof(arg.value.f64));
+        return std::hash<uint64_t>{}(float_bits);
+    }
+    case ConstantArgType::STRING:
+        return std::hash<std::string>{}(arg.str);
+    }
+    assert(false && "Unsupported constant arg type");
+    return 0;
+}
+
 [[maybe_unused]]
 inline void hash_combine(size_t& h, size_t other) {
     h ^= other + 0x9e3779b9 + (h << 6) + (h >> 2);
@@ -319,6 +344,24 @@ struct HashVector {
         const std::hash<T> elem_hash;
         for (const T& x : v)
             hash_combine(ret, elem_hash(x));
+        return ret;
+    }
+};
+
+struct KernelCacheKey {
+    uint64_t dispatch_token;
+    std::vector<ConstantArg> constants;
+
+    bool operator==(const KernelCacheKey& other) const {
+        return dispatch_token == other.dispatch_token && constants == other.constants;
+    }
+};
+
+struct HashKernelCacheKey {
+    size_t operator()(const KernelCacheKey& key) const {
+        size_t ret = std::hash<uint64_t>{}(key.dispatch_token);
+        for (const ConstantArg& constant : key.constants)
+            hash_combine(ret, hash_constant_arg(constant));
         return ret;
     }
 };
@@ -345,9 +388,9 @@ int64_t pack_dtype_and_ndim(DLDataType dtype, size_t ndim) {
 
 struct KernelFamily : SimpleRefcount<KernelFamily> {
     using KernelMap = std::unordered_map<
-            std::vector<ConstantArg>, CudaKernelHandle, HashVector<ConstantArg>>;
+            KernelCacheKey, CudaKernelHandle, HashKernelCacheKey>;
 
-    KernelMap kernels_by_constants;
+    KernelMap kernels_by_dispatch_key;
 };
 
 union CudaArg {
@@ -1473,9 +1516,13 @@ Status extract_cuda_args(PyObject* const* pyargs, size_t num_pyargs,
     helper.record_copies.clear();
 
     helper.cuda_context = nullptr;
+    // Constant flags describe logical Python parameters. Argument handlers can
+    // expand one parameter into multiple ABI leaves, so no flag can be mapped
+    // safely unless the logical and flattened arities still match exactly.
+    bool constant_flags_aligned = num_pyargs == constant_arg_flags.size();
     for (size_t i = 0; i < num_pyargs; ++i) {
         PyObject* pyobj = pyargs[i];
-        bool is_constant = constant_arg_flags[i];
+        bool is_constant = constant_flags_aligned && constant_arg_flags[i];
 
         switch (arg_kinds[i]) {
         case PythonArgKind::TorchTensorDlpack:
@@ -1872,7 +1919,7 @@ bool try_clarify_launch_out_of_resources_error(CUkernel kernel, const Grid& bloc
 }
 
 Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional<Grid> cluster,
-              std::optional<CUstream> stream, int sharedmem,
+              std::optional<CUstream> stream, int sharedmem, uint64_t dispatch_token,
               PyObject* const* pyargs, Py_ssize_t num_pyargs) {
     LaunchHelperPtr helper = launch_helper_get();
     get_pyarg_types(pyargs, num_pyargs, helper->pyarg_types);
@@ -1959,8 +2006,9 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
         if (!ensure_numba_context(dispatcher.ensure_context_func.get()))
             return ErrorRaised;
 
-        KernelFamily::KernelMap& kernel_map = profile->family->kernels_by_constants;
-        kernel_iter = kernel_map.find(helper->constants);
+        KernelFamily::KernelMap& kernel_map = profile->family->kernels_by_dispatch_key;
+        KernelCacheKey cache_key{dispatch_token, helper->constants};
+        kernel_iter = kernel_map.find(cache_key);
         if (kernel_iter == kernel_map.end()) {
             // Slowest path: need to compile a new kernel
             Result<CudaKernelHandle> kernel = compile(dispatcher.compile_func.get(), pyargs, num_pyargs);
@@ -1968,7 +2016,7 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
             // Defer the post-load callback until after emplace so that racing
             // threads that compile the same kernel don't fire duplicate callbacks.
             PyPtr post_load_cb = std::move(kernel->post_load_callback);
-            auto [it, inserted] = kernel_map.emplace(helper->constants, std::move(*kernel));
+            auto [it, inserted] = kernel_map.emplace(std::move(cache_key), std::move(*kernel));
             kernel_iter = it;
             if (inserted && post_load_cb) {
                 PyPtr py_handle = steal(PyLong_FromVoidPtr(
@@ -1997,8 +2045,9 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
                 return ErrorRaised;
         }
 
-        KernelFamily::KernelMap& kernel_map = profile->family->kernels_by_constants;
-        kernel_iter = kernel_map.find(helper->constants);
+        KernelFamily::KernelMap& kernel_map = profile->family->kernels_by_dispatch_key;
+        KernelCacheKey cache_key{dispatch_token, helper->constants};
+        kernel_iter = kernel_map.find(cache_key);
         if (kernel_iter == kernel_map.end()) {
             // Slowest path: need to compile a new kernel
             Result<CudaKernelHandle> kernel = compile(dispatcher.compile_func.get(), pyargs, num_pyargs);
@@ -2007,7 +2056,7 @@ Status launch(KernelDispatcher& dispatcher, Grid grid, Grid block, std::optional
             // Defer the post-load callback until after emplace so that racing
             // threads that compile the same kernel don't fire duplicate callbacks.
             PyPtr post_load_cb = std::move(kernel->post_load_callback);
-            auto [it, inserted] = kernel_map.emplace(helper->constants, std::move(*kernel));
+            auto [it, inserted] = kernel_map.emplace(std::move(cache_key), std::move(*kernel));
             kernel_iter = it;
             if (inserted && post_load_cb) {
                 PyPtr py_handle = steal(PyLong_FromVoidPtr(
@@ -2350,28 +2399,60 @@ struct LaunchConfiguration {
     int sharedmem;
 };
 
+Result<uint64_t> parse_dispatch_token(PyObject* value) {
+    unsigned long long token = PyLong_AsUnsignedLongLong(value);
+    if (PyErr_Occurred()) return ErrorRaised;
+    return static_cast<uint64_t>(token);
+}
+
 PyObject* LaunchConfiguration_vectorcall(PyObject* self, PyObject *const *args,
                                              size_t nargsf, PyObject* kwnames) {
-    if (kwnames) {
-        PyErr_SetString(PyExc_TypeError, "Keyword arguments are not supported");
-        return nullptr;
-    }
-
     LaunchConfiguration& config = py_unwrap<LaunchConfiguration>(self);
 
     Py_ssize_t num_args = PyVectorcall_NARGS(nargsf);
+    uint64_t dispatch_token = 0;
+    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
+        if (PyTuple_GET_SIZE(kwnames) != 1) {
+            PyErr_SetString(PyExc_TypeError, "Only _dispatch_token keyword is supported");
+            return nullptr;
+        }
+        PyObject* keyword = PyTuple_GET_ITEM(kwnames, 0);
+        int is_dispatch_token = PyObject_RichCompareBool(
+                keyword, g__dispatch_token_pyunicode, Py_EQ);
+        if (is_dispatch_token < 0) return nullptr;
+        if (!is_dispatch_token) {
+            PyErr_SetString(PyExc_TypeError, "Only _dispatch_token keyword is supported");
+            return nullptr;
+        }
+        Result<uint64_t> parsed_token = parse_dispatch_token(args[num_args]);
+        if (!parsed_token.is_ok()) return nullptr;
+        dispatch_token = *parsed_token;
+    }
 
     KernelDispatcher& dispatcher = py_unwrap<KernelDispatcher>(config.dispatcher.get());
-    if (!launch(dispatcher, config.grid, config.block, config.cluster, config.stream, config.sharedmem, args, num_args))
+    if (!launch(dispatcher, config.grid, config.block, config.cluster, config.stream,
+                config.sharedmem, dispatch_token, args, num_args))
         return nullptr;
 
     return Py_NewRef(Py_None);
 }
 
 PyObject* LaunchConfiguration_call(PyObject* self, PyObject* args, PyObject* kwargs) {
-    if (kwargs) {
-        PyErr_SetString(PyExc_TypeError, "Keyword arguments are not supported");
-        return nullptr;
+    uint64_t dispatch_token = 0;
+    if (kwargs && PyDict_Size(kwargs) != 0) {
+        if (PyDict_Size(kwargs) != 1) {
+            PyErr_SetString(PyExc_TypeError, "Only _dispatch_token keyword is supported");
+            return nullptr;
+        }
+        PyObject* token_value = PyDict_GetItemWithError(kwargs, g__dispatch_token_pyunicode);
+        if (!token_value) {
+            if (!PyErr_Occurred())
+                PyErr_SetString(PyExc_TypeError, "Only _dispatch_token keyword is supported");
+            return nullptr;
+        }
+        Result<uint64_t> parsed_token = parse_dispatch_token(token_value);
+        if (!parsed_token.is_ok()) return nullptr;
+        dispatch_token = *parsed_token;
     }
 
     LaunchConfiguration& config = py_unwrap<LaunchConfiguration>(self);
@@ -2381,7 +2462,8 @@ PyObject* LaunchConfiguration_call(PyObject* self, PyObject* args, PyObject* kwa
     PyObject** pyargs = &_PyTuple_CAST(args)->ob_item[0];
     Py_ssize_t num_pyargs = PyTuple_GET_SIZE(args);
 
-    if (!launch(dispatcher, config.grid, config.block, config.cluster, config.stream, config.sharedmem, pyargs, num_pyargs))
+    if (!launch(dispatcher, config.grid, config.block, config.cluster, config.stream,
+                config.sharedmem, dispatch_token, pyargs, num_pyargs))
         return nullptr;
 
     return Py_NewRef(Py_None);
@@ -2550,37 +2632,6 @@ void try_get_numpy_globals() {
 } // anonymous namespace
 
 
-namespace std {
-template<>
-struct hash<ConstantArg> {
-    size_t operator()(const ConstantArg& arg) const {
-        switch (arg.type) {
-        case ConstantArgType::INT64:
-            return std::hash<int64_t>{}(arg.value.i64);
-        case ConstantArgType::UINT64:
-            return std::hash<uint64_t>{}(arg.value.u64)
-                 ^ (static_cast<size_t>(ConstantArgType::UINT64) << 1);
-        case ConstantArgType::BOOL:
-            // Shift the BOOL tag past the 0/1 payload bit before mixing it into
-            // the integer hash, so BOOL values do not just swap INT64 0/1 hashes.
-            return std::hash<int64_t>{}(arg.value.i64)
-                 ^ (static_cast<size_t>(ConstantArgType::BOOL) << 1);
-        case ConstantArgType::FLOAT64:
-            // hash float bits directly
-            uint64_t float_bits;
-            std::memcpy(&float_bits, &arg.value.f64, sizeof(arg.value.f64));
-            return std::hash<uint64_t>{}(float_bits);
-        case ConstantArgType::STRING:
-            return std::hash<std::string>{}(arg.str);
-        }
-        // unreachable code
-        assert(false && "Unsupported constant arg type");
-        return 0;
-    }
-};
-} // std namespace
-
-
 #define INIT_STRING_CONSTANT(ident) \
     if (!(g_##ident##_pyunicode = PyUnicode_InternFromString(#ident))) return ErrorRaised;
 
@@ -2593,6 +2644,7 @@ Status kernel_init(PyObject* m) {
     INIT_STRING_CONSTANT(strides);
     INIT_STRING_CONSTANT(__dlpack__);
     INIT_STRING_CONSTANT(int64);
+    INIT_STRING_CONSTANT(_dispatch_token);
 
     try_get_torch_globals();
     try_get_cupy_globals();

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -589,7 +589,7 @@ class _ArgMarshaller:
                 coerced_types.append(runtime_type)
         return coerced_args, coerced_types
 
-    def _launch(self, argtypes, launch_args, launch_values=None):
+    def _launch(self, argtypes, launch_args, launch_values=None, original_args=None):
         """Set compile arg types and invoke the C++ launcher with error handling."""
         # Preserve existing thread-local state for nested launches triggered by
         # compile-time helpers.
@@ -597,6 +597,7 @@ class _ArgMarshaller:
             launch_values = launch_args
         previous_types = getattr(_compile_arg_types, "types", _MISSING)
         previous_values = getattr(_compile_arg_types, "values", _MISSING)
+        previous_launch_args = getattr(_compile_arg_types, "launch_args", _MISSING)
         previous_launch_config = getattr(_compile_arg_types, "launch_config", _MISSING)
         previous_available_launch_config = getattr(
             _compile_arg_types, "available_launch_config", _MISSING
@@ -605,6 +606,10 @@ class _ArgMarshaller:
         try:
             _compile_arg_types.types = argtypes
             _compile_arg_types.values = tuple(launch_values)
+            if original_args is not None:
+                _compile_arg_types.launch_args = tuple(original_args)
+            elif hasattr(_compile_arg_types, "launch_args"):
+                delattr(_compile_arg_types, "launch_args")
             if self._available_launch_config is not None:
                 _compile_arg_types.available_launch_config = self._available_launch_config
             elif hasattr(_compile_arg_types, "available_launch_config"):
@@ -743,6 +748,11 @@ class _ArgMarshaller:
                     delattr(_compile_arg_types, "values")
             else:
                 _compile_arg_types.values = previous_values
+            if previous_launch_args is _MISSING:
+                if hasattr(_compile_arg_types, "launch_args"):
+                    delattr(_compile_arg_types, "launch_args")
+            else:
+                _compile_arg_types.launch_args = previous_launch_args
             if previous_launch_config is _MISSING:
                 if hasattr(_compile_arg_types, "launch_config"):
                     delattr(_compile_arg_types, "launch_config")
@@ -781,7 +791,9 @@ class _ArgMarshaller:
 
     def _call_impl(self, *args):
         nargs = len(args)
-        has_ext = bool(self._extensions)
+        value_extensions = [arg for arg in args if callable(getattr(arg, "prepare_args", None))]
+        extensions = [*self._extensions, *value_extensions]
+        has_ext = bool(extensions)
 
         # Fast caches are only valid when no extension can transform values or
         # register per-launch callbacks through prepare_args().
@@ -810,7 +822,7 @@ class _ArgMarshaller:
                                 _sync_cuda_array_interface_stream(args[idx])
                             return self._launch(cached_argtypes, args)
 
-        reversed_ext = self._extensions[::-1] if has_ext else None
+        reversed_ext = extensions[::-1] if has_ext else None
         copy_item = self._maybe_copy_to_device_item
         callbacks = self._callbacks
 
@@ -857,7 +869,13 @@ class _ArgMarshaller:
         flat_args = []
         for arg in coerced_args:
             _flatten_arg(arg, flat_args)
-        result = self._launch(coerced_types, flat_args, coerced_args)
+        original_args = args if value_extensions else None
+        result = self._launch(
+            coerced_types,
+            flat_args,
+            launch_values=coerced_args,
+            original_args=original_args,
+        )
 
         for callback in callbacks:
             callback()
@@ -2922,6 +2940,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         has_extension_snapshot = active_extensions is not _MISSING
         if not has_extension_snapshot:
             active_extensions = self.extensions
+        active_launch_args = getattr(_compile_arg_types, "launch_args", _MISSING)
         force_launch_config = getattr(_compile_arg_types, "force_launch_config", False)
         available_launch_config = getattr(_compile_arg_types, "available_launch_config", None)
         launch_config_tracker = (
@@ -3030,6 +3049,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             active_launch_config is not None
             or launch_config_tracker is not None
             or has_extension_snapshot
+            or active_launch_args is not _MISSING
         ):
             targetoptions = self.targetoptions.copy()
             if has_extension_snapshot:
@@ -3040,6 +3060,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 targetoptions[_LAUNCH_CONFIG_TRACKER_OPTION] = launch_config_tracker
             if active_launch_config is not None:
                 targetoptions["__launch_config__"] = dict(active_launch_config)
+            if active_launch_args is not _MISSING:
+                targetoptions["__launch_args__"] = tuple(active_launch_args)
 
         # A cached result bypasses compiler passes. Until planner identity and
         # implementation are part of the persistent cache key, active planners

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -832,6 +832,7 @@ class _ArgMarshaller:
 
         for i in range(nargs):
             val = args[i]
+            extension_transformed = False
 
             try:
                 ty = typeof(val)
@@ -845,17 +846,21 @@ class _ArgMarshaller:
                         "Please register a typeof_impl for this type."
                     )
                 for ext in reversed_ext:
+                    previous_ty = ty
+                    previous_val = val
                     ty, val = ext.prepare_args(ty, val, stream=None, retr=callbacks)
+                    extension_transformed |= ty != previous_ty or val is not previous_val
                 if val is not args[i]:
                     all_pass_through = False
 
             dev = copy_item(val)
             if dev is not val:
                 all_pass_through = False
-                try:
-                    ty = typeof(dev)
-                except (ValueError, TypeError):
-                    ty = None
+                if not extension_transformed:
+                    try:
+                        ty = typeof(dev)
+                    except (ValueError, TypeError):
+                        ty = None
 
             device_args[i] = dev
             argtypes[i] = ty

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -79,6 +79,8 @@ _DISPATCHER_STATE_ATTRS = (
     "_launch_lock",
     "_launch_config_overloads",
     "_launch_config_dispatchers",
+    "_dispatch_tokens",
+    "_next_dispatch_token",
     "_launch_config_generation",
     "_requires_launch_config",
     "_literal_arg_positions",
@@ -420,6 +422,7 @@ class _ArgMarshaller:
         launch_config_generation=None,
         stream_ref=None,
         launch_stream=None,
+        supports_dispatch_token=False,
     ):
         self._launcher = launcher
         self._callbacks = []
@@ -437,6 +440,7 @@ class _ArgMarshaller:
         self._launch_config_generation = launch_config_generation
         self._stream_ref = stream_ref
         self._launch_stream = launch_stream
+        self._supports_dispatch_token = supports_dispatch_token
         self._adjusted_launcher_key = None
         self._adjusted_launcher = None
         self._sig_cache = {}  # {type_key: (argtypes, fast_ok)}
@@ -730,7 +734,11 @@ class _ArgMarshaller:
                 _compile_arg_types.launch_config = active_launch_config
             elif hasattr(_compile_arg_types, "launch_config"):
                 delattr(_compile_arg_types, "launch_config")
-            return launcher(*launch_args)
+            dispatch_token_for = getattr(dispatcher, "_dispatch_token_for", None)
+            if not self._supports_dispatch_token or dispatch_token_for is None:
+                return launcher(*launch_args)
+            dispatch_token = dispatch_token_for(tuple(argtypes))
+            return launcher(*launch_args, _dispatch_token=dispatch_token)
         except UserFacingInternalCompilerError as e:
             if os.environ.get("NUMBA_CUDA_MLIR_ICE_FULL_TB", "0").strip() == "1":
                 raise
@@ -1628,6 +1636,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         # recompile() invalidates old launch-config generations.
         self._launch_config_overloads = {}
         self._launch_config_dispatchers = collections.OrderedDict()
+        self._dispatch_tokens = {}
+        self._next_dispatch_token = 1
         self._launch_config_generation = 0
         self._requires_launch_config = False
         self._literal_arg_positions = frozenset()
@@ -1686,6 +1696,20 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             debug=bool(self.targetoptions.get("debug", False)),
             literal_arg_flags=tuple(literal_args),
         )
+
+    def _dispatch_token_for(self, argtypes):
+        """Return a stable native-cache token for exact top-level Numba types."""
+        self._ensure_dispatcher_state()
+        argtypes = tuple(argtypes)
+        with self._launch_config_lock:
+            token = self._dispatch_tokens.get(argtypes)
+            if token is None:
+                token = self._next_dispatch_token
+                if token > (1 << 64) - 1:
+                    raise OverflowError("native dispatch token space exhausted")
+                self._next_dispatch_token += 1
+                self._dispatch_tokens[argtypes] = token
+            return token
 
     @property
     def _launch_config_enabled(self):
@@ -1888,6 +1912,10 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
                 self._launch_config_overloads = {}
             if not hasattr(self, "_launch_config_dispatchers"):
                 self._launch_config_dispatchers = collections.OrderedDict()
+            if not hasattr(self, "_dispatch_tokens"):
+                self._dispatch_tokens = {}
+            if not hasattr(self, "_next_dispatch_token"):
+                self._next_dispatch_token = 1
             if not hasattr(self, "_launch_config_generation"):
                 self._launch_config_generation = 0
             if not hasattr(self, "_requires_launch_config"):
@@ -2086,6 +2114,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             launch_config_generation=launch_config_generation,
             stream_ref=stream_ref,
             launch_stream=launch_stream,
+            supports_dispatch_token=True,
         )
 
     def _reduce_states(self):
@@ -3570,6 +3599,8 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
             self._retain_old_dispatcher(self._c)
             self._launch_config_generation += 1
             self._launch_config_overloads.clear()
+            self._dispatch_tokens.clear()
+            self._next_dispatch_token = 1
             old_launch_config_dispatchers = list(self._launch_config_dispatchers.values())
             self._launch_config_dispatchers = collections.OrderedDict()
             for dispatcher in old_launch_config_dispatchers:

--- a/src/numba_cuda_mlir/lowering/cuda.py
+++ b/src/numba_cuda_mlir/lowering/cuda.py
@@ -33,6 +33,7 @@ from numba_cuda_mlir.lowering_utilities import (
     storage_itemsize_bytes,
     storage_bitwidth,
     memref_llvm_address_space,
+    is_valid_memref_element_type,
 )
 from numba_cuda_mlir.lowering_utilities.type_conversions import (
     to_mlir_type,
@@ -471,26 +472,127 @@ def cuda_shared_memory(lower: MLIRLower, target, args: list[Any], kwargs: list[t
     lower.store_var(target, array)
 
 
+def _allocate_llvm_backed_local_array(
+    lower: MLIRLower,
+    target,
+    shape: tuple[int, ...],
+    element_type: ir.Type,
+    alignment: int,
+):
+    """Allocate LLVM elements and expose their logical shape as an i8 memref.
+
+    LLVM owns the element ABI layout: the alloca count and typed GEPs are in
+    units of ``element_type``.  The byte-backed memref is descriptor-only and
+    carries logical sizes/strides, so array shape metadata never becomes a byte
+    count. The descriptor wraps the alloca's generic pointer. CUDA's public
+    local-array contract requires literal dimensions, so this helper
+    deliberately accepts only a fully static shape.
+    """
+
+    rank = len(shape)
+    if rank == 0:
+        raise ValueError("cuda.local.array requires at least one shape dimension")
+    if any(not isinstance(dim, int) for dim in shape):
+        raise InternalCompilerError("LLVM-backed cuda.local.array requires a fully static shape")
+
+    dynamic = ir.ShapedType.get_dynamic_size()
+    dynamic_stride = ir.ShapedType.get_dynamic_stride_or_offset()
+    memref_type = ir.MemRefType.get(
+        shape=[dynamic] * rank,
+        element_type=T.i8(),
+        layout=ir.StridedLayoutAttr.get(
+            offset=dynamic_stride,
+            strides=[dynamic_stride] * rank,
+        ),
+    )
+
+    pointer_type = llvm.PointerType.get()
+    descriptor_type = llvm.StructType.get_literal(
+        [
+            pointer_type,
+            pointer_type,
+            T.i64(),
+            llvm.ArrayType.get(T.i64(), rank),
+            llvm.ArrayType.get(T.i64(), rank),
+        ]
+    )
+
+    with lower.alloca_insertion_point():
+        sizes = [constant(dim, T.i64()) for dim in shape]
+
+        element_count = constant(1, T.i64())
+        for size in sizes:
+            element_count = arith.muli(element_count, size)
+
+        if alignment == 8:
+            # Match the existing memref.alloca path: omitting the default lets
+            # LLVM preserve a stricter natural alignment for the element type.
+            pointer = llvm.alloca(pointer_type, element_count, element_type)
+        else:
+            pointer = llvm.alloca(
+                pointer_type,
+                element_count,
+                element_type,
+                alignment=alignment,
+            )
+
+        strides = [None] * rank
+        stride = constant(1, T.i64())
+        for index in range(rank - 1, -1, -1):
+            strides[index] = stride
+            stride = arith.muli(stride, sizes[index])
+
+        descriptor = llvm.UndefOp(descriptor_type).result
+        insert = lambda value, field, *position: llvm.insertvalue(
+            container=value,
+            value=field,
+            position=ir.DenseI64ArrayAttr.get(list(position)),
+        )
+        descriptor = insert(descriptor, pointer, 0)
+        descriptor = insert(descriptor, pointer, 1)
+        descriptor = insert(descriptor, constant(0, T.i64()), 2)
+        for index, size in enumerate(sizes):
+            descriptor = insert(descriptor, size, 3, index)
+        for index, logical_stride in enumerate(strides):
+            descriptor = insert(descriptor, logical_stride, 4, index)
+
+        array = builtin.unrealized_conversion_cast([memref_type], [descriptor])
+
+    lower.store_var(target, array)
+
+
 @lower(cuda.local_array, types.Tuple, types.DTypeSpec, types.Number)
 @lower(cuda.local_array, types.Number, types.DTypeSpec, types.Number)
+@lower(cuda.local_array, types.Tuple, types.TypeRef, types.Number)
+@lower(cuda.local_array, types.Number, types.TypeRef, types.Number)
 @lower(cuda.local_array, types.Tuple, types.DTypeSpec)
 @lower(cuda.local_array, types.Number, types.DTypeSpec)
+@lower(cuda.local_array, types.Tuple, types.TypeRef)
+@lower(cuda.local_array, types.Number, types.TypeRef)
 @lower(cuda.local_array, types.Tuple, types.StringLiteral)
 @lower(cuda.local_array, types.Number, types.StringLiteral)
 @lower(cuda.local_array, types.Tuple, types.DTypeSpec, types.NoneType)
 @lower(cuda.local_array, types.Number, types.DTypeSpec, types.NoneType)
+@lower(cuda.local_array, types.Tuple, types.TypeRef, types.NoneType)
+@lower(cuda.local_array, types.Number, types.TypeRef, types.NoneType)
 @lower(cuda.local_array, types.Tuple, types.StringLiteral, types.NoneType)
 @lower(cuda.local_array, types.Number, types.StringLiteral, types.NoneType)
 @lower(cuda.local_array, types.UniTuple, types.DTypeSpec)
+@lower(cuda.local_array, types.UniTuple, types.TypeRef)
 @lower(cuda.local_array, types.UniTuple, types.StringLiteral)
 @lower(cuda.local_array, types.UniTuple, types.DTypeSpec, types.Number)
+@lower(cuda.local_array, types.UniTuple, types.TypeRef, types.Number)
 @lower(cuda.local_array, types.UniTuple, types.DTypeSpec, types.NoneType)
+@lower(cuda.local_array, types.UniTuple, types.TypeRef, types.NoneType)
 @lower(cuda.local_array, types.UniTuple, types.StringLiteral, types.NoneType)
 @lower(cuda.local_array, types.Tuple, types.DTypeSpec, types.IntegerLiteral)
 @lower(cuda.local_array, types.Number, types.DTypeSpec, types.IntegerLiteral)
+@lower(cuda.local_array, types.Tuple, types.TypeRef, types.IntegerLiteral)
+@lower(cuda.local_array, types.Number, types.TypeRef, types.IntegerLiteral)
 @lower(cuda.local_array, types.Tuple, types.StringLiteral, types.IntegerLiteral)
 @lower(cuda.local_array, types.Number, types.StringLiteral, types.IntegerLiteral)
 @lower(cuda.local_array, types.UniTuple, types.DTypeSpec, types.IntegerLiteral)
+@lower(cuda.local_array, types.UniTuple, types.TypeRef, types.IntegerLiteral)
 @lower(cuda.local_array, types.UniTuple, types.StringLiteral, types.IntegerLiteral)
 def cuda_local_array(lower: MLIRLower, target, args: list[Any], kwargs: list[tuple[str, Any]]):
     shape, dtype, alignas = _extract_shape_and_dtype(*args, **dict(kwargs))
@@ -526,6 +628,23 @@ def cuda_local_array(lower: MLIRLower, target, args: list[Any], kwargs: list[tup
 
     np_dtype = _resolve_numba_dtype(lower, dtype)
     mlir_dtype = lower.get_storage_type(np_dtype)
+
+    from numba_cuda_mlir.types import Record
+
+    if not isinstance(np_dtype, (Record, types.CharSeq, types.UnicodeCharSeq)) and not (
+        is_valid_memref_element_type(mlir_dtype)
+    ):
+        if static_shape is None:
+            raise InternalCompilerError(
+                "LLVM-backed cuda.local.array requires a fully static shape"
+            )
+        return _allocate_llvm_backed_local_array(
+            lower,
+            target,
+            tuple(static_shape),
+            mlir_dtype,
+            alignas,
+        )
 
     if static_shape is not None:
         # Static shape - use static memref allocation

--- a/src/numba_cuda_mlir/lowering/cuda.py
+++ b/src/numba_cuda_mlir/lowering/cuda.py
@@ -70,6 +70,7 @@ from typing import Any
 from numba_cuda_mlir.logging import trace
 import numpy as np
 from numba_cuda_mlir.numba_cuda.typing.templates import ConcreteTemplate
+from numba_cuda_mlir.numba_cuda.core.errors import UnsupportedError
 from numba_cuda_mlir.numba_cuda import stubs as cuda_stubs
 
 
@@ -365,11 +366,16 @@ def _resolve_numba_dtype(lower, dtype_var):
 
 shmem_id = 0
 
+_LLVM_BACKED_SHARED_DTYPE_ERROR = (
+    "cuda.shared.array does not yet support LLVM-backed element dtypes. "
+    "Use cuda.local.array for per-thread extension storage or a built-in "
+    "shared-memory dtype."
+)
+
 
 def cuda_static_shared_memory(lower: MLIRLower, target, static_shape, dtype, alignas):
     global shmem_id
     shape = tuple(static_shape)
-    dtype = lower.get_storage_type(_resolve_numba_dtype(lower, dtype))
     mspace = ir.Attribute.parse("#gpu.address_space<workgroup>")
     ty = T.memref(*shape, element_type=dtype, memory_space=mspace)
     gpu_module = lower.mlir_gpu_module
@@ -388,30 +394,42 @@ def cuda_static_shared_memory(lower: MLIRLower, target, static_shape, dtype, ali
 
 @lower(cuda.shared.array, types.Number)
 @lower(cuda.shared.array, types.Number, types.DTypeSpec)
+@lower(cuda.shared.array, types.Number, types.TypeRef)
 @lower(cuda.shared.array, types.Number, types.StringLiteral)
 @lower(cuda.shared.array, types.Number, types.DTypeSpec, types.Number)
+@lower(cuda.shared.array, types.Number, types.TypeRef, types.Number)
 @lower(cuda.shared.array, types.Number, types.StringLiteral, types.Number)
 @lower(cuda.shared.array, types.Number, types.DTypeSpec, types.IntegerLiteral)
+@lower(cuda.shared.array, types.Number, types.TypeRef, types.IntegerLiteral)
 @lower(cuda.shared.array, types.Number, types.StringLiteral, types.IntegerLiteral)
 @lower(cuda.shared.array, types.Number, types.DTypeSpec, types.NoneType)
+@lower(cuda.shared.array, types.Number, types.TypeRef, types.NoneType)
 @lower(cuda.shared.array, types.Number, types.StringLiteral, types.NoneType)
 @lower(cuda.shared.array, types.UniTuple)
 @lower(cuda.shared.array, types.UniTuple, types.DTypeSpec)
+@lower(cuda.shared.array, types.UniTuple, types.TypeRef)
 @lower(cuda.shared.array, types.UniTuple, types.StringLiteral)
 @lower(cuda.shared.array, types.UniTuple, types.DTypeSpec, types.Number)
+@lower(cuda.shared.array, types.UniTuple, types.TypeRef, types.Number)
 @lower(cuda.shared.array, types.UniTuple, types.StringLiteral, types.Number)
 @lower(cuda.shared.array, types.UniTuple, types.DTypeSpec, types.IntegerLiteral)
+@lower(cuda.shared.array, types.UniTuple, types.TypeRef, types.IntegerLiteral)
 @lower(cuda.shared.array, types.UniTuple, types.StringLiteral, types.IntegerLiteral)
 @lower(cuda.shared.array, types.UniTuple, types.DTypeSpec, types.NoneType)
+@lower(cuda.shared.array, types.UniTuple, types.TypeRef, types.NoneType)
 @lower(cuda.shared.array, types.UniTuple, types.StringLiteral, types.NoneType)
 @lower(cuda.shared.array, types.Tuple)
 @lower(cuda.shared.array, types.Tuple, types.DTypeSpec)
+@lower(cuda.shared.array, types.Tuple, types.TypeRef)
 @lower(cuda.shared.array, types.Tuple, types.StringLiteral)
 @lower(cuda.shared.array, types.Tuple, types.DTypeSpec, types.Number)
+@lower(cuda.shared.array, types.Tuple, types.TypeRef, types.Number)
 @lower(cuda.shared.array, types.Tuple, types.StringLiteral, types.Number)
 @lower(cuda.shared.array, types.Tuple, types.DTypeSpec, types.IntegerLiteral)
+@lower(cuda.shared.array, types.Tuple, types.TypeRef, types.IntegerLiteral)
 @lower(cuda.shared.array, types.Tuple, types.StringLiteral, types.IntegerLiteral)
 @lower(cuda.shared.array, types.Tuple, types.DTypeSpec, types.NoneType)
+@lower(cuda.shared.array, types.Tuple, types.TypeRef, types.NoneType)
 @lower(cuda.shared.array, types.Tuple, types.StringLiteral, types.NoneType)
 def cuda_shared_memory(lower: MLIRLower, target, args: list[Any], kwargs: list[tuple[str, Any]]):
     shape, dtype, alignas = _extract_shape_and_dtype(*args, **dict(kwargs))
@@ -450,14 +468,17 @@ def cuda_shared_memory(lower: MLIRLower, target, args: list[Any], kwargs: list[t
 
     static_shape = [_is_static_dim(x) for x in shape_op]
 
+    np_dtype = _resolve_numba_dtype(lower, dtype)
+    dtype = lower.get_storage_type(np_dtype)
+    if not is_valid_memref_element_type(dtype):
+        raise UnsupportedError(_LLVM_BACKED_SHARED_DTYPE_ERROR, loc=target.loc)
+
     is_dynamic_shared_shape = len(static_shape) == 1 and static_shape[0] == 0
     if all([x is not None for x in static_shape]) and not is_dynamic_shared_shape:
         return cuda_static_shared_memory(lower, target, static_shape, dtype, alignas)
 
     shape = coerce_to_shape_tuple(shape_op)
 
-    np_dtype = _resolve_numba_dtype(lower, dtype)
-    dtype = lower.get_storage_type(np_dtype)
     mr_type = ir.MemRefType.get(
         shape=[ir.MemRefType.get_dynamic_size() for _ in shape],
         element_type=dtype,

--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -1562,6 +1562,7 @@ def lower_charseq_array_setitem_string(builder: MLIRLower, target, args, kwargs)
 @lower(operator.setitem, types.Array, types.Integer, types.NPTimedelta)
 @lower(operator.setitem, types.Array, types.Integer, Record)
 @lower(operator.setitem, types.Array, types.Integer, VectorType)
+@lower(operator.setitem, types.Array, types.Integer, types.Any)
 def lower_array_setitem(builder: MLIRLower, target, args, kwargs):
     trace()
 
@@ -1581,6 +1582,7 @@ def lower_array_setitem(builder: MLIRLower, target, args, kwargs):
     index = builder.load_var(args[1])
     index = lowering_utilities.index_of(index)
     value = builder.load_var(args[2])
+    value = _cast_array_store_value(builder, array_numba_type, args[2], value)
     mrt = array.type
     if mrt.rank == 1:
         lowering_utilities.array_element_value_store(
@@ -1637,6 +1639,18 @@ def _setitem_indices_to_memref_indices(
             )
 
 
+def _cast_array_store_value(
+    builder: MLIRLower,
+    array_type: types.Array,
+    value_var: numba_ir.Var,
+    value: ir.Value,
+) -> ir.Value:
+    value_type = builder.get_numba_type(value_var.name)
+    if value_type != array_type.dtype:
+        return builder.lower_cast(value_type, array_type.dtype, value)
+    return value
+
+
 @lower(operator.setitem, types.Array, types.Tuple, types.Any)
 @lower(operator.setitem, types.Array, types.UniTuple, types.Any)
 def lower_array_setitem_tuple(builder, target, args, kwargs):
@@ -1654,6 +1668,7 @@ def lower_array_setitem_tuple(builder, target, args, kwargs):
     tup = builder.load_var(tup) if isinstance(tup, numba_ir.Var) else tup
     indices = _setitem_indices_to_memref_indices(tup)
     value = builder.load_var(args[2])
+    value = _cast_array_store_value(builder, array_numba_type, args[2], value)
     lowering_utilities.array_element_value_store(
         array_numba_type,
         array,
@@ -1669,9 +1684,10 @@ def lower_array_slice_setitem(builder, target, args, kwargs):
     trace()
     array = builder.load_var(args[0])
     slice_val = builder.load_var(args[1])
-    value = builder.load_var(args[2])
-
     array_numba_type = builder.get_numba_type(args[0].name)
+    value = builder.load_var(args[2])
+    value = _cast_array_store_value(builder, array_numba_type, args[2], value)
+
     mr_type = array.type
     rank = mr_type.rank
 
@@ -1792,7 +1808,7 @@ def lower_array_tuple_getitem(builder: MLIRLower, target, args, kwargs):
                 array, full_offsets, full_sizes, full_strides, full_is_scalar
             )
             builder.store_var(target, value)
-        case types.Number() | types.Boolean():
+        case types.Type():
             value = lowering_utilities.array_element_value_load(
                 array_numba_type,
                 array,
@@ -1802,7 +1818,7 @@ def lower_array_tuple_getitem(builder: MLIRLower, target, args, kwargs):
             builder.store_var(target, value)
         case _:
             raise InternalCompilerError(
-                f"Target type {target_type} is not an array or number, but a tuple was used to index it"
+                f"Target type {target_type} is not an array or scalar, but a tuple was used to index it"
             )
 
 

--- a/src/numba_cuda_mlir/lowering_utilities/__init__.py
+++ b/src/numba_cuda_mlir/lowering_utilities/__init__.py
@@ -14,6 +14,7 @@ from numba_cuda_mlir.numba_cuda import types, typing
 from numba_cuda_mlir.annotations import AnyCallable, PS
 from numba_cuda_mlir.lowering_utilities import type_conversions
 from numba_cuda_mlir.lowering_utilities.type_conversions import (
+    is_valid_memref_element_type,
     np_dtype_to_mlir_type as mlir_type_from_numpy_dtype,
     to_mlir_type,
 )
@@ -75,17 +76,17 @@ def memref_data_pointer_as_index(array: ir.Value, element_type: ir.Type | None =
 
 
 def _memref_index_offset(array: ir.Value, indices: list[ir.Value]) -> ir.Value:
-    """Return the element offset for indices into a potentially-strided memref."""
+    """Return the logical element offset into a potentially-strided memref."""
     metadata = memref.extract_strided_metadata(array)
     rank = array.type.rank
     ndim = len(indices)
     if ndim == 1 and rank != 1:
-        return convert(indices[0], T.i64())
+        return convert(metadata[1], T.i64()) + convert(indices[0], T.i64())
     if ndim != rank:
         raise ValueError(
             f"Expected either a scalar linear index or {rank} indices for {array.type}, got {ndim}"
         )
-    linear_idx = arith.constant(T.i64(), 0)
+    linear_idx = convert(metadata[1], T.i64())
     for d, index in enumerate(indices):
         idx_val = convert(index, T.i64())
         stride = convert(metadata[2 + rank + d], T.i64())
@@ -93,7 +94,13 @@ def _memref_index_offset(array: ir.Value, indices: list[ir.Value]) -> ir.Value:
     return linear_idx
 
 
-def memref_to_llvm_ptr(array: ir.Value, indices: list[ir.Value], element_type: ir.Type) -> ir.Value:
+def memref_to_llvm_ptr(
+    array: ir.Value,
+    indices: list[ir.Value],
+    element_type: ir.Type,
+    *,
+    address_space: int | None = None,
+) -> ir.Value:
     """Convert memref + indices to LLVM pointer.
 
     Extracts base pointer from a potentially-strided memref and computes the
@@ -103,14 +110,21 @@ def memref_to_llvm_ptr(array: ir.Value, indices: list[ir.Value], element_type: i
         array: Memref value (potentially strided)
         indices: List of index values
         element_type: Element type for getelementptr
+        address_space: Override for descriptors whose i8 backing does not
+            encode the pointer's address space.
 
     Returns:
         LLVM pointer (!llvm.ptr) to the indexed element
     """
     # Extract base pointer from memref and convert to an address-space-preserving
     # LLVM pointer.
-    ptr_type = _memref_llvm_pointer_type(ir.MemRefType(array.type))
-    base_ptr_idx = memref_data_pointer_as_index(array)
+    ptr_type = (
+        llvm.PointerType.get(address_space)
+        if address_space is not None
+        else _memref_llvm_pointer_type(ir.MemRefType(array.type))
+    )
+    metadata = memref.extract_strided_metadata(array)
+    base_ptr_idx = memref.extract_aligned_pointer_as_index(metadata[0])
     base_ptr = llvm.inttoptr(res=ptr_type, arg=convert(base_ptr_idx, T.i64()))
 
     linear_idx = _memref_index_offset(array, indices)
@@ -332,6 +346,22 @@ def storage_itemsize_bytes(numba_type: types.Type) -> int:
     return (bitwidth + 7) // 8
 
 
+def uses_byte_backed_llvm_array_storage(array_type: types.Array) -> bool:
+    """Return whether an array stores LLVM-dialect values behind an i8 memref.
+
+    Record and character arrays have their own byte-oriented lowering paths.
+    This predicate identifies compiler-extension values whose data model uses
+    an LLVM type that cannot legally be a MemRef element type.
+    """
+
+    from numba_cuda_mlir.types import Record
+
+    dtype = array_type.dtype
+    if isinstance(dtype, (Record, types.CharSeq, types.UnicodeCharSeq)):
+        return False
+    return not is_valid_memref_element_type(get_storage_type(dtype))
+
+
 def _is_bool_numba_type(numba_type: types.Type) -> bool:
     return isinstance(numba_type, (types.Boolean, types.BooleanLiteral))
 
@@ -410,9 +440,20 @@ def array_element_value_load(
     *,
     dynamic_shared_memory: bool = False,
 ):
-    if dynamic_shared_memory:
+    byte_backed_llvm = uses_byte_backed_llvm_array_storage(array_type)
+    if dynamic_shared_memory or byte_backed_llvm:
         storage_type = get_storage_type(array_type.dtype)
-        ptr = memref_to_llvm_ptr(array, list(indices), storage_type)
+        # Array types do not retain storage provenance across device-function
+        # boundaries. Reconstruct an NVPTX generic pointer for byte-backed
+        # extension values so one signature can receive local or global
+        # storage. Address-space-specific extension arrays require a distinct
+        # lowering path.
+        ptr = memref_to_llvm_ptr(
+            array,
+            list(indices),
+            storage_type,
+            address_space=0 if byte_backed_llvm else None,
+        )
         stored = llvm_ptr_load(storage_type, ptr)
     else:
         stored = memref.load(array, list(indices))
@@ -428,8 +469,14 @@ def array_element_value_store(
     dynamic_shared_memory: bool = False,
 ):
     stored = value_to_storage(array_type.dtype, value)
-    if dynamic_shared_memory:
-        ptr = memref_to_llvm_ptr(array, list(indices), stored.type)
+    byte_backed_llvm = uses_byte_backed_llvm_array_storage(array_type)
+    if dynamic_shared_memory or byte_backed_llvm:
+        ptr = memref_to_llvm_ptr(
+            array,
+            list(indices),
+            stored.type,
+            address_space=0 if byte_backed_llvm else None,
+        )
         llvm_ptr_store(stored, ptr)
     else:
         memref.store(value=stored, memref=array, indices=list(indices))

--- a/src/numba_cuda_mlir/lowering_utilities/type_conversions.py
+++ b/src/numba_cuda_mlir/lowering_utilities/type_conversions.py
@@ -14,6 +14,12 @@ import numpy as np
 import ctypes
 
 
+def is_valid_memref_element_type(mlir_type: ir.Type) -> bool:
+    """Return whether *mlir_type* is legal as a MemRef element type."""
+
+    return not str(mlir_type).startswith("!llvm.")
+
+
 @singledispatch
 def to_numba_type(obj):
     raise TypeError(f"No conversion found for type {obj}")
@@ -407,13 +413,18 @@ def _(ty: types.Type) -> ir.Type:
                 offset=dyn_stride,
                 strides=[dyn_stride] * ty.ndim,
             )
-            # For Record arrays, use byte-based memref (i8) since llvm.ptr
-            # is not a valid memref element type
-            if isinstance(ty.dtype, Record):
-                return ir.MemRefType.get([dyn] * ty.ndim, T.i8(), layout=layout)
             from numba_cuda_mlir.models import mlir_data_manager
 
             dtype = mlir_data_manager.lookup(ty.dtype).get_data_type()
+            # Record, character-sequence, and LLVM-dialect extension elements
+            # use a logical i8 memref descriptor. Their element access is
+            # lowered through dedicated byte-backed paths because !llvm.* is
+            # not a legal memref element type.
+            if isinstance(
+                ty.dtype,
+                (Record, types.CharSeq, types.UnicodeCharSeq),
+            ) or not is_valid_memref_element_type(dtype):
+                return ir.MemRefType.get([dyn] * ty.ndim, T.i8(), layout=layout)
             return ir.MemRefType.get([dyn] * ty.ndim, dtype, layout=layout)
         case types.AggregateType():
             st = llvm.StructType.get_identified(ty.name)

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -527,11 +527,12 @@ extern "C" __global__ void
             non_omitted_argtypes = [
                 argty for argty in self.fndesc.argtypes if not _is_omitted_arg(argty)
             ]
-            # Flatten tuple types for MLIR function signature
-            flat_argtypes = []
+            # Flatten each data model's argument ABI for the MLIR function
+            # signature. Composite extension types can expand to multiple
+            # arguments even when their frontend Numba type is not a tuple.
+            argtypes = []
             for argty in non_omitted_argtypes:
-                flat_argtypes.extend(self._flatten_type(argty))
-            argtypes = [self.get_argument_type(argtype) for argtype in flat_argtypes]
+                argtypes.extend(self._flatten_argument_types(argty))
             flat_restypes = self._flatten_type(self.fndesc.restype)
             restypes = [self.get_return_type(rt) for rt in flat_restypes]
             # Opaque types (DType, Function, Module, ...) lower to MLIR NoneType
@@ -1073,20 +1074,11 @@ extern "C" __global__ void
                 # NoneType args are excluded from the MLIR function signature;
                 # store the MLIR NoneType as a placeholder
                 self.store_var(target, ir.NoneType.get())
-            elif isinstance(arg_type, types.BaseTuple):
-                flat_start_idx = self._get_flat_arg_start_index(arg.index)
-                # Reassemble tuple from flattened block arguments
-                arg_value = self._reassemble_tuple_from_block_args(arg_type, flat_start_idx)
-                value = self.from_argument(arg_type, arg_value)
-                target_type = self.get_numba_type(target.name)
-                self.incref(target_type, value)
-                self.store_var(target, value)
             else:
                 flat_start_idx = self._get_flat_arg_start_index(arg.index)
-                # Single argument - get the block argument at the flat index
-                block_arg = self.mlir_funcOp.entry_block.arguments[flat_start_idx]
+                arg_value = self._reassemble_argument_from_block_args(arg_type, flat_start_idx)
                 target_type = self.get_numba_type(target.name)
-                value = self.from_argument(target_type, block_arg)
+                value = self.from_argument(arg_type, arg_value)
                 self.incref(target_type, value)
                 self.store_var(target, value)
 
@@ -2147,7 +2139,9 @@ extern "C" __global__ void
             results = [] if not numba_abi else [self.get_return_type(types.int32)]
         else:
             results = [self.get_return_type(sig.return_type)]
-        inputs = [self.get_argument_type(arg_type) for arg_type in sig.args]
+        inputs = []
+        for arg_type in sig.args:
+            inputs.extend(self._flatten_argument_types(arg_type))
         return ir.FunctionType.get(inputs=inputs, results=results)
 
     def _lower_call_external_numba_abi(self, target, fn_value: ExternFunction, args):
@@ -3712,15 +3706,13 @@ extern "C" __global__ void
 
     def _count_flat_elements(self, numba_type) -> int:
         """Count how many flat MLIR arguments a type expands to."""
+        return len(self._flatten_argument_types(numba_type))
+
+    def _flatten_argument_types(self, numba_type) -> list:
+        """Flatten a data model's argument ABI to MLIR function inputs."""
         if isinstance(numba_type, types.NoneType):
-            return 0
-        if isinstance(numba_type, types.BaseTuple):
-            if isinstance(numba_type, types.UniTuple):
-                return numba_type.count * self._count_flat_elements(numba_type.dtype)
-            else:
-                return sum(self._count_flat_elements(t) for t in numba_type.types)
-        else:
-            return 1
+            return []
+        return self._flatten_abi_value(self.get_argument_type(numba_type))
 
     def _flatten_type(self, numba_type) -> list:
         """Recursively flatten a Numba type to a list of scalar/array types."""
@@ -3746,34 +3738,17 @@ extern "C" __global__ void
                 flat_idx += self._count_flat_elements(self.fndesc.argtypes[i])
         return flat_idx
 
-    def _reassemble_tuple_from_block_args(self, numba_type, start_idx: int) -> tuple:
-        """Reassemble a tuple from flattened block arguments. Returns Python tuple of ir.Values."""
-        if isinstance(numba_type, types.UniTuple):
-            elements = []
-            idx = start_idx
-            for _ in range(numba_type.count):
-                if isinstance(numba_type.dtype, types.BaseTuple):
-                    elem = self._reassemble_tuple_from_block_args(numba_type.dtype, idx)
-                    idx += self._count_flat_elements(numba_type.dtype)
-                else:
-                    elem = self.mlir_funcOp.entry_block.arguments[idx]
-                    idx += 1
-                elements.append(elem)
-            return tuple(elements)
-        elif isinstance(numba_type, types.BaseTuple):
-            elements = []
-            idx = start_idx
-            for elem_type in numba_type.types:
-                if isinstance(elem_type, types.BaseTuple):
-                    elem = self._reassemble_tuple_from_block_args(elem_type, idx)
-                    idx += self._count_flat_elements(elem_type)
-                else:
-                    elem = self.mlir_funcOp.entry_block.arguments[idx]
-                    idx += 1
-                elements.append(elem)
-            return tuple(elements)
-        else:
-            return self.mlir_funcOp.entry_block.arguments[start_idx]
+    def _reassemble_argument_from_block_args(self, numba_type, start_idx: int):
+        """Reassemble a model argument from its flattened block arguments."""
+        assert self.mlir_funcOp is not None
+        block_args = iter(self.mlir_funcOp.entry_block.arguments[start_idx:])
+
+        def reassemble(abi_type):
+            if isinstance(abi_type, (tuple, list)):
+                return tuple(reassemble(element) for element in abi_type)
+            return next(block_args)
+
+        return reassemble(self.get_argument_type(numba_type))
 
     def verify_mlir_module(self):
         trace("Verifying MLIR module:\n%s", str(self.mlir_module))

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -21,6 +21,7 @@ from numba_cuda_mlir.numba_cuda.datamodel.models import ArrayModel
 from numba_cuda_mlir.annotations import Builder, AnyCallable, PS
 from numba_cuda_mlir.errors import InternalCompilerError, ensure_verifies
 from numba_cuda_mlir.lowering_utilities.type_conversions import (
+    is_valid_memref_element_type,
     to_mlir_type,
     to_numba_type,
 )
@@ -112,15 +113,6 @@ def get_mlir_module_str(metadata):
 
 def _is_omitted_arg(argty):
     return isinstance(argty, (types.Omitted, types.NoneType))
-
-
-def _is_valid_memref_element_type(mlir_type: ir.Type) -> bool:
-    """
-    MemRef element types must be builtin/tensor scalars etc.; LLVM dialect
-    types (structs, pointers, llvm.array, ...) are invalid and must use
-    llvm.alloca + llvm.load/store instead.
-    """
-    return not str(mlir_type).startswith("!llvm.")
 
 
 def get_gpu_module_name():
@@ -737,7 +729,7 @@ extern "C" __global__ void
             )
 
         mlir_type = self.get_storage_type(var_type)
-        if not _is_valid_memref_element_type(mlir_type):
+        if not is_valid_memref_element_type(mlir_type):
             return self.alloca(mlir_type, count=1)
 
         memref_type = ir.MemRefType.get(shape=[1], element_type=mlir_type)
@@ -764,7 +756,7 @@ extern "C" __global__ void
                     continue
                 mlir_type = self.get_storage_type(var_type)
 
-                if not _is_valid_memref_element_type(mlir_type):
+                if not is_valid_memref_element_type(mlir_type):
                     self.varmap[var_name] = self.alloca(mlir_type, count=1)
                     trace(
                         f"Allocated LLVM stack space for {type(var_type).__name__} "
@@ -3077,7 +3069,7 @@ extern "C" __global__ void
         if not all(isinstance(x, ir.Value) for x in value):
             raise InternalCompilerError(f"Tuple {value} contains non-MLIR values: {value=}.")
         dtype = value[0].type
-        if _is_valid_memref_element_type(dtype):
+        if is_valid_memref_element_type(dtype):
             with self.alloca_insertion_point():
                 mr_type = T.memref(len(value), element_type=dtype)
                 mr = memref.alloca(memref=mr_type, dynamic_sizes=[], symbol_operands=[])
@@ -3108,7 +3100,7 @@ extern "C" __global__ void
         if not all(isinstance(x, ir.Value) for x in value):
             raise InternalCompilerError(f"Tuple {value} contains non-MLIR values: {value=}.")
         dtype = value[0].type
-        uses_llvm = not _is_valid_memref_element_type(dtype)
+        uses_llvm = not is_valid_memref_element_type(dtype)
         storage = self.concretize_tuple(value)
         return storage, uses_llvm
 

--- a/src/numba_cuda_mlir/models.py
+++ b/src/numba_cuda_mlir/models.py
@@ -164,7 +164,7 @@ class StructModel(DataModel):
         return self._data_type
 
     def get_argument_type(self):
-        return self.get_data_type()
+        return tuple(model.get_argument_type() for model in self._models)
 
     def get_return_type(self):
         return self.get_data_type()
@@ -189,7 +189,13 @@ class StructModel(DataModel):
         return self._as("as_data", builder, value, self.get_data_type())
 
     def as_argument(self, builder, value):
-        return self.as_data(builder, value)
+        return tuple(
+            model.as_argument(
+                builder,
+                llvm.extractvalue(model.get_value_type(), value, [i]),
+            )
+            for i, model in enumerate(self._models)
+        )
 
     def as_return(self, builder, value):
         return self.as_data(builder, value)
@@ -198,7 +204,11 @@ class StructModel(DataModel):
         return self._from("from_data", builder, value)
 
     def from_argument(self, builder, value):
-        return self.from_data(builder, value)
+        out = llvm.UndefOp(self.get_value_type()).result
+        for i, (model, field) in enumerate(zip(self._models, value)):
+            converted = model.from_argument(builder, field)
+            out = llvm.insertvalue(out, converted, [i])
+        return out
 
     def from_return(self, builder, value):
         return self.from_data(builder, value)

--- a/src/numba_cuda_mlir/models.py
+++ b/src/numba_cuda_mlir/models.py
@@ -509,15 +509,26 @@ class UnionType(PrimitiveModel):
         super().__init__(dmm, fe_type, ele_ty)
 
 
+def _is_valid_memref_element_type(mlir_type):
+    """Return whether *mlir_type* is legal as a MemRef element type."""
+
+    return not str(mlir_type).startswith("!llvm.")
+
+
 @register_model(types.Array)
 class ArrayModel(PrimitiveModel):
     def __init__(self, dmm, fe_type):
         from numba_cuda_mlir.types import Record
 
-        # For Record, CharSeq, and UnicodeCharSeq arrays, use byte-based
-        # memref (memref<?xi8>).  Elements are accessed via byte offset
-        # pointer arithmetic.
-        if isinstance(fe_type.dtype, (Record, types.CharSeq, types.UnicodeCharSeq)):
+        ele_ty = dmm.lookup(fe_type.dtype).get_data_type()
+
+        # For Record, CharSeq, UnicodeCharSeq, and extension types whose MLIR
+        # storage representation belongs to the LLVM dialect, use byte-based
+        # memrefs. MemRefs cannot legally use LLVM dialect types as elements;
+        # those elements are accessed through byte-offset pointer arithmetic.
+        if isinstance(
+            fe_type.dtype, (Record, types.CharSeq, types.UnicodeCharSeq)
+        ) or not _is_valid_memref_element_type(ele_ty):
             shape = [ShapedType.get_dynamic_size() for _ in range(fe_type.ndim)]
 
             dyn_stride = MemRefType.get_dynamic_stride_or_offset()
@@ -529,7 +540,6 @@ class ArrayModel(PrimitiveModel):
             super().__init__(dmm, fe_type, be_type)
             return
 
-        ele_ty = dmm.lookup(fe_type.dtype).get_data_type()
         shape = [ShapedType.get_dynamic_size() for _ in range(fe_type.ndim)]
 
         # Create strided layout with all dynamic strides

--- a/src/numba_cuda_mlir/models.py
+++ b/src/numba_cuda_mlir/models.py
@@ -23,6 +23,9 @@ from numba_cuda_mlir.numba_cuda.datamodel.registry import DataModelManager, regi
 from numba_cuda_mlir.numba_cuda.types import misc as nb_types_misc
 from numba_cuda_mlir.numba_cuda.types.ext_types import GridGroup as GridGroupClass
 from numba_cuda_mlir.type_defs import float_types
+from numba_cuda_mlir.lowering_utilities.type_conversions import (
+    is_valid_memref_element_type,
+)
 from numba_cuda_mlir.numba_cuda.types.containers import (
     NamedTuple,
     NamedUniTuple,
@@ -509,12 +512,6 @@ class UnionType(PrimitiveModel):
         super().__init__(dmm, fe_type, ele_ty)
 
 
-def _is_valid_memref_element_type(mlir_type):
-    """Return whether *mlir_type* is legal as a MemRef element type."""
-
-    return not str(mlir_type).startswith("!llvm.")
-
-
 @register_model(types.Array)
 class ArrayModel(PrimitiveModel):
     def __init__(self, dmm, fe_type):
@@ -528,7 +525,7 @@ class ArrayModel(PrimitiveModel):
         # those elements are accessed through byte-offset pointer arithmetic.
         if isinstance(
             fe_type.dtype, (Record, types.CharSeq, types.UnicodeCharSeq)
-        ) or not _is_valid_memref_element_type(ele_ty):
+        ) or not is_valid_memref_element_type(ele_ty):
             shape = [ShapedType.get_dynamic_size() for _ in range(fe_type.ndim)]
 
             dyn_stride = MemRefType.get_dynamic_stride_or_offset()

--- a/tests/numba_cuda_tests/cudapy/test_dispatcher.py
+++ b/tests/numba_cuda_tests/cudapy/test_dispatcher.py
@@ -296,7 +296,6 @@ class TestDispatcher(NumbaCUDATestCase):
         ]
         self._test_explicit_signatures(sigs)
 
-    @pytest.mark.xfail(True, reason="Incorrect result")
     def test_explicit_signatures_same_type_class(self):
         # A more interesting one...
         # (Note that the type of r is deliberately float64 in both cases so

--- a/tests/test_argument_handler_extensions.py
+++ b/tests/test_argument_handler_extensions.py
@@ -13,6 +13,7 @@ import numpy as np
 from numba_cuda_mlir._mlir.ir import IntegerType
 import pytest
 
+from numba_cuda_mlir import descriptor as descriptor_mod
 from numba_cuda_mlir.numba_cuda.datamodel.models import PrimitiveModel
 from numba_cuda_mlir.numba_cuda.typing.templates import AbstractTemplate, signature
 from numba_cuda_mlir.numba_cuda.extending import typeof_impl
@@ -106,6 +107,36 @@ def test_pointer_handler_transforms_pointerwrapper():
     out = np.zeros(1, dtype=np.uint64)
     kernel[1, 1](out, my_wrapper)
     assert out[0] == my_wrapper.ptr
+
+
+def test_value_owned_handler_transforms_without_dispatcher_extension():
+    ptr_value = 0x12345678
+    my_wrapper = PointerWrapper(ptr_value)
+    observed = []
+
+    def prepare_args(ty, val, stream=None, retr=None):
+        assert stream is None
+        assert retr is not None
+        if val is my_wrapper:
+            return types.uint64, val.ptr
+        return ty, val
+
+    my_wrapper.prepare_args = prepare_args
+
+    def launcher(value):
+        observed.append(
+            (
+                getattr(descriptor_mod._compile_arg_types, "launch_args", None),
+                value,
+            )
+        )
+        return "launched"
+
+    marshaller = descriptor_mod._ArgMarshaller(launcher)
+
+    assert marshaller(my_wrapper) == "launched"
+    assert observed == [((my_wrapper,), ptr_value)]
+    assert not hasattr(descriptor_mod._compile_arg_types, "launch_args")
 
 
 def test_multiple_extension_handlers():

--- a/tests/test_argument_handler_extensions.py
+++ b/tests/test_argument_handler_extensions.py
@@ -3,9 +3,9 @@
 """
 Tests for argument handler extensions.
 
-prepare_args transforms both types and values. Original types (from typeof() on
-the original args) are used for compilation. Transformed types/values are used
-at launch time for argument marshalling.
+prepare_args transforms both types and values. Its transformed types are
+authoritative for compilation, while transformed values are flattened and
+marshalled for launch.
 """
 
 import operator
@@ -118,7 +118,7 @@ def test_value_owned_handler_transforms_without_dispatcher_extension():
         assert stream is None
         assert retr is not None
         if val is my_wrapper:
-            return types.uint64, val.ptr
+            return types.uint64, (val.ptr,)
         return ty, val
 
     my_wrapper.prepare_args = prepare_args
@@ -127,6 +127,7 @@ def test_value_owned_handler_transforms_without_dispatcher_extension():
         observed.append(
             (
                 getattr(descriptor_mod._compile_arg_types, "launch_args", None),
+                tuple(descriptor_mod._compile_arg_types.types),
                 value,
             )
         )
@@ -135,7 +136,7 @@ def test_value_owned_handler_transforms_without_dispatcher_extension():
     marshaller = descriptor_mod._ArgMarshaller(launcher)
 
     assert marshaller(my_wrapper) == "launched"
-    assert observed == [((my_wrapper,), ptr_value)]
+    assert observed == [((my_wrapper,), (types.uint64,), ptr_value)]
     assert not hasattr(descriptor_mod._compile_arg_types, "launch_args")
 
 

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -127,6 +127,42 @@ def test_arg_marshaller_exposes_launch_config_during_launch():
     assert not hasattr(descriptor_mod._compile_arg_types, "launch_config")
 
 
+def test_arg_marshaller_passes_call_scoped_dispatch_token():
+    observed = []
+
+    class Dispatcher(_Dispatcher):
+        def _dispatch_token_for(self, argtypes):
+            observed.append(argtypes)
+            return 17
+
+    def launcher(value, **kwargs):
+        observed.append((value, kwargs))
+        return "launched"
+
+    marshaller = _ArgMarshaller(
+        launcher,
+        dispatcher=Dispatcher(),
+        supports_dispatch_token=True,
+    )
+
+    assert marshaller._launch((types.int32,), (np.int32(4),)) == "launched"
+    assert observed == [
+        (types.int32,),
+        (np.int32(4), {"_dispatch_token": 17}),
+    ]
+
+
+def test_dispatch_tokens_are_stable_and_exact():
+    def kernel():
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+
+    int32_token = dispatcher._dispatch_token_for((types.int32,))
+    assert dispatcher._dispatch_token_for((types.int32,)) == int32_token
+    assert dispatcher._dispatch_token_for((types.int64,)) != int32_token
+
+
 def test_arg_marshaller_restores_launch_config_after_error():
     original_launch_config = {"block": (16, 1, 1)}
     dispatcher = _Dispatcher()
@@ -1540,7 +1576,7 @@ def test_launch_config_dispatcher_cache_retains_boundary_before_eviction():
 
 def test_retained_marshaller_reregisters_after_cache_eviction(monkeypatch):
     def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
-        return lambda *args: None
+        return lambda *args, **kwargs: None
 
     monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
 
@@ -1576,7 +1612,7 @@ def test_retained_marshaller_reregisters_after_cache_eviction(monkeypatch):
 
 def test_retained_marshaller_does_not_reregister_after_recompile(monkeypatch):
     def launch_configuration(kernel_dispatcher, griddim, blockdim, stream, sharedmem, cluster):
-        return lambda *args: None
+        return lambda *args, **kwargs: None
 
     monkeypatch.setattr(descriptor_mod, "LaunchConfiguration", launch_configuration)
 

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -156,6 +156,25 @@ def test_arg_marshaller_restores_launch_config_after_error():
     assert descriptor_mod._compile_arg_types.launch_config == original_launch_config
 
 
+def test_arg_marshaller_restores_original_launch_args_after_error():
+    outer_launch_args = ("outer",)
+    inner_launch_args = ("inner",)
+    descriptor_mod._compile_arg_types.launch_args = outer_launch_args
+    observed = []
+
+    def launcher():
+        observed.append(descriptor_mod._compile_arg_types.launch_args)
+        raise ValueError("launch failed")
+
+    marshaller = _ArgMarshaller(launcher)
+
+    with pytest.raises(ValueError, match="launch failed"):
+        marshaller._launch((), (), original_args=inner_launch_args)
+
+    assert observed == [inner_launch_args]
+    assert descriptor_mod._compile_arg_types.launch_args is outer_launch_args
+
+
 def test_arg_marshaller_clears_launch_config_after_error():
     dispatcher = _Dispatcher()
     launch_config = {
@@ -1161,6 +1180,34 @@ def test_compile_impl_generic_applies_shared_memory_carveout(monkeypatch):
     assert dispatcher._compile_impl([1]) == (b"generic", "kernel", False)
     assert len(applied) == 1
     assert dispatcher.overloads[(types.int32,)] is applied[0]
+
+
+def test_compile_impl_transports_original_launch_args_without_mutation(monkeypatch):
+    from numba_cuda_mlir import mlir_compiler
+
+    def kernel(x):
+        pass
+
+    dispatcher = descriptor_mod.MLIRDispatcher(kernel)
+    original_arg = object()
+    compile_calls = []
+
+    class CompilerResult:
+        signature = cuda_typing.signature(types.none, types.int32)
+        metadata = {"cubin": b"generic", "func_name": "kernel"}
+
+    def mlir_compiler_entry(pyfunc, func_args, targetoptions, override_argtypes):
+        compile_calls.append((tuple(func_args), dict(targetoptions)))
+        return CompilerResult()
+
+    monkeypatch.setattr(mlir_compiler, "mlir_compiler_entry", mlir_compiler_entry)
+    descriptor_mod._compile_arg_types.types = (types.int32,)
+    descriptor_mod._compile_arg_types.launch_args = (original_arg,)
+
+    assert dispatcher._compile_impl([1]) == (b"generic", "kernel", False)
+    assert compile_calls[0][0] == (1,)
+    assert compile_calls[0][1]["__launch_args__"] == (original_arg,)
+    assert "__launch_args__" not in dispatcher.targetoptions
 
 
 def test_launch_config_key_validation():

--- a/tests/test_memref_element_type.py
+++ b/tests/test_memref_element_type.py
@@ -11,8 +11,8 @@ For LLVM dialect types (``!llvm.struct<…>``), ``memref`` is not valid and
 ``llvm.alloca`` must be used instead.  This situation arises with any
 extension type whose data model lowers to ``!llvm.struct<…>``.
 
-The integration tests below define a minimal extension type that lowers to
-``!llvm.struct<(i32, i32)>`` and force multi-assignment so the stack
+The integration tests below define a minimal extension type that lowers to a
+padded ``!llvm.struct<(i8, i64)>`` and force multi-assignment so the stack
 allocation path is exercised end-to-end.
 """
 
@@ -20,7 +20,7 @@ import numpy as np
 
 from numba_cuda_mlir import cuda, extending, types
 from numba_cuda_mlir.extending import lower_cast, lowering_registry
-from numba_cuda_mlir.lowering_utilities import convert
+from numba_cuda_mlir.lowering_utilities import constant, convert
 from numba_cuda_mlir.models import PrimitiveModel, mlir_data_manager, register_model
 from numba_cuda_mlir._mlir import ir as mlir_ir
 from numba_cuda_mlir._mlir.dialects import llvm
@@ -28,7 +28,7 @@ from numba_cuda_mlir.numba_cuda.typeconv import Conversion
 
 
 # ---------------------------------------------------------------------------
-# Custom extension type: two i32 fields packed in an LLVM struct.
+# Custom extension type: i8 and i64 fields in a padded LLVM struct.
 # Represents a (value, valid_bit) pair — a minimal "masked" scalar.
 # ---------------------------------------------------------------------------
 
@@ -46,6 +46,11 @@ class MiniMaskedType(types.Type):
             return Conversion.safe
         return None
 
+    def can_convert_from(self, typingctx, other):
+        if isinstance(other, types.Integer):
+            return Conversion.safe
+        return None
+
 
 mini_masked = MiniMaskedType()
 
@@ -53,8 +58,9 @@ mini_masked = MiniMaskedType()
 @register_model(MiniMaskedType)
 class MiniMaskedModel(PrimitiveModel):
     def __init__(self, dmm, fe_type):
-        i32 = mlir_ir.IntegerType.get_signless(32)
-        be_type = llvm.StructType.get_literal([i32, i32])
+        i8 = mlir_ir.IntegerType.get_signless(8)
+        i64 = mlir_ir.IntegerType.get_signless(64)
+        be_type = llvm.StructType.get_literal([i8, i64])
         super().__init__(dmm, fe_type, be_type)
 
 
@@ -80,9 +86,10 @@ def _type_make_masked(context):
 def _lower_make_masked(builder, target, args, kwargs):
     value = builder.load_var(args[0])
     valid = builder.load_var(args[1])
-    i32 = mlir_ir.IntegerType.get_signless(32)
-    value = convert(value, i32)
-    valid = convert(valid, i32)
+    i8 = mlir_ir.IntegerType.get_signless(8)
+    i64 = mlir_ir.IntegerType.get_signless(64)
+    value = convert(value, i8)
+    valid = convert(valid, i64)
     struct_ty = builder.get_mlir_type(mini_masked)
     undef = llvm.UndefOp(struct_ty)
     with_value = llvm.insertvalue(
@@ -106,11 +113,47 @@ def _lower_make_masked(builder, target, args, kwargs):
 @lower_cast(MiniMaskedType, types.Integer)
 def _cast_mini_masked_to_int(context, builder, fromty, toty, val):
     result_ty = builder.get_mlir_type(toty)
-    return llvm.extractvalue(
-        res=result_ty,
+    stored_ty = mlir_ir.IntegerType.get_signless(8)
+    stored = llvm.extractvalue(
+        res=stored_ty,
         container=val,
         position=mlir_ir.DenseI64ArrayAttr.get([0]),
     )
+    return convert(stored, result_ty)
+
+
+@lower_cast(types.Integer, MiniMaskedType)
+def _cast_int_to_mini_masked(context, builder, fromty, toty, val):
+    i8 = mlir_ir.IntegerType.get_signless(8)
+    i64 = mlir_ir.IntegerType.get_signless(64)
+    struct_ty = builder.get_mlir_type(toty)
+    undef = llvm.UndefOp(struct_ty)
+    with_value = llvm.insertvalue(
+        container=undef,
+        value=convert(val, i8),
+        position=mlir_ir.DenseI64ArrayAttr.get([0]),
+    )
+    return llvm.insertvalue(
+        container=with_value,
+        value=constant(1, i64),
+        position=mlir_ir.DenseI64ArrayAttr.get([1]),
+    )
+
+
+class _PointerArray:
+    """Keep a device pointer array alive while overriding its Numba dtype."""
+
+    def __init__(self, array):
+        self._array = array
+
+    @property
+    def __cuda_array_interface__(self):
+        return self._array.__cuda_array_interface__
+
+
+@extending.typeof_impl.register(_PointerArray)
+def _typeof_pointer_array(value, context):
+    return types.Array(types.CPointer(types.int32), 1, "C")
 
 
 extending.refresh_registries()
@@ -119,6 +162,14 @@ extending.refresh_registries()
 # ---------------------------------------------------------------------------
 # Integration tests
 # ---------------------------------------------------------------------------
+
+
+def test_local_array_public_shape_contract_remains_static():
+    """LLVM-backed storage does not broaden CUDA's literal-shape API."""
+
+    from numba_cuda_mlir.typing.cuda import LocalArrayTemplate
+
+    assert LocalArrayTemplate.allow_dynamic_shape is False
 
 
 def test_extension_array_model_uses_byte_backed_memref():
@@ -138,7 +189,7 @@ def test_extension_type_multi_assign_uses_alloca():
     ``m`` is assigned twice (both as MiniMasked) so
     allocate_stack_space_for_vars_with_multiple_assigns fires.  Without the
     _is_valid_memref_element_type guard this would crash at MLIR verification
-    because memref<!llvm.struct<(i32, i32)>> is not legal.
+    because memref<!llvm.struct<(i8, i64)>> is not legal.
 
     Branch unification (``m`` vs ``int32``) forces a cast that reads ``m``
     back from its alloca slot, verifying the full store-load round trip.
@@ -199,3 +250,131 @@ def test_extension_type_loop_reassign():
     out[0] = 0
     kernel[1, 1](n, out)
     assert out[0] == -1, f"expected -1, got {out[0]}"
+
+
+def test_extension_type_local_array_round_trip():
+    """Local arrays preserve logical shape while storing LLVM-backed values."""
+
+    @cuda.jit
+    def kernel(out):
+        values = cuda.local.array(4, dtype=mini_masked)
+        for i in range(len(values)):
+            values[i] = make_masked(i + 10, 1)
+        for i in range(len(values)):
+            out[i] = values[i]
+
+    out = np.zeros(4, dtype=np.int32)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, np.arange(10, 14, dtype=np.int32))
+
+    mlir = next(iter(kernel.inspect_mlir().values()))
+    assert "!llvm.struct<(i8, i64)>" in mlir
+
+
+def test_extension_type_local_array_crosses_device_function_boundary():
+    """Generic pointer reconstruction survives storage-origin erasure."""
+
+    @cuda.jit(device=True, inline="never")
+    def read(values, index):
+        return values[index]
+
+    @cuda.jit
+    def kernel(out):
+        values = cuda.local.array(2, dtype=mini_masked)
+        values[0] = make_masked(77, 1)
+        values[1] = make_masked(88, 1)
+        out[0] = read(values, 0)
+
+    out = np.zeros(1, dtype=np.int32)
+    kernel[1, 1](out)
+    assert out[0] == 77
+
+    mlir = next(iter(kernel.inspect_mlir().values()))
+    assert "func.func" in mlir
+    assert "memref<?xi8" in mlir
+
+
+def test_extension_type_local_array_store_casts():
+    """Scalar, tuple-indexed, and slice stores cast to the array dtype."""
+
+    @cuda.jit
+    def kernel(out):
+        scalar = cuda.local.array(1, dtype=mini_masked)
+        matrix = cuda.local.array((2, 2), dtype=mini_masked)
+        sliced = cuda.local.array(3, dtype=mini_masked)
+
+        scalar[0] = np.int32(31)
+        matrix[1, 1] = np.int32(41)
+        sliced[1:] = np.int32(51)
+
+        out[0] = scalar[0]
+        out[1] = matrix[1, 1]
+        out[2] = sliced[1]
+        out[3] = sliced[2]
+
+    out = np.zeros(4, dtype=np.int32)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, np.array([31, 41, 51, 51], dtype=np.int32))
+
+
+def test_llvm_backed_global_pointer_array_round_trip():
+    """The same generic byte-backed ABI can access global pointer arrays."""
+
+    @cuda.jit
+    def kernel(pointers, out):
+        out[0] = pointers[0][0]
+
+    pointee = cuda.to_device(np.array([123], dtype=np.int32))
+    pointer_value = pointee.__cuda_array_interface__["data"][0]
+    pointer_bits = cuda.to_device(np.array([pointer_value], dtype=np.uint64))
+    pointers = _PointerArray(pointer_bits)
+    out = cuda.to_device(np.zeros(1, dtype=np.int32))
+
+    kernel[1, 1](pointers, out)
+    assert out.copy_to_host()[0] == 123
+
+    mlir = next(iter(kernel.inspect_mlir().values()))
+    assert "memref<?xi8" in mlir
+    assert "llvm.inttoptr" in mlir
+
+
+def test_extension_type_multidimensional_local_array_round_trip():
+    """Logical multidimensional strides address adjacent extension values."""
+
+    @cuda.jit
+    def kernel(out):
+        values = cuda.local.array((2, 3), dtype=mini_masked)
+        for row in range(2):
+            for column in range(3):
+                values[row, column] = make_masked(row * 10 + column, 1)
+        for row in range(2):
+            for column in range(3):
+                out[row, column] = values[row, column]
+
+    out = np.zeros((2, 3), dtype=np.int32)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(
+        out,
+        np.array([[0, 1, 2], [10, 11, 12]], dtype=np.int32),
+    )
+
+
+def test_extension_type_local_array_slice_preserves_offset():
+    """Subview offsets remain logical element offsets for LLVM-backed values."""
+
+    @cuda.jit
+    def kernel(out):
+        values = cuda.local.array(5, dtype=mini_masked, alignment=16)
+        for i in range(len(values)):
+            values[i] = make_masked(i + 20, 1)
+        tail = values[2:]
+        for i in range(len(tail)):
+            out[i] = tail[i]
+
+    out = np.zeros(3, dtype=np.int32)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, np.arange(22, 25, dtype=np.int32))
+
+    mlir = next(iter(kernel.inspect_mlir().values()))
+    assert "llvm.alloca" in mlir
+    assert "alignment = 16" in mlir

--- a/tests/test_memref_element_type.py
+++ b/tests/test_memref_element_type.py
@@ -121,7 +121,7 @@ def _cast_mini_masked_to_int(context, builder, fromty, toty, val):
         container=val,
         position=mlir_ir.DenseI64ArrayAttr.get([0]),
     )
-    return convert(stored, result_ty)
+    return convert(stored, result_ty, signed=True)
 
 
 @lower_cast(types.Integer, MiniMaskedType)

--- a/tests/test_memref_element_type.py
+++ b/tests/test_memref_element_type.py
@@ -21,7 +21,7 @@ import numpy as np
 from numba_cuda_mlir import cuda, extending, types
 from numba_cuda_mlir.extending import lower_cast, lowering_registry
 from numba_cuda_mlir.lowering_utilities import convert
-from numba_cuda_mlir.models import PrimitiveModel, register_model
+from numba_cuda_mlir.models import PrimitiveModel, mlir_data_manager, register_model
 from numba_cuda_mlir._mlir import ir as mlir_ir
 from numba_cuda_mlir._mlir.dialects import llvm
 from numba_cuda_mlir.numba_cuda.typeconv import Conversion
@@ -119,6 +119,16 @@ extending.refresh_registries()
 # ---------------------------------------------------------------------------
 # Integration tests
 # ---------------------------------------------------------------------------
+
+
+def test_extension_array_model_uses_byte_backed_memref():
+    """Array models must not form memrefs with LLVM-dialect elements."""
+
+    with mlir_ir.Context(), mlir_ir.Location.unknown():
+        array_type = types.Array(mini_masked, 1, "C")
+        model = mlir_data_manager.lookup(array_type)
+
+        assert str(model.get_value_type()).startswith("memref<?xi8")
 
 
 def test_extension_type_multi_assign_uses_alloca():

--- a/tests/test_memref_element_type.py
+++ b/tests/test_memref_element_type.py
@@ -17,6 +17,7 @@ allocation path is exercised end-to-end.
 """
 
 import numpy as np
+import pytest
 
 from numba_cuda_mlir import cuda, extending, types
 from numba_cuda_mlir.extending import lower_cast, lowering_registry
@@ -25,6 +26,7 @@ from numba_cuda_mlir.models import PrimitiveModel, mlir_data_manager, register_m
 from numba_cuda_mlir._mlir import ir as mlir_ir
 from numba_cuda_mlir._mlir.dialects import llvm
 from numba_cuda_mlir.numba_cuda.typeconv import Conversion
+from numba_cuda_mlir.numba_cuda.core.errors import UnsupportedError
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +271,23 @@ def test_extension_type_local_array_round_trip():
 
     mlir = next(iter(kernel.inspect_mlir().values()))
     assert "!llvm.struct<(i8, i64)>" in mlir
+
+
+@pytest.mark.parametrize("shape", [4, 0], ids=["static", "dynamic"])
+def test_extension_type_shared_array_is_rejected(shape):
+    """Shared storage rejects LLVM-backed dtypes before forming an invalid memref."""
+
+    def kernel():
+        values = cuda.shared.array(shape, dtype=mini_masked)
+        values[0] = make_masked(1, 1)
+
+    with pytest.raises(UnsupportedError) as exc_info:
+        cuda.compile_ptx(kernel, (), cc=(8, 0))
+    assert exc_info.value.msg == (
+        "cuda.shared.array does not yet support LLVM-backed element dtypes. "
+        "Use cuda.local.array for per-thread extension storage or a built-in "
+        "shared-memory dtype."
+    )
 
 
 def test_extension_type_local_array_crosses_device_function_boundary():

--- a/tests/test_semantic_dispatch_identity.py
+++ b/tests/test_semantic_dispatch_identity.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from numba_cuda_mlir import cuda, extending, types
+from numba_cuda_mlir._mlir import ir
+from numba_cuda_mlir.models import PrimitiveModel, register_model
+from numba_cuda_mlir.numba_cuda.extending import typeof_impl
+
+
+class CompileTimeValueType(types.Type):
+    def __init__(self, value):
+        self.value = value
+        super().__init__(name=f"CompileTimeValue({value})")
+
+    @property
+    def key(self):
+        return self.value
+
+
+@register_model(CompileTimeValueType)
+class CompileTimeValueModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        super().__init__(dmm, fe_type, ir.IntegerType.get_signless(32))
+
+
+class CompileTimeValue:
+    def __init__(self, value):
+        self.value = value
+
+    def prepare_args(self, ty, val, stream=None, retr=None):
+        if val is not self:
+            return ty, val
+        return ty, np.int32(0)
+
+
+@typeof_impl.register(CompileTimeValue)
+def typeof_compile_time_value(val, c):
+    return CompileTimeValueType(val.value)
+
+
+@extending.overload_attribute(
+    CompileTimeValueType,
+    "constant",
+    inline="always",
+    typing_registry=extending.typing_registry,
+    lowering_registry=extending.lowering_registry,
+)
+def compile_time_value_constant(value):
+    constant = value.value
+
+    def get(value):
+        return constant
+
+    return get
+
+
+@pytest.mark.parametrize("first,second", [(2, 3), (3, 2)])
+def test_value_owned_semantic_type_participates_in_native_dispatch(first, second):
+    @cuda.jit
+    def kernel(out, value):
+        out[0] = value.constant
+
+    out = np.zeros(1, dtype=np.int32)
+
+    kernel[1, 1](out, CompileTimeValue(first))
+    assert out[0] == first
+
+    kernel[1, 1](out, CompileTimeValue(second))
+    assert out[0] == second
+    assert len(kernel.overloads) == 2
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        (np.float32(2.5), 1.5),
+        (1.5, np.float32(2.5)),
+    ],
+)
+def test_native_dispatch_distinguishes_compiled_scalar_widths(values):
+    @cuda.jit
+    def kernel(out, value):
+        out[0] = value
+
+    out = np.zeros(1, dtype=np.float64)
+    for value in values:
+        kernel[1, 1](out, value)
+        assert out[0] == value
+    assert len(kernel.overloads) == 2

--- a/tests/test_value_owned_kernel_arguments.py
+++ b/tests/test_value_owned_kernel_arguments.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from numba_cuda_mlir import cuda, extending, types
+from numba_cuda_mlir import descriptor as descriptor_mod
 from numba_cuda_mlir.models import StructModel, register_model
 from numba_cuda_mlir.numba_cuda.extending import typeof_impl
 
@@ -42,6 +43,7 @@ def typeof_runtime_pair(val, c):
 
 extending.make_attribute_wrapper(RuntimePairType, "left", "left")
 extending.make_attribute_wrapper(RuntimePairType, "right", "right")
+extending.refresh_registries()
 
 
 @cuda.jit
@@ -57,3 +59,33 @@ def test_value_owned_struct_argument_matches_flattened_launcher_abi(left, right)
     _runtime_pair_kernel[1, 1](out, RuntimePair(left, right))
 
     np.testing.assert_array_equal(out, np.array([left, right], dtype=np.int32))
+
+
+def test_flattened_argument_disables_misaligned_constant_flags():
+    @cuda.jit
+    def kernel(out, pair, scalar):
+        out[0] = pair.right + scalar
+
+    native_compile_calls = []
+
+    def compile_with_count(args):
+        native_compile_calls.append(args)
+        return kernel._compile(args)
+
+    # The flags describe the three logical arguments. RuntimePair expands to
+    # two native leaves, so indexing these flags against the four flattened
+    # arguments would incorrectly mark pair.right, rather than scalar,
+    # constant and create a second native cache entry when pair.right changes.
+    kernel._c = descriptor_mod._cext.KernelDispatcher(
+        compile_with_count,
+        (False, False, True),
+        descriptor_mod._ensure_numba_cuda_context,
+    )
+
+    out = np.zeros(1, dtype=np.int32)
+    kernel[1, 1](out, RuntimePair(1, 2), np.int32(5))
+    assert out[0] == 7
+
+    kernel[1, 1](out, RuntimePair(1, 3), np.int32(5))
+    assert out[0] == 8
+    assert len(native_compile_calls) == 1

--- a/tests/test_value_owned_kernel_arguments.py
+++ b/tests/test_value_owned_kernel_arguments.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from numba_cuda_mlir import cuda, extending, types
+from numba_cuda_mlir.models import StructModel, register_model
+from numba_cuda_mlir.numba_cuda.extending import typeof_impl
+
+
+class RuntimePairType(types.Type):
+    def __init__(self):
+        super().__init__(name="RuntimePair")
+
+
+runtime_pair_type = RuntimePairType()
+
+
+@register_model(RuntimePairType)
+class RuntimePairModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        super().__init__(dmm, fe_type, (("left", types.int32), ("right", types.int32)))
+
+
+class RuntimePair:
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def prepare_args(self, ty, val, stream=None, retr=None):
+        if val is not self:
+            return ty, val
+        assert ty == runtime_pair_type
+        return ty, (np.int32(self.left), np.int32(self.right))
+
+
+@typeof_impl.register(RuntimePair)
+def typeof_runtime_pair(val, c):
+    return runtime_pair_type
+
+
+extending.make_attribute_wrapper(RuntimePairType, "left", "left")
+extending.make_attribute_wrapper(RuntimePairType, "right", "right")
+
+
+@cuda.jit
+def _runtime_pair_kernel(out, pair):
+    out[0] = pair.left
+    out[1] = pair.right
+
+
+@pytest.mark.parametrize("left,right", [(3, 7), (-11, 29)])
+def test_value_owned_struct_argument_matches_flattened_launcher_abi(left, right):
+    out = np.zeros(2, dtype=np.int32)
+
+    _runtime_pair_kernel[1, 1](out, RuntimePair(left, right))
+
+    np.testing.assert_array_equal(out, np.array([left, right], dtype=np.int32))


### PR DESCRIPTION
## Why this is needed

CUDA interoperability providers can define structured kernel arguments whose Python/frontend representation differs from the flattened native launcher ABI. Without preserving that semantic frontend type through compilation, the compiler and launcher can disagree about argument count and layout, and native cache entries can alias distinct frontend types.

Provider-defined types backed by LLVM dialect values also cannot be used directly as MLIR memref element types. Thread-local arrays of those values require byte-backed storage with explicit, element-size-aware loads and stores.

This work addresses #60 and #63. It is now based directly on current `main`; it no longer contains or depends on the compiler extension loader/protocol work from closed #253.

## What changes

- recognize value-owned `prepare_args()` handlers at launch time
- preserve provider-owned values and semantic frontend types through compilation
- flatten composite arguments consistently across compiler and native launcher ABI boundaries
- key native kernels by frontend argument types and disable constant specialization when frontend/native arities differ
- represent LLVM-backed provider types with byte-backed arrays
- support LLVM-backed element types in thread-local arrays while explicitly rejecting them for shared arrays
- keep signedness explicit in the provider-facing regression coverage

## Review boundary

- Upstream base: `2272ad8dcf907e021ed4fb77327dfd6174b1427e`
- Branch head: `bb7326c1343eb7a812e69ffc4d2f77e179cc2810`
- Review surface: nine commits, 14 files, `+990/-177`
- The rebased range is patch-equivalent to the former structured-argument/local-array range, except that the obsolete extension-bootstrap call is intentionally absent.

## Validation

- rebuilt the CPython 3.12 native launcher against the recorded LLVM/MLIR inputs
- focused dispatcher/argument/ABI/cache/local-array cohort: `147 passed, 1 skipped, 5 xfailed`
- downstream `cuda.coop.numba_mlir` `gpu_dataclass` and `ThreadData` GPU cohort: `10 passed`
- `uvx --from pre-commit pre-commit run --from-ref origin/main --to-ref HEAD`: passed
- `git diff --check origin/main..HEAD`: passed
- all nine rebased commits have valid GPG signatures
