### PR TITLE
Support static dtype metadata in device code

### DIFF
--- a/src/numba_cuda_mlir/lowering/builtins.py
+++ b/src/numba_cuda_mlir/lowering/builtins.py
@@ -758,6 +758,13 @@ def operator_is_none_lower(builder, target, args, kwargs):
     builder.store_var(target, result)
 
 
+@lower(operator.is_, types.BaseTuple, types.NoneType)
+@lower(operator.is_, types.NoneType, types.BaseTuple)
+def operator_is_tuple_none_lower(builder, target, args, kwargs):
+    result = arith.constant(result=ir.IntegerType.get_signless(1), value=False)
+    builder.store_var(target, result)
+
+
 @lower(operator.is_, types.NoneType, types.NoneType)
 def operator_is_none_none_lower(builder, target, args, kwargs):
     """Lower 'None is None' - always True."""
@@ -810,6 +817,13 @@ def operator_is_bool_literal_lower(builder, target, args, kwargs):
 @lower(operator.is_not, types.Number, types.NoneType)
 @lower(operator.is_not, types.NoneType, types.Number)
 def operator_is_not_none_lower(builder, target, args, kwargs):
+    result = arith.constant(result=ir.IntegerType.get_signless(1), value=True)
+    builder.store_var(target, result)
+
+
+@lower(operator.is_not, types.BaseTuple, types.NoneType)
+@lower(operator.is_not, types.NoneType, types.BaseTuple)
+def operator_is_not_tuple_none_lower(builder, target, args, kwargs):
     result = arith.constant(result=ir.IntegerType.get_signless(1), value=True)
     builder.store_var(target, result)
 

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -2536,6 +2536,20 @@ extern "C" __global__ void
             return self._zero_value_for_type(self.get_mlir_type(target_type.dtype))
         raise InternalCompilerError(f"Cannot materialize type token for {target_type}.")
 
+    def _materialize_static_dtype_attribute(self, target_type):
+        if isinstance(target_type, types.DTypeSpec):
+            return self._materialize_type_token(target_type)
+        if isinstance(target_type, types.NoneType):
+            return ir.NoneType.get()
+        if isinstance(target_type, types.BaseTuple):
+            return tuple(
+                self._materialize_static_dtype_attribute(element_type)
+                for element_type in self._tuple_element_types(target_type)
+            )
+        if isinstance(target_type, types.Literal):
+            return self.lower_literal_if_needed(target_type.literal_value, target_type)
+        raise InternalCompilerError(f"Cannot materialize static dtype attribute {target_type}.")
+
     def _zero_value_for_type(self, mlir_type):
         if isinstance(mlir_type, (ir.IntegerType, ir.IndexType)):
             return arith.constant(result=mlir_type, value=0)
@@ -2657,8 +2671,24 @@ extern "C" __global__ void
             self.store_var(target, self._materialize_type_token(target_type))
             return
 
-        if isinstance(value_type, types.DType) and attr == "kind":
-            self.store_var(target, target_type.literal_value)
+        if isinstance(value_type, types.DType) and attr in {
+            "alignment",
+            "base",
+            "byteorder",
+            "char",
+            "hasobject",
+            "isalignedstruct",
+            "isbuiltin",
+            "isnative",
+            "itemsize",
+            "kind",
+            "name",
+            "names",
+            "num",
+            "shape",
+            "str",
+        }:
+            self.store_var(target, self._materialize_static_dtype_attribute(target_type))
             return
 
         if (field_idx := self._get_struct_field_index(value_type, attr)) is not None:

--- a/src/numba_cuda_mlir/numba_cuda/typing/arraydecl.py
+++ b/src/numba_cuda_mlir/numba_cuda/typing/arraydecl.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 
 from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir.numba_cuda import utils
