### PR TITLE
Normalize slices and allow dynamic shared mem views

### DIFF
--- a/src/numba_cuda_mlir/lowering/cuda.py
+++ b/src/numba_cuda_mlir/lowering/cuda.py
@@ -608,37 +608,31 @@ def lower_strides(
     target: numba_ir.Var,
     array: numba_ir.Var,
 ):
-    from numba_cuda_mlir.lowering_utilities import int_of, index_of
+    from numba_cuda_mlir.lowering_utilities import index_of
 
+    array_numba_type = mlir_lower.get_numba_type(array.name)
     array = mlir_lower.load_var(array)
     array_type = array.type
     rank = array_type.rank
-    array_numba_type = mlir_lower.get_numba_type(array.name)
-
-    # Get element size in bytes
     element_size = storage_itemsize_bytes(array_numba_type)
 
-    # Get dimensions - handle both memref and tensor types
     if isinstance(array_type, ir.MemRefType):
-        dims = [
-            memref.dim(source=array, index=arith.constant(result=T.index(), value=i))
-            for i in range(rank)
+        metadata = memref.extract_strided_metadata(array)
+        element_strides = metadata[2 + rank : 2 + 2 * rank]
+        strides = [
+            arith.muli(index_of(stride), index_of(element_size)) for stride in element_strides
         ]
     elif isinstance(array_type, ir.RankedTensorType):
         dims = [
             tensor.dim(source=array, index=arith.constant(result=T.index(), value=i))
             for i in range(rank)
         ]
+        strides = [None] * rank
+        strides[-1] = index_of(element_size)
+        for i in range(rank - 2, -1, -1):
+            strides[i] = arith.muli(strides[i + 1], dims[i + 1])
     else:
         raise NotImplementedError(f"strides not implemented for {array_type}")
-
-    # Compute strides (C-contiguous order)
-    # stride[rank-1] = element_size
-    # stride[i] = stride[i+1] * dim[i+1]
-    strides = [None] * rank
-    strides[-1] = index_of(element_size)
-    for i in range(rank - 2, -1, -1):
-        strides[i] = arith.muli(strides[i + 1], dims[i + 1])
 
     mlir_lower.store_var(target, tuple(strides))
 

--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
 import functools
 import operator
 from numba_cuda_mlir import lowering_utilities
@@ -842,32 +841,22 @@ def numpy_take(a, indices, axis=None):
 
 
 class Slice:
+    """Store slice bounds as index values."""
+
     def __init__(
         self,
-        start: ir.Value,
+        start: ir.Value | None = None,
         stop: ir.Value | None = None,
         step: ir.Value | None = None,
     ):
-        # Handle None for start (e.g., x[:5] has start=None meaning 0)
-        if isinstance(start, ir.NoneType):
-            start = None
-        self.start: ir.Value = (
-            lowering_utilities.convert(start, T.index())
-            if start is not None
-            else arith.index_cast(arith.constant(result=T.i64(), value=0), to=T.index())
-        )
-        # Handle None for stop (e.g., x[2:] has stop=None meaning end of array)
-        if isinstance(stop, ir.NoneType):
-            stop = None
-        self.stop: ir.Value | None = lowering_utilities.convert(stop, T.index()) if stop else None
-        # Handle None for step (default to 1)
-        if isinstance(step, ir.NoneType):
-            step = None
-        self.step: ir.Value = (
-            lowering_utilities.convert(step, T.index())
-            if step
-            else arith.constant(result=T.index(), value=1)
-        )
+        def as_index(bound):
+            if bound is None or isinstance(bound, ir.NoneType):
+                return None
+            return lowering_utilities.convert(bound, T.index())
+
+        self.start: ir.Value | None = as_index(start)
+        self.stop: ir.Value | None = as_index(stop)
+        self.step: ir.Value | None = as_index(step)
 
     def __str__(self):
         return f"Slice(start={self.start}, stop={self.stop}, step={self.step})"
@@ -879,6 +868,109 @@ class Slice:
         yield self.start
         yield self.stop
         yield self.step
+
+
+def _resolve_slice(builder, slc: Slice, mr: ir.Value, dim_index: int = 0):
+    """Return (start, length, step) index values with Python slice semantics for dim dim_index."""
+    start, stop, step = slc.start, slc.stop, slc.step
+    c_step = 1 if step is None else try_extract_constant(step)
+    if c_step == 0:
+        raise ValueError("slice step cannot be zero")
+    step = index_of(1) if step is None else step
+    extent = mr.type.shape[dim_index]
+    dynamic = ir.ShapedType.get_dynamic_size()
+    ext = index_of(extent) if extent != dynamic else memref.dim(mr, index_of(dim_index))
+    zero = index_of(0)
+    one = index_of(1)
+    neg1 = index_of(-1)
+
+    if c_step is None:
+        is_zero = arith.cmpi(arith.CmpIPredicate.eq, step, zero)
+        error_memref = builder._get_or_create_error_global()
+        if error_memref is not None:
+            with scf.if_ctx_manager(is_zero):
+                set_error_code_if_zero(error_memref, KERNEL_ERROR_CODES[ValueError])
+                scf.yield_([])
+        # The flagged zero step still reaches the length division; substitute one.
+        step = arith.select(is_zero, one, step)
+
+    is_negative_step = arith.cmpi(arith.CmpIPredicate.slt, step, zero)
+    extent_minus_one = arith.subi(ext, one)
+    lower = arith.select(is_negative_step, neg1, zero)
+    upper = arith.select(is_negative_step, extent_minus_one, ext)
+
+    def fix_bound(bound, default):
+        if bound is None:
+            return default
+        is_negative = arith.cmpi(arith.CmpIPredicate.slt, bound, zero)
+        wrapped = arith.select(is_negative, arith.addi(bound, ext), bound)
+        return arith.minsi(arith.maxsi(wrapped, lower), upper)
+
+    resolved_start = fix_bound(start, arith.select(is_negative_step, extent_minus_one, zero))
+    resolved_stop = fix_bound(stop, arith.select(is_negative_step, neg1, ext))
+
+    delta = arith.subi(resolved_stop, resolved_start)
+    dividend = arith.select(
+        is_negative_step,
+        arith.addi(delta, one),
+        arith.subi(delta, one),
+    )
+    nominal_length = arith.addi(one, arith.divsi(dividend, step))
+    is_empty = arith.select(
+        is_negative_step,
+        arith.cmpi(arith.CmpIPredicate.sge, delta, zero),
+        arith.cmpi(arith.CmpIPredicate.sle, delta, zero),
+    )
+    length = arith.select(is_empty, zero, nominal_length)
+    return resolved_start, length, step
+
+
+def _strided_view(
+    array: ir.Value,
+    offsets: list[ir.Value],
+    sizes: list[ir.Value],
+    strides: list[ir.Value],
+    dims_to_drop: list[bool] | None = None,
+) -> ir.Value:
+    """Build a strided view; dimensions marked in dims_to_drop are dropped from the result."""
+    rank = array.type.rank
+    metadata = memref_dialect.extract_strided_metadata(array)
+    source_strides = list(metadata[2 + rank : 2 + 2 * rank])
+    result_offset = metadata[1]
+    result_strides = []
+    result_sizes = []
+    if dims_to_drop is None:
+        dims_to_drop = [False] * rank
+
+    for offset, size, stride, source_stride, drop in zip(
+        offsets, sizes, strides, source_strides, dims_to_drop
+    ):
+        result_offset = arith.addi(
+            result_offset,
+            arith.muli(index_of(offset), index_of(source_stride)),
+        )
+        if not drop:
+            result_sizes.append(index_of(size))
+            result_strides.append(arith.muli(index_of(source_stride), index_of(stride)))
+
+    dynamic_size = ir.ShapedType.get_dynamic_size()
+    dynamic_stride = ir.ShapedType.get_dynamic_stride_or_offset()
+    result_type = ir.MemRefType.get(
+        [dynamic_size] * len(result_sizes),
+        array.type.element_type,
+        layout=ir.StridedLayoutAttr.get(dynamic_stride, [dynamic_stride] * len(result_sizes)),
+        memory_space=array.type.memory_space,
+    )
+    return memref_dialect.reinterpret_cast(
+        result_type,
+        array,
+        offsets=[result_offset],
+        sizes=result_sizes,
+        strides=result_strides,
+        static_offsets=[dynamic_stride],
+        static_sizes=[dynamic_size] * len(result_sizes),
+        static_strides=[dynamic_stride] * len(result_sizes),
+    )
 
 
 @lower(slice, types.VarArg(types.Any))
@@ -944,90 +1036,6 @@ def _lower_record_array_getitem(builder, target, args, kwargs):
     trace("Record array getitem: stored ptr to %s", target.name)
 
 
-def _get_memref_strides(memref_type: ir.MemRefType) -> list[int]:
-    """Extract static strides from a memref's layout, computing C-contiguous
-    strides when the layout is the default identity map."""
-    dyn = ir.ShapedType.get_dynamic_stride_or_offset()
-    dyn_size = ir.ShapedType.get_dynamic_size()
-    layout = memref_type.layout
-    if isinstance(layout, ir.StridedLayoutAttr):
-        return list(layout.strides)
-    source_shape = list(memref_type.shape)
-    result = []
-    for i in range(memref_type.rank):
-        suffix = source_shape[i + 1 :]
-        if all(d != dyn_size for d in suffix):
-            stride = 1
-            for d in suffix:
-                stride *= d
-            result.append(stride)
-        else:
-            result.append(dyn)
-    return result
-
-
-def _rank_reducing_subview(
-    array: ir.Value,
-    sv_offsets: list[ir.Value],
-    sv_sizes: list[ir.Value],
-    sv_strides: list[ir.Value],
-    dims_to_drop: list[bool],
-) -> ir.Value:
-    """Create a memref.subview that drops dimensions marked in *dims_to_drop*,
-    then collapse_shape to produce the rank-reduced result.  This is used for
-    both ``arr[i]`` and ``arr[(i, j)]`` style indexing where scalar indices
-    reduce the array rank."""
-    array_type: ir.MemRefType = array.type
-    source_rank = array_type.rank
-    dyn = ir.ShapedType.get_dynamic_stride_or_offset()
-    dyn_size = ir.ShapedType.get_dynamic_size()
-
-    subview_shape = [1 if dims_to_drop[i] else dyn_size for i in range(source_rank)]
-    source_strides = _get_memref_strides(array_type)
-
-    subview_type = ir.MemRefType.get(
-        subview_shape,
-        array_type.element_type,
-        layout=ir.StridedLayoutAttr.get(dyn, source_strides),
-        memory_space=array_type.memory_space,
-    )
-    subview = memref.subview(array, sv_offsets, sv_sizes, sv_strides, result_type=subview_type)
-
-    # Build reassociation: group each dropped dim with the next kept dim.
-    reassociation: list[list[int]] = []
-    pending: list[int] = []
-    for i in range(source_rank):
-        pending.append(i)
-        if not dims_to_drop[i]:
-            reassociation.append(pending)
-            pending = []
-    if pending:
-        if reassociation:
-            reassociation[-1].extend(pending)
-        else:
-            reassociation.append(pending)
-
-    # Compute result strides for the collapsed memref. A dimension group
-    # requires a dynamic stride if any source dimension in the group has a
-    # dynamic stride OR a dynamic size (since the product of sizes affects
-    # the effective stride after collapsing).
-    result_strides = []
-    for group in reassociation:
-        needs_dyn = any(source_strides[d] == dyn or subview_shape[d] == dyn_size for d in group)
-        if needs_dyn:
-            result_strides.append(dyn)
-        else:
-            result_strides.append(source_strides[group[-1]])
-    n_kept = len(result_strides)
-    result_type = ir.MemRefType.get(
-        [dyn_size] * n_kept,
-        array_type.element_type,
-        layout=ir.StridedLayoutAttr.get(dyn, result_strides),
-        memory_space=array_type.memory_space,
-    )
-    return memref.collapse_shape(result_type, subview, reassociation)
-
-
 @lower(operator.getitem, types.Array, types.Number)
 @lower(operator.getitem, types.Array, types.Integer)
 @lower(operator.getitem, types.Buffer, types.Integer)
@@ -1071,152 +1079,24 @@ def lower_array_getitem(builder, target, args, kwargs):
         sv_sizes = [index_of(1)] + [memref.dim(array, index_of(i)) for i in range(1, rank)]
         sv_strides = [index_of(1)] * rank
         dims_to_drop = [True] + [False] * (rank - 1)
-        value = _rank_reducing_subview(array, sv_offsets, sv_sizes, sv_strides, dims_to_drop)
+        value = _strided_view(array, sv_offsets, sv_sizes, sv_strides, dims_to_drop)
 
     builder.store_var(target, value)
-
-
-@dataclass
-class MemRefSlice:
-    offset: ir.Value
-    size: ir.Value
-    stride: ir.Value
-    static_offset: int
-    static_size: int
-    static_stride: int
-
-    @staticmethod
-    def get(array: ir.Value, slice: Slice):
-        from numba_cuda_mlir.lowering_utilities import try_extract_constant as extract
-
-        # first, last, step, static first, static last, static step
-        f, l, s, sf, sl, ss = [None for _ in range(6)]
-
-        # size, static size
-        sz, ssz = None, None
-
-        if v := extract(slice.start):
-            sf = v
-        else:
-            f = slice.start
-        if v := extract(slice.stop):
-            sl = v
-        elif slice.stop is None:
-            l = memref.dim(array, index_of(0))
-        else:
-            l = slice.stop
-        if v := extract(slice.step):
-            ss = v
-        else:
-            s = slice.step
-
-        if sf and sl:
-            ssz = sl - sf
-        else:
-            sz = l - f
-
-        return MemRefSlice(
-            offset=f,
-            size=sz,
-            stride=s,
-            static_offset=sf,
-            static_size=ssz,
-            static_stride=ss,
-        )
-
-
-class MemRefSlices:
-    def __init__(self, *slices: list[MemRefSlice]):
-        self.slices = slices
-
-    def __add__(self, other: "MemRefSlices") -> "MemRefSlices":
-        return MemRefSlices(*self.slices, *other.slices)
-
-    def __len__(self):
-        return len(self.slices)
-
-    def subview(self, mr: ir.Value) -> dict[str, list[ir.Value | int]]:
-        # TODO(ajm): replace with tensor.generate
-        kws = {
-            "offsets": [
-                (slice.static_offset if slice.static_offset is not None else slice.offset)
-                for slice in self.slices
-            ],
-            "sizes": [
-                (slice.static_size if slice.static_size is not None else slice.size)
-                for slice in self.slices
-            ],
-            "strides": [
-                (slice.static_stride if slice.static_stride is not None else slice.stride)
-                for slice in self.slices
-            ],
-        }
-        dyn = ir.ShapedType.get_dynamic_stride_or_offset()
-        source_strides, _ = mr.type.get_strides_and_offset()
-        result_strides = []
-        for src_stride, s in zip(source_strides, self.slices):
-            if s.static_stride is not None and src_stride != dyn:
-                result_strides.append(src_stride * s.static_stride)
-            else:
-                result_strides.append(dyn)
-        layout = ir.StridedLayoutAttr.get(offset=dyn, strides=result_strides)
-        mrt = ir.MemRefType.get(
-            element_type=mr.type.element_type,
-            shape=[
-                (slice.static_size if slice.static_size is not None else dyn)
-                for slice in self.slices
-            ],
-            layout=layout,
-            memory_space=mr.type.memory_space,
-        )
-        return memref.subview(mr, **kws, result_type=mrt)
-
-
-def slice_memref(mr: ir.Value, mrs: MemRefSlices) -> ir.Value:
-    value = mrs.subview(mr)
-    return value
 
 
 @lower(operator.getitem, types.Array, types.SliceType)
 def lower_array_slice_getitem(builder, target, args, kwargs):
     trace()
     mr = builder.load_var(args[0])
-    mr_type = mr.type
-    dtype = mr_type.element_type
-    rank = mr_type.rank
-    slice = builder.load_var(args[1])
-    start, stop, step = slice.start, slice.stop, slice.step
-    if start is None:
-        start = arith.index_cast(arith.constant(result=T.i64(), value=0), to=T.index())
-    if stop is None:
-        stop = memref.dim(mr, index_of(0))
-    if step is None:
-        step = index_of(1)
-    starts, stops, steps = [start], [stop], [step]
-    for i in range(1, rank):
-        starts.append(index_of(0))
-        stops.append(memref.dim(mr, index_of(i)))
-        steps.append(index_of(1))
+    rank = mr.type.rank
+    slc = builder.load_var(args[1])
+    start, length, step = _resolve_slice(builder, slc, mr)
 
-    dyn = ir.ShapedType.get_dynamic_stride_or_offset()
-    source_strides, _ = mr_type.get_strides_and_offset()
-    result_strides = []
-    for src_stride, step in zip(source_strides, steps):
-        step_val = try_extract_constant(step)
-        if step_val is not None and src_stride != dyn:
-            result_strides.append(src_stride * step_val)
-        else:
-            result_strides.append(dyn)
-    layout = ir.StridedLayoutAttr.get(offset=dyn, strides=result_strides)
-    mrt = ir.MemRefType.get(
-        element_type=dtype,
-        shape=[dyn for _ in range(rank)],
-        layout=layout,
-        memory_space=mr_type.memory_space,
-    )
-    sizes = [(stop - start) // step for start, stop, step in zip(starts, stops, steps)]
-    mr = memref.subview(mr, offsets=starts, sizes=sizes, strides=steps, result_type=mrt)
-    builder.store_var(target, mr)
+    offsets = [start] + [index_of(0) for _ in range(1, rank)]
+    sizes = [length] + [memref.dim(mr, index_of(i)) for i in range(1, rank)]
+    strides = [step] + [index_of(1) for _ in range(1, rank)]
+    view = _strided_view(mr, offsets, sizes, strides)
+    builder.store_var(target, view)
 
 
 def _idx_c(value: int) -> ir.Value:
@@ -1677,32 +1557,20 @@ def lower_array_slice_setitem(builder, target, args, kwargs):
     mr_type = array.type
     rank = mr_type.rank
 
-    # Parse slice bounds for dimension 0
-    start, stop, step = slice_val.start, slice_val.stop, slice_val.step
-    if start is None:
-        start = index_of(0)
-    else:
-        start = index_of(start)
-    if stop is None:
-        stop = memref.dim(array, index_of(0))
-    else:
-        stop = index_of(stop)
-    if step is None:
-        step = index_of(1)
-    else:
-        step = index_of(step)
+    start, length, step = _resolve_slice(builder, slice_val, array)
 
-    # Build bounds for all dimensions - first dim uses slice, rest use full range
-    starts = [start] + [index_of(0)] * (rank - 1)
-    stops = [stop] + [memref.dim(array, index_of(i + 1)) for i in range(rank - 1)]
-    steps = [step] + [index_of(1)] * (rank - 1)
+    # Map a forward loop onto the resolved slice.
+    starts = [index_of(0)] * rank
+    stops = [length] + [memref.dim(array, index_of(i + 1)) for i in range(rank - 1)]
+    steps = [index_of(1)] * rank
 
     @scf.forall_(starts, stops, steps)
     def fill_all(*indices):
+        idx0 = arith.addi(start, arith.muli(indices[0], step))
         lowering_utilities.array_element_value_store(
             array_numba_type,
             array,
-            list(indices),
+            [idx0, *indices[1:]],
             value,
             dynamic_shared_memory=builder._is_dynamic_shared_memory(array),
         )
@@ -1740,30 +1608,21 @@ def lower_array_tuple_getitem(builder: MLIRLower, target, args, kwargs):
     n_indexed = len(tuple_indices)
     n_trailing = source_rank - n_indexed
 
-    error_memref = builder._get_or_create_error_global()
-    zero = arith.constant(result=T.index(), value=0)
-    dims = [memref.dim(array, index_of(i)) for i in range(source_rank)]
-
     offsets, sizes, strides, is_scalar = [], [], [], []
     for i, index in enumerate(tuple_indices):
         match index:
-            case Slice(start=start, stop=stop, step=step):
+            case Slice() as slc:
                 if not isinstance(target_type, types.Array):
                     raise TypeError(
                         f"Target type {target_type} is not an array, but a slice was used to index it"
                     )
-                offsets.append(start)
-                end = stop or dims[i]
-                sizes.append(end - start)
-                strides.append(step or 1)
+                s_start, s_length, s_step = _resolve_slice(builder, slc, array, i)
+                offsets.append(s_start)
+                sizes.append(s_length)
+                strides.append(s_step)
                 is_scalar.append(False)
-                if error_memref is not None:
-                    is_not_positive = arith.cmpi(arith.CmpIPredicate.sle, strides[-1], zero)
-                    with scf.if_ctx_manager(is_not_positive):
-                        set_error_code_if_zero(error_memref, KERNEL_ERROR_CODES[ValueError])
-                        scf.yield_([])
-            case int() as i:
-                offsets.append(arith.constant(result=T.index(), value=i))
+            case int() as const_index:
+                offsets.append(arith.constant(result=T.index(), value=const_index))
                 sizes.append(1)
                 strides.append(1)
                 is_scalar.append(True)
@@ -1778,8 +1637,9 @@ def lower_array_tuple_getitem(builder: MLIRLower, target, args, kwargs):
                 )
 
     # Extend with full-extent entries for unindexed trailing dimensions
+    trailing_dims = [memref.dim(array, index_of(n_indexed + i)) for i in range(n_trailing)]
     full_offsets = list(offsets) + [index_of(0)] * n_trailing
-    full_sizes = list(sizes) + [dims[n_indexed + i] for i in range(n_trailing)]
+    full_sizes = list(sizes) + trailing_dims
     full_strides = list(strides) + [index_of(1)] * n_trailing
     full_is_scalar = list(is_scalar) + [False] * n_trailing
 
@@ -1790,9 +1650,7 @@ def lower_array_tuple_getitem(builder: MLIRLower, target, args, kwargs):
                 raise InternalCompilerError(
                     f"Result rank {n_kept} does not match target type ndim {target_type.ndim}"
                 )
-            value = _rank_reducing_subview(
-                array, full_offsets, full_sizes, full_strides, full_is_scalar
-            )
+            value = _strided_view(array, full_offsets, full_sizes, full_strides, full_is_scalar)
             builder.store_var(target, value)
         case types.Number() | types.Boolean():
             value = lowering_utilities.array_element_value_load(

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -1298,6 +1298,16 @@ extern "C" __global__ void
                 )
 
                 return materialize_string_constant(self.mlir_gpu_module, value)
+            case slice():
+                from numba_cuda_mlir.lowering.numpy import Slice
+
+                # Materialize frozen slices like inline slices.
+                return Slice(
+                    *(
+                        self.lower_literal_if_needed(bound) if bound is not None else None
+                        for bound in (value.start, value.stop, value.step)
+                    )
+                )
             case _:
                 return value
 
@@ -2354,7 +2364,14 @@ extern "C" __global__ void
         bytes_op = arith.constant(result=T.index(), value=bytes)
         shm_base = self._get_shared_memory_base()
         total_shared_memory_bytes = self._load_total_shared_memory_bytes()
-        dynamic_shared_bytes = memref.dim(shm_base, index_of(0))
+        # LLVM 7 has no dynamic_smem_size intrinsic; read the sreg directly.
+        smem_size = llvm.inline_asm(
+            T.i32(),
+            [],
+            "mov.u32 $0, %dynamic_smem_size;",
+            "=r",
+        )
+        dynamic_shared_bytes = self.mlir_convert(smem_size, T.index())
         remaining_bytes = arith.subi(lhs=dynamic_shared_bytes, rhs=total_shared_memory_bytes)
         size = arith.divui(lhs=remaining_bytes, rhs=bytes_op)
         view = memref.view(
@@ -2363,7 +2380,6 @@ extern "C" __global__ void
             byte_shift=total_shared_memory_bytes,
             sizes=[size],
         )
-        self._store_total_shared_memory_bytes(dynamic_shared_bytes)
         self._dynamic_shared_memory_values.append(view)
         return view
 

--- a/src/numba_cuda_mlir/optimization/__init__.py
+++ b/src/numba_cuda_mlir/optimization/__init__.py
@@ -192,10 +192,28 @@ def _resolve_shared_bit_storage_float_accesses(module: ir.Module):
         op.operation.erase()
 
 
+def _externalize_dynamic_shared_globals(module: ir.Module):
+    """Give zero-length ``__dynamic_shmem__`` globals external linkage so their size is unknown."""
+    external = ir.Attribute.parse("#llvm.linkage<external>")
+
+    def walk(op):
+        for region in op.regions:
+            for block in region.blocks:
+                for child in block.operations:
+                    if child.operation.name == "llvm.mlir.global":
+                        sym = ir.StringAttr(child.attributes["sym_name"]).value
+                        if sym.startswith("__dynamic_shmem__"):
+                            child.attributes["linkage"] = external
+                    walk(child.operation)
+
+    walk(module.operation)
+
+
 def run_pre_codegen_patterns(module: ir.Module):
     fixup_nvvm_arg_attrs(module.operation)
     _resolve_exotic_float_casts(module)
     _resolve_shared_bit_storage_float_accesses(module)
+    _externalize_dynamic_shared_globals(module)
     # TODO(ajm): why does this not trigger?
     # patterns = RewritePatternSet()
     # patterns.add(gpu.GPUFuncOp, fixup_nvvm_arg_attrs)

--- a/tests/numba_cuda_tests/cudapy/test_sm.py
+++ b/tests/numba_cuda_tests/cudapy/test_sm.py
@@ -282,7 +282,6 @@ class TestSharedMemory(NumbaCUDATestCase):
         expected = np.array([99, 1, 2, 99, 3, 4, 99], dtype=np.int32)
         self._test_dynshared_slice(slice_gaps, arr, expected)
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_dynshared_slice_write_backwards(self):
         # Test writing values into disjoint slices of dynamic shared memory
         # with negative steps
@@ -305,7 +304,6 @@ class TestSharedMemory(NumbaCUDATestCase):
         expected = np.array([2, 1, 4, 3], dtype=np.int32)
         self._test_dynshared_slice(slice_write_backwards, arr, expected)
 
-    @pytest.mark.xfail(True, reason="Typing error")
     def test_dynshared_slice_nonunit_stride(self):
         # Test writing values into slice of dynamic shared memory with
         # non-unit stride
@@ -337,7 +335,6 @@ class TestSharedMemory(NumbaCUDATestCase):
         expected = np.array([1, 99, 2, 99, 3, 99], dtype=np.int32)
         self._test_dynshared_slice(slice_nonunit_stride, arr, expected)
 
-    @pytest.mark.xfail(True, reason="ICE")
     def test_dynshared_slice_nonunit_reverse_stride(self):
         # Test writing values into slice of dynamic shared memory with
         # reverse non-unit stride

--- a/tests/test_dynamic_shared_memory.py
+++ b/tests/test_dynamic_shared_memory.py
@@ -68,3 +68,41 @@ def test_dynamic_shared_after_conditional_runtime_shaped_shared():
     out = cuda.to_device(np.zeros(2, dtype=np.float32))
     k[1, 1, 0, 16](cuda.to_device(flag), cuda.to_device(n_arr), out)
     np.testing.assert_allclose(out.copy_to_host(), np.array([13.0, 21.0], dtype=np.float32))
+
+
+def test_dynamic_shared_runtime_offset_store():
+    """Stores through a runtime-offset view of dynamic shared memory reach memory."""
+
+    @cuda.jit
+    def k(idx, out):
+        shared = cuda.shared.array(0, dtype=float32)
+        shared[0] = 11.0
+        shared[1] = 22.0
+        shared[2] = 33.0
+        view = shared[idx[0] :]
+        view[0] = 99.0
+        for i in range(3):
+            out[i] = shared[i]
+
+    idx = np.array([1], dtype=np.int32)
+    out = cuda.to_device(np.zeros(3, dtype=np.float32))
+    k[1, 1, 0, 16](cuda.to_device(idx), out)
+    np.testing.assert_allclose(out.copy_to_host(), np.array([11.0, 99.0, 33.0], dtype=np.float32))
+
+
+def test_dynamic_shared_arrays_alias():
+    """All shared.array(0) arrays view the same region with the full extent."""
+
+    @cuda.jit
+    def k(out):
+        a = cuda.shared.array(0, dtype=float32)
+        b = cuda.shared.array(0, dtype=float32)
+        a[0] = 11.0
+        b[0] = 22.0
+        out[0] = a[0]
+        out[1] = a.shape[0]
+        out[2] = b.shape[0]
+
+    out = cuda.to_device(np.zeros(3, dtype=np.float32))
+    k[1, 1, 0, 64](out)
+    np.testing.assert_allclose(out.copy_to_host(), np.array([22.0, 16.0, 16.0], dtype=np.float32))

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -104,6 +104,360 @@ def test_slice_axis0_offset_3d_per_block():
     np.testing.assert_array_equal(dst.copy_to_host(), src)
 
 
+FROZEN_SLICE_CASES = (
+    ("empty_tail", slice(4, 4)),
+    ("empty_head", slice(0, 0)),
+    ("head", slice(0, 2)),
+    ("mid", slice(1, 3)),
+    ("full", slice(0, 4)),
+    ("no_stop", slice(2, None)),
+    ("empty_no_stop", slice(4, None)),
+    ("no_bounds", slice(None)),
+    ("step", slice(0, 4, 2)),
+    ("empty_step", slice(4, 4, 2)),
+    ("overlong_step", slice(0, 4, 3)),
+    ("negative_start", slice(-3, 3)),
+    ("negative_stop", slice(1, -1)),
+    ("clamped", slice(0, 9)),
+    ("clamped_empty", slice(9, 9)),
+    ("reversed", slice(None, None, -1)),
+    ("reversed_bounded", slice(3, 1, -1)),
+    ("reversed_step2", slice(None, None, -2)),
+)
+
+
+@pytest.mark.parametrize(
+    "frozen", [c[1] for c in FROZEN_SLICE_CASES], ids=[c[0] for c in FROZEN_SLICE_CASES]
+)
+def test_frozen_slice_of_statically_shaped_array(frozen):
+    n = 4
+
+    @cuda.jit
+    def k(out):
+        scratch = cuda.local.array(n, dtype=np.float32)
+        for i in range(n):
+            scratch[i] = np.float32(i)
+        view = scratch[frozen]
+        out[0] = np.float32(view.shape[0])
+        total = np.float32(0.0)
+        for i in range(view.shape[0]):
+            total += view[i]
+        out[1] = total
+
+    out = np.zeros(2, dtype=np.float32)
+    k[1, 1](out)
+    expected = np.arange(n, dtype=np.float32)[frozen]
+    assert out[0] == expected.shape[0]
+    assert out[1] == expected.sum()
+
+
+def test_inline_constant_slice_of_statically_shaped_array():
+    @cuda.jit
+    def k(out):
+        scratch = cuda.local.array(4, dtype=np.float32)
+        for i in range(4):
+            scratch[i] = np.float32(i)
+        empty = scratch[4:4]
+        out[0] = np.float32(empty.shape[0])
+        stepped = scratch[0:4:2]
+        total = np.float32(0.0)
+        for i in range(stepped.shape[0]):
+            total += stepped[i]
+        out[1] = total
+
+    out = np.zeros(2, dtype=np.float32)
+    k[1, 1](out)
+    assert out[0] == 0
+    assert out[1] == np.arange(4, dtype=np.float32)[0:4:2].sum()
+
+
+def test_frozen_slice_in_tuple_index():
+    frozen = slice(1, 3)
+
+    @cuda.jit
+    def k(out):
+        scratch = cuda.local.array((4, 2), dtype=np.float32)
+        for i in range(4):
+            for j in range(2):
+                scratch[i, j] = np.float32(i * 2 + j)
+        view = scratch[frozen, 1]
+        out[0] = np.float32(view.shape[0])
+        total = np.float32(0.0)
+        for i in range(view.shape[0]):
+            total += view[i]
+        out[1] = total
+
+    out = np.zeros(2, dtype=np.float32)
+    k[1, 1](out)
+    expected = (np.arange(8, dtype=np.float32).reshape(4, 2))[frozen, 1]
+    assert out[0] == expected.shape[0]
+    assert out[1] == expected.sum()
+
+
+def test_frozen_slice_through_device_function():
+    frozen = slice(4, 4)
+
+    @cuda.jit(device=True)
+    def view_len(arr):
+        v = arr[frozen]
+        return np.float32(v.shape[0])
+
+    @cuda.jit
+    def k(out):
+        scratch = cuda.local.array(4, dtype=np.float32)
+        for i in range(4):
+            scratch[i] = np.float32(i)
+        out[0] = view_len(scratch)
+
+    out = np.zeros(1, dtype=np.float32)
+    k[1, 1](out)
+    assert out[0] == 0
+
+
+def test_frozen_slice_setitem():
+    frozen = slice(1, 3)
+
+    @cuda.jit
+    def k(out):
+        scratch = cuda.local.array(4, dtype=np.float32)
+        for i in range(4):
+            scratch[i] = np.float32(0)
+        scratch[frozen] = np.float32(5)
+        for i in range(4):
+            out[i] = scratch[i]
+
+    out = np.zeros(4, dtype=np.float32)
+    k[1, 1](out)
+    expected = np.zeros(4, dtype=np.float32)
+    expected[frozen] = 5
+    assert np.array_equal(out, expected)
+
+
+def test_inline_reversed_slices():
+    @cuda.jit
+    def k(out):
+        scratch = cuda.local.array(4, dtype=np.float32)
+        for i in range(4):
+            scratch[i] = np.float32(i)
+        rev = scratch[::-1]
+        out[0] = np.float32(rev.shape[0])
+        out[1] = rev[0]
+        bounded = scratch[3:1:-1]
+        out[2] = np.float32(bounded.shape[0])
+        out[3] = bounded[1]
+        stepped = scratch[::-2]
+        out[4] = np.float32(stepped.shape[0])
+        out[5] = stepped[1]
+
+    out = np.zeros(6, dtype=np.float32)
+    k[1, 1](out)
+    ref = np.arange(4, dtype=np.float32)
+    assert out[0] == 4 and out[1] == ref[::-1][0]
+    assert out[2] == 2 and out[3] == ref[3:1:-1][1]
+    assert out[4] == 2 and out[5] == ref[::-2][1]
+
+
+def test_empty_slice_preserves_stride():
+    @cuda.jit
+    def k(out):
+        scratch = cuda.local.array(4, dtype=np.float32)
+        out[0] = scratch[4:4:2].strides[0]
+        out[1] = scratch[1:1:-2].strides[0]
+
+    out = np.zeros(2, dtype=np.int64)
+    k[1, 1](out)
+    assert np.array_equal(out, np.array([8, -8], dtype=np.int64))
+
+
+RUNTIME_BOUNDS_CASES = (
+    ("basic", 1, 3),
+    ("negative_start", -3, 3),
+    ("negative_stop", 1, -1),
+    ("clamped", 0, 9),
+    ("empty", 3, 1),
+    ("empty_oob", 9, 9),
+    ("negative_empty", -1, -3),
+)
+
+
+@pytest.mark.parametrize(
+    "start,stop",
+    [c[1:] for c in RUNTIME_BOUNDS_CASES],
+    ids=[c[0] for c in RUNTIME_BOUNDS_CASES],
+)
+def test_runtime_slice_bounds(start, stop):
+    @cuda.jit
+    def k(arr, out, i, j):
+        view = arr[i:j]
+        out[0] = np.float32(view.shape[0])
+        total = np.float32(0.0)
+        for t in range(view.shape[0]):
+            total += view[t]
+        out[1] = total
+
+    arr = np.arange(4, dtype=np.float32)
+    out = np.zeros(2, dtype=np.float32)
+    k[1, 1](arr, out, start, stop)
+    expected = arr[start:stop]
+    assert out[0] == expected.shape[0]
+    assert out[1] == expected.sum()
+
+
+@pytest.mark.parametrize(
+    "step",
+    [1, 2, 3, -1, -2, np.iinfo(np.intp).max, np.iinfo(np.intp).min],
+    ids=lambda s: f"step{s}",
+)
+def test_runtime_slice_step(step):
+    @cuda.jit
+    def k(arr, out, s):
+        view = arr[::s]
+        out[0] = np.float32(view.shape[0])
+        total = np.float32(0.0)
+        for t in range(view.shape[0]):
+            total += view[t]
+        out[1] = total
+
+    arr = np.arange(5, dtype=np.float32)
+    out = np.zeros(2, dtype=np.float32)
+    k[1, 1](arr, out, step)
+    expected = arr[::step]
+    assert out[0] == expected.shape[0]
+    assert out[1] == expected.sum()
+
+
+def test_constant_intp_min_step_on_dynamic_source():
+    step = np.iinfo(np.intp).min
+
+    @cuda.jit
+    def k(arr, out):
+        view = arr[::step]
+        out[0] = view.shape[0]
+        out[1] = view[0]
+
+    arr = np.arange(5, dtype=np.int64)
+    out = np.zeros(2, dtype=np.int64)
+    k[1, 1](arr, out)
+    assert np.array_equal(out, np.array([1, 4], dtype=np.int64))
+
+
+def test_runtime_stepped_slice_inexact_length():
+    @cuda.jit
+    def k(arr, out, i, j):
+        view = arr[i:j:2]
+        out[0] = np.float32(view.shape[0])
+
+    arr = np.arange(4, dtype=np.float32)
+    out = np.zeros(1, dtype=np.float32)
+    k[1, 1](arr, out, 0, 3)
+    assert out[0] == 2
+
+
+def test_constant_zero_step_is_a_compile_error():
+    @cuda.jit
+    def k(arr, out):
+        view = arr[::0]
+        out[0] = np.float32(view.shape[0])
+
+    arr = np.arange(4, dtype=np.float32)
+    out = np.zeros(1, dtype=np.float32)
+    with pytest.raises(ValueError, match="slice step cannot be zero"):
+        k[1, 1](arr, out)
+
+
+def test_runtime_zero_step_raises_value_error():
+    @cuda.jit(debug=True, opt=False)
+    def k(arr, out, s):
+        view = arr[::s]
+        out[0] = np.float32(view.shape[0])
+
+    arr = np.arange(4, dtype=np.float32)
+    out = np.zeros(1, dtype=np.float32)
+    with pytest.raises(ValueError):
+        k[1, 1](arr, out, 0)
+
+
+def test_thread_index_derived_slice():
+    @cuda.jit
+    def k(arr, out):
+        i = cuda.threadIdx.x
+        view = arr[i:]
+        out[i] = np.float32(view.shape[0])
+
+    arr = np.arange(8, dtype=np.float32)
+    out = np.zeros(8, dtype=np.float32)
+    k[1, 8](arr, out)
+    assert np.array_equal(out, np.arange(8, 0, -1, dtype=np.float32))
+
+
+def test_overflowed_nonnegative_expression_bound():
+    # Overflowed bounds wrap like any negative index.
+    @cuda.jit
+    def k(arr, out):
+        start = arr.shape[0] * np.int64(1 << 62)
+        view = arr[start:]
+        out[0] = start
+        out[1] = view.shape[0]
+
+    arr = np.arange(3, dtype=np.int64)
+    out = np.zeros(2, dtype=np.int64)
+    k[1, 1](arr, out)
+    assert out[0] == np.iinfo(np.int64).min // 2
+    assert out[1] == 3
+
+
+def test_dynamic_source_negative_step_unchanged():
+    @cuda.jit
+    def k(arr, out):
+        view = arr[3:1:-1]
+        out[0] = np.float32(view.shape[0])
+        out[1] = view[0]
+        out[2] = view[1]
+
+    arr = np.arange(4, dtype=np.float32)
+    out = np.zeros(3, dtype=np.float32)
+    k[1, 1](arr, out)
+    assert out[0] == 2
+    assert out[1] == 3
+    assert out[2] == 2
+
+
+def test_static_partial_index():
+    @cuda.jit
+    def k(out):
+        scratch = cuda.local.array((4, 2), dtype=np.float32)
+        for i in range(4):
+            for j in range(2):
+                scratch[i, j] = np.float32(i * 2 + j)
+        row = scratch[2]
+        out[0] = row[0]
+        out[1] = row[1]
+
+    out = np.zeros(2, dtype=np.float32)
+    k[1, 1](out)
+    assert out[0] == 4
+    assert out[1] == 5
+
+
+def test_slice_lowers_to_strided_view():
+    @cuda.jit
+    def k(arr, out, s):
+        view = arr[s:]
+        out[0] = view[0]
+
+    arr = np.arange(4, dtype=np.float32)
+    out = np.zeros(1, dtype=np.float32)
+    k[1, 1](arr, out, 1)
+    assert out[0] == 1
+
+    # CHECK-LABEL: gpu.func
+    # CHECK: memref.extract_strided_metadata
+    # CHECK: memref.reinterpret_cast
+    cres = compiler.compile_for(k, arr, out, 1)
+    mlir = cres.mlir_module_str
+    testing.filecheck_with_comments(mlir)
+
+
 if __name__ == "__main__":
     test_incomplete_slice(*INCOMPLETE_SLICE_CASES[0])
     test_slice_axis0_offset_2d(3)


### PR DESCRIPTION
Fixes #262.

Slice bounds are passed through a single helper which wraps negative bounds, clamps to extent, deals with omitted bounds according to the step sign, and gets an exact length. A constant zero step raises at compile time, runtime zero steps set the kernel error code. Sliced and integer-indexed views get built with memref.extract_strided_metadata and memref.reinterpret_cast on the parent array's offset and strides instead of memref.subview, which can't express negative strides. strides reads the parent's real strides instead of assuming that the parent is C-contiguous.

Dynamic shared memory sizes its region from the %dynamic_smem_size register as numba-cuda does, so slices can get clamped to the real extent. Every shared.array(0) view aliases the whole region. `__dynamic_shmem__` globals get external linkage before codegen to stop stores getting optimised out.

Three dynamic-shared xfails in test_sm.py change to passing, 47 test_slicing.py tests added and passing, 38 of which fail on main. 2 test_dynamic_shared_memory.py tests added, both of which fail on main.
