### PR TITLE
Support dtype type and kind attributes

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -2653,6 +2653,14 @@ extern "C" __global__ void
             self.store_var(target, const)
             return
 
+        if isinstance(value_type, types.DType) and attr == "type":
+            self.store_var(target, self._materialize_type_token(target_type))
+            return
+
+        if isinstance(value_type, types.DType) and attr == "kind":
+            self.store_var(target, target_type.literal_value)
+            return
+
         if (field_idx := self._get_struct_field_index(value_type, attr)) is not None:
             struct_val = self.load_var(value)
             result = llvm.extractvalue(

--- a/tests/test_dtype_attributes.py
+++ b/tests/test_dtype_attributes.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+
+from numba_cuda_mlir import cuda
+
+
+def test_captured_dtype_type_attribute():
+    idx_dtype = np.dtype(np.int64)
+
+    @cuda.jit
+    def kernel(dst):
+        i = cuda.grid(1)
+        if i < dst.size:
+            dst[i] = idx_dtype.type(0) if i == 0 else i
+
+    dst = np.zeros(4, dtype=np.int64)
+    kernel[1, 32](dst)
+    np.testing.assert_array_equal(dst, [0, 1, 2, 3])
+
+
+def test_captured_dtype_kind_attribute():
+    int_dtype = np.dtype(np.int64)
+    float_dtype = np.dtype(np.float64)
+
+    @cuda.jit
+    def kernel(dst):
+        dst[0] = int_dtype.kind == "i"
+        dst[1] = float_dtype.kind == "f"
+
+    dst = np.zeros(2, dtype=np.bool_)
+    kernel[1, 1](dst)
+    np.testing.assert_array_equal(dst, [True, True])


### PR DESCRIPTION
Lower captured dtype .type as the existing compile-time type-token representation and .kind as its typed string literal in MLIR lowering.

Cover integer and floating dtype closures in tests/test_dtype_attributes.py.