+from numba_cuda_mlir.numba_cuda.np import numpy_support
 from numba_cuda_mlir.numba_cuda.typing.templates import (
     AttributeTemplate,
     AbstractTemplate,
@@ -568,6 +569,14 @@ class ArrayAttribute(AttributeTemplate):
 class DTypeAttr(AttributeTemplate):
     key = types.DType
 
+    @staticmethod
+    def _dtype(ary):
+        return numpy_support.as_dtype(ary.dtype)
+
+    @classmethod
+    def _literal_attr(cls, ary, attr):
+        return types.literal(getattr(cls._dtype(ary), attr))
+
     def resolve_type(self, ary):
         # Wrap the numeric type in NumberClass
         return types.NumberClass(ary.dtype)
@@ -580,6 +589,51 @@ class DTypeAttr(AttributeTemplate):
         else:
             return None  # other types not supported yet
         return types.StringLiteral(val)
+
+    def resolve_itemsize(self, ary):
+        return self._literal_attr(ary, "itemsize")
+
+    def resolve_num(self, ary):
+        return self._literal_attr(ary, "num")
+
+    def resolve_alignment(self, ary):
+        return self._literal_attr(ary, "alignment")
+
+    def resolve_isbuiltin(self, ary):
+        return self._literal_attr(ary, "isbuiltin")
+
+    def resolve_hasobject(self, ary):
+        return self._literal_attr(ary, "hasobject")
+
+    def resolve_isalignedstruct(self, ary):
+        return self._literal_attr(ary, "isalignedstruct")
+
+    def resolve_isnative(self, ary):
+        return self._literal_attr(ary, "isnative")
+
+    def resolve_char(self, ary):
+        return self._literal_attr(ary, "char")
+
+    def resolve_name(self, ary):
+        return self._literal_attr(ary, "name")
+
+    def resolve_str(self, ary):
+        return self._literal_attr(ary, "str")
+
+    def resolve_byteorder(self, ary):
+        return self._literal_attr(ary, "byteorder")
+
+    def resolve_names(self, ary):
+        names = self._dtype(ary).names
+        if names is None:
+            return types.none
+        return types.Tuple(tuple(types.literal(name) for name in names))
+
+    def resolve_shape(self, ary):
+        return types.Tuple(tuple(types.literal(size) for size in self._dtype(ary).shape))
+
+    def resolve_base(self, ary):
+        return types.DType(numpy_support.from_dtype(self._dtype(ary).base))
 
 
 @infer

--- a/tests/test_dtype_static_attributes.py
+++ b/tests/test_dtype_static_attributes.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+
+from numba_cuda_mlir import cuda
+
+
+def test_captured_dtype_scalar_metadata():
+    int_dtype = np.dtype(np.int32)
+    float_dtype = np.dtype(np.float64)
+
+    @cuda.jit
+    def kernel(out):
+        out[0] = int_dtype.itemsize
+        out[1] = int_dtype.num
+        out[2] = int_dtype.alignment
+        out[3] = int_dtype.isbuiltin
+        out[4] = int_dtype.hasobject
+        out[5] = int_dtype.isalignedstruct
+        out[6] = int_dtype.isnative
+        out[7] = int_dtype.char == "i"
+        out[8] = int_dtype.name == "int32"
+        out[9] = int_dtype.str == "<i4"
+        out[10] = int_dtype.byteorder == "="
+        out[11] = float_dtype.kind == "f"
+        out[12] = int_dtype.base.itemsize
+        out[13] = int_dtype.names is None
+        out[14] = len(int_dtype.shape)
+
+    out = np.zeros(15, dtype=np.int64)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, [4, 5, 4, 1, 0, 0, 1, 1, 1, 1, 1, 1, 4, 1, 0])
+
+
+def test_captured_dtype_structured_metadata():
+    record_dtype = np.dtype([("x", np.int32), ("y", np.float64)])
+    subarray_dtype = np.dtype((np.int32, (2, 3)))
+
+    @cuda.jit
+    def kernel(out):
+        out[0] = record_dtype.names[0] == "x"
+        out[1] = record_dtype.names[1] == "y"
+        out[2] = subarray_dtype.shape[0]
+        out[3] = subarray_dtype.shape[1]
+        out[4] = subarray_dtype.base.itemsize
+
+    out = np.zeros(5, dtype=np.int64)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, [1, 1, 2, 3, 4])

--- a/tests/test_dtype_static_attributes.py
+++ b/tests/test_dtype_static_attributes.py
@@ -67,7 +67,9 @@ def test_captured_dtype_structured_metadata():
         out[2] = subarray_dtype.shape[0]
         out[3] = subarray_dtype.shape[1]
         out[4] = subarray_dtype.base.itemsize
+        out[5] = record_dtype.names is None
+        out[6] = record_dtype.names is not None
 
-    out = np.zeros(5, dtype=np.int64)
+    out = np.zeros(7, dtype=np.int64)
     kernel[1, 1](out)
-    np.testing.assert_array_equal(out, [1, 1, 2, 3, 4])
+    np.testing.assert_array_equal(out, [1, 1, 2, 3, 4, 0, 1])

--- a/tests/test_dtype_static_attributes.py
+++ b/tests/test_dtype_static_attributes.py
@@ -8,6 +8,11 @@ from numba_cuda_mlir import cuda
 def test_captured_dtype_scalar_metadata():
     int_dtype = np.dtype(np.int32)
     float_dtype = np.dtype(np.float64)
+    int_char = int_dtype.char
+    int_name = int_dtype.name
+    int_str = int_dtype.str
+    int_byteorder = int_dtype.byteorder
+    float_kind = float_dtype.kind
 
     @cuda.jit
     def kernel(out):
@@ -18,18 +23,37 @@ def test_captured_dtype_scalar_metadata():
         out[4] = int_dtype.hasobject
         out[5] = int_dtype.isalignedstruct
         out[6] = int_dtype.isnative
-        out[7] = int_dtype.char == "i"
-        out[8] = int_dtype.name == "int32"
-        out[9] = int_dtype.str == "<i4"
-        out[10] = int_dtype.byteorder == "="
-        out[11] = float_dtype.kind == "f"
+        out[7] = int_dtype.char == int_char
+        out[8] = int_dtype.name == int_name
+        out[9] = int_dtype.str == int_str
+        out[10] = int_dtype.byteorder == int_byteorder
+        out[11] = float_dtype.kind == float_kind
         out[12] = int_dtype.base.itemsize
         out[13] = int_dtype.names is None
         out[14] = len(int_dtype.shape)
 
     out = np.zeros(15, dtype=np.int64)
     kernel[1, 1](out)
-    np.testing.assert_array_equal(out, [4, 5, 4, 1, 0, 0, 1, 1, 1, 1, 1, 1, 4, 1, 0])
+    np.testing.assert_array_equal(
+        out,
+        [
+            int_dtype.itemsize,
+            int_dtype.num,
+            int_dtype.alignment,
+            int_dtype.isbuiltin,
+            int_dtype.hasobject,
+            int_dtype.isalignedstruct,
+            int_dtype.isnative,
+            1,
+            1,
+            1,
+            1,
+            1,
+            int_dtype.base.itemsize,
+            1,
+            0,
+        ],
+    )
 
 
 def test_captured_dtype_structured_metadata():


### PR DESCRIPTION
Resolve dtype scalar, string, and structural metadata attributes as compile-time literals or type tokens in MLIR lowering.

Cover scalar, record, and subarray dtype metadata access.

This closes @267.