### PR TITLE
[Extending] Fix overload registry cache key lookup for literals

### DIFF
--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -1214,6 +1214,7 @@ class MLIRTargetContext(BaseContext):
                 templates.extend(getattr(inner_fnty, "templates", []))
 
         match_args = (sig.recvr, *sig.args) if sig.recvr else sig.args
+        match_args = tuple(types.unliteral(arg) for arg in match_args)
 
         for temp_cls in templates:
             if not hasattr(temp_cls, "_impl_cache"):

--- a/tests/numba_cuda_tests/cudapy/test_device_func.py
+++ b/tests/numba_cuda_tests/cudapy/test_device_func.py
@@ -13,6 +13,7 @@ import numba_cuda_mlir
 from numba_cuda_mlir import cuda
 
 from numba_cuda_mlir.numba_cuda import types
+from numba_cuda_mlir.numba_cuda.testing import skip_if_curand_kernel_missing
 from numba_cuda_mlir.numba_cuda.types import float32, int32
 from numba_cuda_mlir.numba_cuda.core.errors import TypingError
 from types import ModuleType
@@ -337,7 +338,7 @@ class TestDeclareDevice(NumbaCUDATestCase):
         expected = np.ones(2, dtype=np.int32)
         np.testing.assert_equal(x, expected)
 
-    @pytest.mark.xfail(True, reason="curand includes not present")
+    @skip_if_curand_kernel_missing
     def test_include_cuda_header(self):
         sig = types.int32(types.uint64)
         link = [rng_cu]

--- a/tests/numba_cuda_tests/cudapy/test_ssa.py
+++ b/tests/numba_cuda_tests/cudapy/test_ssa.py
@@ -279,7 +279,6 @@ class TestReportedSSAIssues(SSABaseTest):
         result_gpu = np.zeros((3, 2))
         self.check_func(foo, result_gpu, np.zeros((3, 2)))
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_issue3976(self):
         def overload_this(a):
             return 42

--- a/tests/test_numba_cuda_mlir_extending.py
+++ b/tests/test_numba_cuda_mlir_extending.py
@@ -98,6 +98,28 @@ def test_extending_overload_without_lowering():
     k[1, 1](x)
 
 
+def test_extending_overload_with_literal_argument():
+    def double(x):
+        raise NotImplementedError
+
+    @extending.overload(double, typing_registry=extending.typing_registry)
+    def overload_double(x):
+        def impl(x):
+            return x + x
+
+        return impl
+
+    extending.refresh_registries()
+
+    @cuda.jit
+    def k(out):
+        out[0] = double(21)
+
+    out = np.zeros(1, dtype=np.int64)
+    k[1, 1](out)
+    assert out[0] == 42
+
+
 def test_extending_overload_method():
     """User-defined @overload_method dispatches through BoundFunction."""
 


### PR DESCRIPTION
The fix is to normalize literals so the lookup works.