### PR TITLE
Support destructuring targets in consteval loop unrolling

### DIFF
--- a/src/numba_cuda_mlir/ast_transforms/consteval.py
+++ b/src/numba_cuda_mlir/ast_transforms/consteval.py
@@ -43,15 +43,15 @@ class TargetOptionsReplacer(ast.NodeTransformer):
 
 
 class VariableReplacer(ast.NodeTransformer):
-    """Replace a variable name with a constant value throughout an AST."""
+    """Replace a variable name with an expression throughout an AST."""
 
-    def __init__(self, var_name: str, value):
+    def __init__(self, var_name: str, replacement: ast.expr):
         self.var_name = var_name
-        self.value = value
+        self.replacement = replacement
 
     def visit_Name(self, node: ast.Name) -> ast.AST:
         if node.id == self.var_name:
-            return ast.copy_location(ast.Constant(value=self.value), node)
+            return ast.copy_location(copy.deepcopy(self.replacement), node)
         return node
 
 
@@ -103,6 +103,7 @@ class ConstevalTransformer(ast.NodeTransformer):
         """Combined context: base (globals + closure) plus local constants and param types."""
         ctx = self.base_context.copy()
         ctx.update(self.local_consts)
+        ctx.update(self.stored_values)
         # Add parameter types - these shadow any globals with the same name
         ctx.update(self.param_type_map)
         # Add a resolver for current_target_options()
@@ -220,14 +221,6 @@ class ConstevalTransformer(ast.NodeTransformer):
 
     def _unroll_for_loop(self, node: ast.For) -> list[ast.stmt]:
         """Unroll a for loop with consteval iterator."""
-        # Get the loop variable name
-        if not isinstance(node.target, ast.Name):
-            raise ConstevalError(
-                "Loop unrolling only supports simple variable targets, "
-                f"got {type(node.target).__name__}"
-            )
-        var_name = node.target.id
-
         # Evaluate the iterator
         iter_value = self._eval_expr(node.iter.args[0])
         try:
@@ -244,15 +237,25 @@ class ConstevalTransformer(ast.NodeTransformer):
         for value in items:
             # Save current local_consts state
             saved_consts = self.local_consts.copy()
-            # Add loop variable to local_consts for this iteration
-            self.local_consts[var_name] = value
+            bindings = self._bind_loop_target(node.target, value)
+            # Add loop variables to local_consts for this iteration
+            self.local_consts.update(bindings)
+            replacements = {}
+            for var_name, bound_value in bindings.items():
+                if self._can_be_constant(bound_value):
+                    replacements[var_name] = ast.Constant(value=bound_value)
+                else:
+                    replacements[var_name] = ast.Name(
+                        id=self._store_value(bound_value), ctx=ast.Load()
+                    )
 
             for body_stmt in node.body:
                 # Deep copy the statement
                 stmt_copy = copy.deepcopy(body_stmt)
-                # Replace the loop variable with the constant value
-                replacer = VariableReplacer(var_name, value)
-                stmt_copy = replacer.visit(stmt_copy)
+                # Replace each loop variable with its constant value
+                for var_name, replacement in replacements.items():
+                    replacer = VariableReplacer(var_name, replacement)
+                    stmt_copy = replacer.visit(stmt_copy)
                 ast.fix_missing_locations(stmt_copy)
                 # Process the statement (handles nested constevals)
                 transformed = self._transform_statement(stmt_copy)
@@ -267,6 +270,35 @@ class ConstevalTransformer(ast.NodeTransformer):
         # Note: we ignore the else clause (orelse) since unrolled loops
         # don't have a natural "else" semantic
         return unrolled
+
+    def _bind_loop_target(self, target: ast.expr, value) -> dict[str, object]:
+        """Bind a consteval loop target to a compile-time value."""
+        if isinstance(target, ast.Name):
+            return {target.id: value}
+        if isinstance(target, ast.Starred):
+            raise ConstevalError("Loop unrolling does not support starred targets")
+        if not isinstance(target, (ast.Tuple, ast.List)):
+            raise ConstevalError(
+                "Loop unrolling only supports name, tuple, or list targets, "
+                f"got {type(target).__name__}"
+            )
+
+        try:
+            values = list(value)
+        except TypeError as e:
+            raise ConstevalError(
+                f"Cannot unpack {type(value).__name__} into {ast.unparse(target)}"
+            ) from e
+
+        if len(values) != len(target.elts):
+            raise ConstevalError(
+                f"Cannot unpack {len(values)} values into {ast.unparse(target)}"
+            )
+
+        bindings = {}
+        for element, element_value in zip(target.elts, values):
+            bindings.update(self._bind_loop_target(element, element_value))
+        return bindings
 
     def _is_consteval_with(self, node: ast.With) -> bool:
         """Check if this is a 'with consteval():' block."""

