### PR TITLE
Fix variadic overload lowering

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1906,8 +1906,9 @@ extern "C" __global__ void
             )
 
         callee_type = get_func_type(callee)
+        flat_call_vars = self._flatten_abi_value(call_vars)
         call_args = [
-            convert(val, ty) for val, ty in zip(self.load_vars(call_vars), callee_type.inputs)
+            convert(val, ty) for val, ty in zip(self.load_vars(flat_call_vars), callee_type.inputs)
         ]
         call_result = func.call(
             result=callee_type.results,

--- a/tests/test_numba_cuda_mlir_extending.py
+++ b/tests/test_numba_cuda_mlir_extending.py
@@ -98,6 +98,29 @@ def test_extending_overload_without_lowering():
     k[1, 1](x)
 
 
+def test_extending_variadic_overload():
+    def add(*args):
+        raise NotImplementedError
+
+    @extending.overload(add, typing_registry=extending.typing_registry)
+    def add_overload(*args):
+        def impl(*args):
+            return args[0] + args[1]
+
+        return impl
+
+    extending.refresh_registries()
+
+    @cuda.jit
+    def kernel(out, values):
+        out[0] = add(values[0], values[1])
+
+    out = np.zeros(1, dtype=np.int32)
+    values = np.array([20, 22], dtype=np.int32)
+    kernel[1, 1](out, values)
+    assert out[0] == 42
+
+
 def test_extending_overload_method():
     """User-defined @overload_method dispatches through BoundFunction."""
 


### PR DESCRIPTION
Fixes #257

Flatten folded variadic call variables before loading the compiled overload operands. This keeps the existing conversion path for regular and custom argument types.

Adds a GPU regression covering a variadic overload.

Tests:
- `python -m pytest -o addopts="" -o filterwarnings="" -q tests/test_numba_cuda_mlir_extending.py` (20 passed)
- `python -m pre_commit run --files src/numba_cuda_mlir/mlir_lowering.py tests/test_numba_cuda_mlir_extending.py`
