### PR TITLE
Fix device function symbol collisions when inlining is disabled

### DIFF
--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -3025,7 +3025,7 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         sig = typing.signature(return_type, *args)
         return self.compile(sig)
 
-    def _compile_device_callee(self, sig):
+    def _compile_device_callee(self, sig, abi_name=None):
         """Compile enough of a device function to inline/link it into a kernel.
 
         Device callees are cloned from their MLIR into the parent module, so
@@ -3038,7 +3038,9 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         argtypes, return_type = sigutils.normalize_signature(sig)
 
         if argtypes in self.overloads:
-            return self.overloads[argtypes]
+            cached = self.overloads[argtypes]
+            if abi_name is None or cached.metadata.get("device_callee_abi_name") == abi_name:
+                return cached
 
         self._resolve_target_options()
         self._cache_misses[argtypes] += 1
@@ -3046,12 +3048,18 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self._is_compiling = True
         try:
             with self._compile_profiler():
+                targetoptions = self.targetoptions.copy()
+                if abi_name is not None:
+                    abi_info = dict(targetoptions.get("abi_info") or {})
+                    abi_info["abi_name"] = abi_name
+                    targetoptions["abi_info"] = abi_info
                 cres = mlir_compiler.compile_mlir(
                     self.py_func,
                     return_type,
                     argtypes,
-                    targetoptions=self.targetoptions,
+                    targetoptions=targetoptions,
                 )
+                cres.metadata["device_callee_abi_name"] = abi_name
 
             cres.target_context.insert_user_function(cres.entry_point, cres.fndesc, [cres.library])
         except _RequireLaunchConfig:
@@ -3073,18 +3081,18 @@ class MLIRDispatcher(Dispatcher, serialize.ReduceMixin):
         self.overloads[argtypes] = wrapped
         return wrapped
 
-    def _compile_as_device_callee(self, sig):
+    def _compile_as_device_callee(self, sig, abi_name=None):
         """Compile this dispatcher through the lightweight device-callee path."""
         opts = self.targetoptions.copy()
         opts["device"] = True
         opts["lto"] = False
         if self.targetoptions.get("device", False):
             self.targetoptions.update(opts)
-            return self._compile_device_callee(sig)
+            return self._compile_device_callee(sig, abi_name=abi_name)
 
         if not hasattr(self, "_device_dispatcher") or self._device_dispatcher.targetoptions != opts:
             self._device_dispatcher = MLIRDispatcher(self.py_func, targetoptions=opts)
-        cres = self._device_dispatcher._compile_device_callee(sig)
+        cres = self._device_dispatcher._compile_device_callee(sig, abi_name=abi_name)
         argtypes, _ = sigutils.normalize_signature(sig)
         if argtypes not in self.overloads:
             self.overloads[argtypes] = cres

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1679,8 +1679,8 @@ extern "C" __global__ void
             fn = fn._device_dispatcher
 
         folded_argtypes, call_vars, call_argtypes = self._fold_dispatcher_call_args(fn, args, kws)
-        func_name = generate_mangled_name(fn.py_func.__qualname__, call_argtypes)
-        cres = fn._compile_as_device_callee(folded_argtypes)
+        func_name = generate_mangled_name(f"{fn.py_func.__qualname__}_{id(fn)}", call_argtypes)
+        cres = fn._compile_as_device_callee(folded_argtypes, abi_name=func_name)
 
         if callee_linker := cres.metadata.get("linker"):
             self._record_ltoirs_from_linker(callee_linker)

--- a/tests/test_device_functions.py
+++ b/tests/test_device_functions.py
@@ -61,6 +61,26 @@ def test_none_equality_in_device_func():
     assert out[0] == 10
 
 
+def test_factory_device_functions_keep_captures_separate():
+    def make_leaf(offset):
+        @cuda.jit(device=True, inline="never")
+        def leaf(value):
+            return value + offset
+
+        return leaf
+
+    first = make_leaf(3)
+    second = make_leaf(5)
+
+    @cuda.jit
+    def kernel(out):
+        out[0] = second(first(0))
+
+    out = np.zeros(1, dtype=np.int64)
+    kernel[1, 1](out)
+    assert out[0] == 8
+
+
 if __name__ == "__main__":
     test_device_functions()
     test_self_recursion()


### PR DESCRIPTION
This is a partial step towards fixing #249, this resolved a lingering correctness bug with disabled inlining. A better policy for inlining to resolve the compile-time issue is forthcoming.