--- a/src/numba_cuda_mlir/ast_transforms/consteval.py
+++ b/src/numba_cuda_mlir/ast_transforms/consteval.py
@@ -221,6 +221,8 @@ class ConstevalTransformer(ast.NodeTransformer):
 
     def _unroll_for_loop(self, node: ast.For) -> list[ast.stmt]:
         """Unroll a for loop with consteval iterator."""
+        self._check_unroll_loop_control(node)
+
         # Evaluate the iterator
         iter_value = self._eval_expr(node.iter.args[0])
         try:
@@ -271,6 +273,38 @@ class ConstevalTransformer(ast.NodeTransformer):
         # don't have a natural "else" semantic
         return unrolled
 
+    def _check_unroll_loop_control(self, node: ast.For) -> None:
+        """Reject loop control statements that would escape an unrolled loop."""
+
+        class LoopControlFinder(ast.NodeVisitor):
+            control = None
+
+            def visit_Break(self, node: ast.Break) -> None:
+                self.control = "break"
+
+            def visit_Continue(self, node: ast.Continue) -> None:
+                self.control = "continue"
+
+            def visit_For(self, node: ast.For) -> None:
+                for stmt in node.orelse:
+                    self.visit(stmt)
+
+            def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+                for stmt in node.orelse:
+                    self.visit(stmt)
+
+            def visit_While(self, node: ast.While) -> None:
+                for stmt in node.orelse:
+                    self.visit(stmt)
+
+        finder = LoopControlFinder()
+        for stmt in node.body:
+            finder.visit(stmt)
+        if finder.control:
+            raise ConstevalError(
+                f"Loop unrolling does not support {finder.control} statements"
+            )
+
     def _bind_loop_target(self, target: ast.expr, value) -> dict[str, object]:
         """Bind a consteval loop target to a compile-time value."""
         if isinstance(target, ast.Name):
@@ -291,7 +325,10 @@ class ConstevalTransformer(ast.NodeTransformer):
             ) from e
 
         if len(values) != len(target.elts):
-            raise ConstevalError(f"Cannot unpack {len(values)} values into {ast.unparse(target)}")
+            direction = "not enough" if len(values) < len(target.elts) else "too many"
+            raise ConstevalError(
+                f"{direction} values to unpack (expected {len(target.elts)}, got {len(values)})"
+            )
 
         bindings = {}
         for element, element_value in zip(target.elts, values):

--- a/src/numba_cuda_mlir/ast_transforms/consteval.py
+++ b/src/numba_cuda_mlir/ast_transforms/consteval.py
@@ -291,9 +291,7 @@ class ConstevalTransformer(ast.NodeTransformer):
             ) from e
 
         if len(values) != len(target.elts):
-            raise ConstevalError(
-                f"Cannot unpack {len(values)} values into {ast.unparse(target)}"
-            )
+            raise ConstevalError(f"Cannot unpack {len(values)} values into {ast.unparse(target)}")
 
         bindings = {}
         for element, element_value in zip(target.elts, values):

--- a/src/numba_cuda_mlir/ast_transforms/consteval.py
+++ b/src/numba_cuda_mlir/ast_transforms/consteval.py
@@ -301,9 +301,7 @@ class ConstevalTransformer(ast.NodeTransformer):
         for stmt in node.body:
             finder.visit(stmt)
         if finder.control:
-            raise ConstevalError(
-                f"Loop unrolling does not support {finder.control} statements"
-            )
+            raise ConstevalError(f"Loop unrolling does not support {finder.control} statements")
 
     def _bind_loop_target(self, target: ast.expr, value) -> dict[str, object]:
         """Bind a consteval loop target to a compile-time value."""

--- a/src/numba_cuda_mlir/cuda/__init__.pyi
+++ b/src/numba_cuda_mlir/cuda/__init__.pyi
@@ -15,8 +15,10 @@ def literal_unroll(value: Any) -> Any:
     """
     Unroll a loop at compile time.
 
-    Wrap your range in a loop:
+    For compile-time range unrolling, use ``consteval`` from
+    ``cuda.experimental``:
 
-        >>> for i in cuda.literal_unroll(range(10)):
+        >>> from numba_cuda_mlir.cuda.experimental import consteval
+        >>> for i in consteval(range(10)):
         ...     array[i] = i
     """

--- a/src/numba_cuda_mlir/cuda/experimental/__init__.py
+++ b/src/numba_cuda_mlir/cuda/experimental/__init__.py
@@ -49,6 +49,11 @@ def consteval(value=None):
 
         x = consteval(GLOBAL_CONST * 2)
 
+    Usage in a loop (unrolls each compile-time iteration)::
+
+        for i in consteval(range(10)):
+            array[i] = i
+
     Usage as context manager (executes block at compile time)::
 
         with consteval():

--- a/tests/ast_transforms/test_loop_unroll.py
+++ b/tests/ast_transforms/test_loop_unroll.py
@@ -93,6 +93,83 @@ def test_unroll_tuple_runs():
     assert all(result == 15.0)
 
 
+def test_unroll_tuple_target():
+    """Test loop unrolling with a tuple target."""
+    PAIRS = ((0, 10), (1, 20), (2, 30))
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        for idx, val in consteval(PAIRS):
+            arr[idx] = float(val)
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert "arr[0] = float(10)" in source
+    assert "arr[1] = float(20)" in source
+    assert "arr[2] = float(30)" in source
+    assert "for idx, val in" not in source
+
+
+def test_unroll_recursive_tuple_list_target():
+    """Test loop unrolling with recursive tuple and list targets."""
+    ITEMS = ((0, [1, 2]), (1, [3, 4]))
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        for idx, (lhs, rhs) in consteval(ITEMS):
+            value = consteval(idx + lhs + rhs)
+            arr[idx] = float(value)
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert "value = 3" in source
+    assert "value = 8" in source
+    assert "arr[0] = float(value)" in source
+    assert "arr[1] = float(value)" in source
+
+
+def test_unroll_tuple_target_with_complex_value():
+    """Test loop unrolling evaluates non-literal target values at compile time."""
+    ITEMS = ((0, [1, 2]),)
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        for idx, values in consteval(ITEMS):
+            value = consteval(values[0])
+            arr[idx] = float(value)
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert "value = 1" in source
+    assert "arr[0] = float(value)" in source
+
+
+def test_unroll_tuple_target_invalid_unpacking_raises():
+    """Test that tuple targets require an exact number of values."""
+    ITEMS = ((0,),)
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        for idx, val in consteval(ITEMS):
+            arr[idx] = float(val)
+
+    with pytest.raises(ConstevalError, match="Cannot unpack 1 values into"):
+        kernel.compile("void(float32[:])")
+
+
+def test_unroll_starred_target_raises():
+    """Test that starred loop targets are rejected explicitly."""
+    ITEMS = ((0, 1),)
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        for idx, *values in consteval(ITEMS):
+            arr[idx] = float(values[0])
+
+    with pytest.raises(ConstevalError, match="does not support starred targets"):
+        kernel.compile("void(float32[:])")
+
+
 def test_unroll_list():
     """Test loop unrolling with a list."""
     ITEMS = [10, 20, 30]

--- a/tests/ast_transforms/test_loop_unroll.py
+++ b/tests/ast_transforms/test_loop_unroll.py
@@ -153,9 +153,7 @@ def test_unroll_tuple_target_invalid_unpacking_raises():
         for idx, val in consteval(ITEMS):
             arr[idx] = float(val)
 
-    with pytest.raises(
-        ConstevalError, match="not enough values to unpack \(expected 2, got 1\)"
-    ):
+    with pytest.raises(ConstevalError, match="not enough values to unpack \(expected 2, got 1\)"):
         kernel.compile("void(float32[:])")
 
 

--- a/tests/ast_transforms/test_loop_unroll.py
+++ b/tests/ast_transforms/test_loop_unroll.py
@@ -153,7 +153,9 @@ def test_unroll_tuple_target_invalid_unpacking_raises():
         for idx, val in consteval(ITEMS):
             arr[idx] = float(val)
 
-    with pytest.raises(ConstevalError, match="Cannot unpack 1 values into"):
+    with pytest.raises(
+        ConstevalError, match="not enough values to unpack \(expected 2, got 1\)"
+    ):
         kernel.compile("void(float32[:])")
 
 
@@ -168,6 +170,43 @@ def test_unroll_starred_target_raises():
 
     with pytest.raises(ConstevalError, match="does not support starred targets"):
         kernel.compile("void(float32[:])")
+
+
+def test_unroll_loop_control_raises():
+    """Test that unrolled loops reject break and continue statements."""
+
+    @numba_cuda_mlir.cuda.jit
+    def break_kernel(arr):
+        for i in consteval(range(2)):
+            break
+
+    with pytest.raises(ConstevalError, match="does not support break statements"):
+        break_kernel.compile("void(float32[:])")
+
+    @numba_cuda_mlir.cuda.jit
+    def continue_kernel(arr):
+        for i in consteval(range(2)):
+            continue
+
+    with pytest.raises(ConstevalError, match="does not support continue statements"):
+        continue_kernel.compile("void(float32[:])")
+
+
+def test_unroll_preserves_nested_loop_control():
+    """Test that loop control in nested runtime loops remains valid."""
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        for i in consteval(range(2)):
+            for j in range(2):
+                if j:
+                    continue
+                arr[i] = float(j)
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert "for j in range(2):" in source
+    assert "continue" in source
 
 
 def test_unroll_list():


### PR DESCRIPTION
It covers tuple/list targets, recursive unpacking, stored non-literal values, and explicit invalid-unpacking errors.