### PR TITLE
Keep array arguments in DWARF

### DIFF
--- a/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
@@ -139,6 +139,7 @@ public:
                                 unsigned numIdx, const char *name);
   LLVMValueRef buildStructGEP(LLVMValueRef ptr, unsigned idx,
                               const char *name);
+  void setVolatile(LLVMValueRef memAccessInst, bool isVolatile);
 
   // --- Atomics ---
   LLVMValueRef buildAtomicRMW(LLVMAtomicRMWBinOp op, LLVMValueRef ptr,
@@ -225,10 +226,53 @@ public:
   LLVMMetadataRef createDIBasicType(const char *name, size_t nameLen,
                                     uint64_t sizeInBits,
                                     LLVMDWARFTypeEncoding encoding);
+  LLVMMetadataRef createDIPointerType(LLVMMetadataRef pointeeTy,
+                                      uint64_t sizeInBits,
+                                      uint32_t alignInBits,
+                                      unsigned addressSpace, const char *name,
+                                      size_t nameLen);
+  LLVMMetadataRef createDIStructType(LLVMMetadataRef scope, const char *name,
+                                     size_t nameLen, LLVMMetadataRef file,
+                                     unsigned lineNo, uint64_t sizeInBits,
+                                     uint32_t alignInBits,
+                                     LLVMMetadataRef *elements,
+                                     unsigned numElements);
+  LLVMMetadataRef createDIUnionType(LLVMMetadataRef scope, const char *name,
+                                    size_t nameLen, LLVMMetadataRef file,
+                                    unsigned lineNo, uint64_t sizeInBits,
+                                    uint32_t alignInBits,
+                                    LLVMMetadataRef *elements,
+                                    unsigned numElements);
+  LLVMMetadataRef createDIArrayType(uint64_t sizeInBits, uint32_t alignInBits,
+                                    LLVMMetadataRef elementTy,
+                                    LLVMMetadataRef *subscripts,
+                                    unsigned numSubscripts);
+  LLVMMetadataRef createDIMemberType(LLVMMetadataRef scope, const char *name,
+                                     size_t nameLen, LLVMMetadataRef file,
+                                     unsigned lineNo, uint64_t sizeInBits,
+                                     uint32_t alignInBits,
+                                     uint64_t offsetInBits,
+                                     LLVMMetadataRef type);
+  LLVMMetadataRef createDISubrange(int64_t lowerBound, int64_t count);
+  /// Temporary forward declaration, used to break cycles while translating
+  /// self-referential composite types; RAUW'd once the real type exists.
+  LLVMMetadataRef createDIForwardDecl(unsigned tag, const char *name,
+                                      size_t nameLen, LLVMMetadataRef scope,
+                                      LLVMMetadataRef file, unsigned lineNo,
+                                      uint64_t sizeInBits,
+                                      uint32_t alignInBits);
+  void replaceMetadataAllUsesWith(LLVMMetadataRef temp,
+                                  LLVMMetadataRef replacement);
   LLVMMetadataRef createDIAutoVariable(LLVMMetadataRef scope, const char *name,
                                        size_t nameLen, LLVMMetadataRef file,
                                        unsigned lineNo, LLVMMetadataRef type,
                                        uint32_t alignInBits);
+  LLVMMetadataRef createDIParameterVariable(LLVMMetadataRef scope,
+                                            const char *name, size_t nameLen,
+                                            unsigned argNo,
+                                            LLVMMetadataRef file,
+                                            unsigned lineNo,
+                                            LLVMMetadataRef type);
   LLVMMetadataRef createDIExpression(int64_t *ops, size_t count);
   LLVMValueRef insertDbgDeclare(LLVMValueRef storage,
                                 LLVMMetadataRef varInfo,
@@ -370,6 +414,7 @@ private:
            LLVMValueRef *, unsigned, const char *)
   LLVM_FN(LLVMValueRef, fnBuildStructGEP, LLVMBuilderRef, LLVMValueRef,
            unsigned, const char *)
+  LLVM_FN(void, fnSetVolatile, LLVMValueRef, LLVMBool)
 
   // Atomics
   LLVM_FN(LLVMValueRef, fnBuildAtomicRMW, LLVMBuilderRef, LLVMAtomicRMWBinOp,
@@ -448,9 +493,34 @@ private:
   LLVM_FN(void, fnSetSubprogram, LLVMValueRef, LLVMMetadataRef)
   LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateBasicType, LLVMDIBuilderRef,
            const char *, size_t, uint64_t, LLVMDWARFTypeEncoding)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderCreatePointerType, LLVMDIBuilderRef,
+           LLVMMetadataRef, uint64_t, uint32_t, unsigned, const char *, size_t)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateStructType, LLVMDIBuilderRef,
+           LLVMMetadataRef, const char *, size_t, LLVMMetadataRef, unsigned,
+           uint64_t, uint32_t, LLVMDIFlags, LLVMMetadataRef, LLVMMetadataRef *,
+           unsigned, unsigned, LLVMMetadataRef, const char *, size_t)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateUnionType, LLVMDIBuilderRef,
+           LLVMMetadataRef, const char *, size_t, LLVMMetadataRef, unsigned,
+           uint64_t, uint32_t, LLVMDIFlags, LLVMMetadataRef *, unsigned,
+           unsigned, const char *, size_t)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateArrayType, LLVMDIBuilderRef,
+           uint64_t, uint32_t, LLVMMetadataRef, LLVMMetadataRef *, unsigned)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateMemberType, LLVMDIBuilderRef,
+           LLVMMetadataRef, const char *, size_t, LLVMMetadataRef, unsigned,
+           uint64_t, uint32_t, uint64_t, LLVMDIFlags, LLVMMetadataRef)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderGetOrCreateSubrange, LLVMDIBuilderRef,
+           int64_t, int64_t)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateReplaceableCompositeType,
+           LLVMDIBuilderRef, unsigned, const char *, size_t, LLVMMetadataRef,
+           LLVMMetadataRef, unsigned, unsigned, uint64_t, uint32_t, LLVMDIFlags,
+           const char *, size_t)
+  LLVM_FN(void, fnMetadataReplaceAllUsesWith, LLVMMetadataRef, LLVMMetadataRef)
   LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateAutoVariable, LLVMDIBuilderRef,
            LLVMMetadataRef, const char *, size_t, LLVMMetadataRef, unsigned,
            LLVMMetadataRef, LLVMBool, LLVMDIFlags, uint32_t)
+  LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateParameterVariable, LLVMDIBuilderRef,
+           LLVMMetadataRef, const char *, size_t, unsigned, LLVMMetadataRef,
+           unsigned, LLVMMetadataRef, LLVMBool, LLVMDIFlags)
   LLVM_FN(LLVMMetadataRef, fnDIBuilderCreateExpression, LLVMDIBuilderRef,
            int64_t *, size_t)
   LLVM_FN(LLVMValueRef, fnDIBuilderInsertDeclareAtEnd, LLVMDIBuilderRef,

--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -93,6 +93,8 @@ private:
   LLVMMetadataRef diSubroutineType = nullptr;
   llvm::StringMap<LLVMMetadataRef> diFileCache;
   LLVMMetadataRef currentSubprogram = nullptr;
+  // Translated DI types; composites cache a forward decl to break recursion.
+  llvm::DenseMap<mlir::Attribute, LLVMMetadataRef> diTypeCache;
 
   LLVMMetadataRef getOrCreateDIFile(llvm::StringRef filename);
   void setDebugLocFromOp(mlir::Operation *op);
@@ -183,6 +185,12 @@ private:
                                bool isDeclare);
 
   LLVMMetadataRef getOrCreateDIType(mlir::LLVM::DITypeAttr typeAttr);
+  LLVMMetadataRef convertDIBasicType(mlir::LLVM::DIBasicTypeAttr attr);
+  LLVMMetadataRef convertDIDerivedType(mlir::LLVM::DIDerivedTypeAttr attr);
+  LLVMMetadataRef convertDICompositeType(mlir::LLVM::DICompositeTypeAttr attr);
+  LLVMMetadataRef convertDISubrange(mlir::LLVM::DISubrangeAttr attr);
+  LLVMMetadataRef opaqueDIType(uint64_t sizeInBits);
+  LLVMMetadataRef diFileOf(mlir::LLVM::DIFileAttr fileAttr);
 
   void emitKernelMetadata(LLVMValueRef fn, mlir::Operation *funcOp);
 

--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -93,8 +93,14 @@ private:
   LLVMMetadataRef diSubroutineType = nullptr;
   llvm::StringMap<LLVMMetadataRef> diFileCache;
   LLVMMetadataRef currentSubprogram = nullptr;
-  // Translated DI types; composites cache a forward decl to break recursion.
+  // Translated DI types.
   llvm::DenseMap<mlir::Attribute, LLVMMetadataRef> diTypeCache;
+  // Composites whose members are still being translated, keyed by their
+  // recursion id, holding the temporary node their self-references resolve to.
+  llvm::DenseMap<mlir::Attribute, LLVMMetadataRef> diRecursionStack;
+  // Recursive composites already translated, keyed by their recursion id, for
+  // self-references reached again after the composite is complete.
+  llvm::DenseMap<mlir::Attribute, LLVMMetadataRef> diRecursiveTypes;
 
   LLVMMetadataRef getOrCreateDIFile(llvm::StringRef filename);
   void setDebugLocFromOp(mlir::Operation *op);

--- a/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
@@ -154,6 +154,7 @@ llvm::Error LLVM70IRBuilder::resolveSymbols() {
   RESOLVE(fnBuildGEP, "LLVMBuildGEP");
   RESOLVE(fnBuildInBoundsGEP, "LLVMBuildInBoundsGEP");
   RESOLVE(fnBuildStructGEP, "LLVMBuildStructGEP");
+  RESOLVE(fnSetVolatile, "LLVMSetVolatile");
 
   // Atomics
   RESOLVE(fnBuildAtomicRMW, "LLVMBuildAtomicRMW");
@@ -213,7 +214,18 @@ llvm::Error LLVM70IRBuilder::resolveSymbols() {
   RESOLVE(fnMetadataAsValue, "LLVMMetadataAsValue");
   RESOLVE(fnSetSubprogram, "LLVMSetSubprogram");
   RESOLVE(fnDIBuilderCreateBasicType, "LLVMDIBuilderCreateBasicType");
+  RESOLVE(fnDIBuilderCreatePointerType, "LLVMDIBuilderCreatePointerType");
+  RESOLVE(fnDIBuilderCreateStructType, "LLVMDIBuilderCreateStructType");
+  RESOLVE(fnDIBuilderCreateUnionType, "LLVMDIBuilderCreateUnionType");
+  RESOLVE(fnDIBuilderCreateArrayType, "LLVMDIBuilderCreateArrayType");
+  RESOLVE(fnDIBuilderCreateMemberType, "LLVMDIBuilderCreateMemberType");
+  RESOLVE(fnDIBuilderGetOrCreateSubrange, "LLVMDIBuilderGetOrCreateSubrange");
+  RESOLVE(fnDIBuilderCreateReplaceableCompositeType,
+          "LLVMDIBuilderCreateReplaceableCompositeType");
+  RESOLVE(fnMetadataReplaceAllUsesWith, "LLVMMetadataReplaceAllUsesWith");
   RESOLVE(fnDIBuilderCreateAutoVariable, "LLVMDIBuilderCreateAutoVariable");
+  RESOLVE(fnDIBuilderCreateParameterVariable,
+          "LLVMDIBuilderCreateParameterVariable");
   RESOLVE(fnDIBuilderCreateExpression, "LLVMDIBuilderCreateExpression");
   RESOLVE(fnDIBuilderInsertDeclareAtEnd, "LLVMDIBuilderInsertDeclareAtEnd");
   RESOLVE(fnDIBuilderInsertDbgValueAtEnd, "LLVMDIBuilderInsertDbgValueAtEnd");
@@ -471,6 +483,10 @@ LLVMValueRef LLVM70IRBuilder::buildArrayAlloca(LLVMTypeRef ty,
 LLVMValueRef LLVM70IRBuilder::buildLoad(LLVMValueRef ptr, const char *n) {
   return fnBuildLoad(builder, ptr, n);
 }
+void LLVM70IRBuilder::setVolatile(LLVMValueRef memAccessInst,
+                                  bool isVolatile) {
+  fnSetVolatile(memAccessInst, isVolatile ? 1 : 0);
+}
 LLVMValueRef LLVM70IRBuilder::buildStore(LLVMValueRef val, LLVMValueRef ptr) {
   return fnBuildStore(builder, val, ptr);
 }
@@ -703,6 +719,62 @@ LLVMMetadataRef LLVM70IRBuilder::createDIBasicType(const char *name,
                                                    LLVMDWARFTypeEncoding enc) {
   return fnDIBuilderCreateBasicType(diBuilder, name, nameLen, sizeInBits, enc);
 }
+LLVMMetadataRef LLVM70IRBuilder::createDIPointerType(
+    LLVMMetadataRef pointeeTy, uint64_t sizeInBits, uint32_t alignInBits,
+    unsigned addressSpace, const char *name, size_t nameLen) {
+  return fnDIBuilderCreatePointerType(diBuilder, pointeeTy, sizeInBits,
+                                      alignInBits, addressSpace, name, nameLen);
+}
+LLVMMetadataRef LLVM70IRBuilder::createDIStructType(
+    LLVMMetadataRef scope, const char *name, size_t nameLen,
+    LLVMMetadataRef file, unsigned lineNo, uint64_t sizeInBits,
+    uint32_t alignInBits, LLVMMetadataRef *elements, unsigned numElements) {
+  return fnDIBuilderCreateStructType(
+      diBuilder, scope, name, nameLen, file, lineNo, sizeInBits, alignInBits,
+      LLVMDIFlagZero, /*DerivedFrom=*/nullptr, elements, numElements,
+      /*RunTimeLang=*/0, /*VTableHolder=*/nullptr, /*UniqueId=*/"", 0);
+}
+LLVMMetadataRef LLVM70IRBuilder::createDIUnionType(
+    LLVMMetadataRef scope, const char *name, size_t nameLen,
+    LLVMMetadataRef file, unsigned lineNo, uint64_t sizeInBits,
+    uint32_t alignInBits, LLVMMetadataRef *elements, unsigned numElements) {
+  return fnDIBuilderCreateUnionType(
+      diBuilder, scope, name, nameLen, file, lineNo, sizeInBits, alignInBits,
+      LLVMDIFlagZero, elements, numElements, /*RunTimeLang=*/0,
+      /*UniqueId=*/"", 0);
+}
+LLVMMetadataRef LLVM70IRBuilder::createDIArrayType(uint64_t sizeInBits,
+                                                   uint32_t alignInBits,
+                                                   LLVMMetadataRef elementTy,
+                                                   LLVMMetadataRef *subscripts,
+                                                   unsigned numSubscripts) {
+  return fnDIBuilderCreateArrayType(diBuilder, sizeInBits, alignInBits,
+                                    elementTy, subscripts, numSubscripts);
+}
+LLVMMetadataRef LLVM70IRBuilder::createDIMemberType(
+    LLVMMetadataRef scope, const char *name, size_t nameLen,
+    LLVMMetadataRef file, unsigned lineNo, uint64_t sizeInBits,
+    uint32_t alignInBits, uint64_t offsetInBits, LLVMMetadataRef type) {
+  return fnDIBuilderCreateMemberType(diBuilder, scope, name, nameLen, file,
+                                     lineNo, sizeInBits, alignInBits,
+                                     offsetInBits, LLVMDIFlagZero, type);
+}
+LLVMMetadataRef LLVM70IRBuilder::createDISubrange(int64_t lowerBound,
+                                                  int64_t count) {
+  return fnDIBuilderGetOrCreateSubrange(diBuilder, lowerBound, count);
+}
+LLVMMetadataRef LLVM70IRBuilder::createDIForwardDecl(
+    unsigned tag, const char *name, size_t nameLen, LLVMMetadataRef scope,
+    LLVMMetadataRef file, unsigned lineNo, uint64_t sizeInBits,
+    uint32_t alignInBits) {
+  return fnDIBuilderCreateReplaceableCompositeType(
+      diBuilder, tag, name, nameLen, scope, file, lineNo, /*RuntimeLang=*/0,
+      sizeInBits, alignInBits, LLVMDIFlagFwdDecl, /*UniqueIdentifier=*/"", 0);
+}
+void LLVM70IRBuilder::replaceMetadataAllUsesWith(LLVMMetadataRef temp,
+                                                 LLVMMetadataRef replacement) {
+  fnMetadataReplaceAllUsesWith(temp, replacement);
+}
 LLVMMetadataRef LLVM70IRBuilder::createDIAutoVariable(
     LLVMMetadataRef scope, const char *name, size_t nameLen,
     LLVMMetadataRef file, unsigned lineNo, LLVMMetadataRef type,
@@ -710,6 +782,13 @@ LLVMMetadataRef LLVM70IRBuilder::createDIAutoVariable(
   return fnDIBuilderCreateAutoVariable(diBuilder, scope, name, nameLen, file,
                                        lineNo, type, /*AlwaysPreserve=*/false,
                                        LLVMDIFlagZero, alignInBits);
+}
+LLVMMetadataRef LLVM70IRBuilder::createDIParameterVariable(
+    LLVMMetadataRef scope, const char *name, size_t nameLen, unsigned argNo,
+    LLVMMetadataRef file, unsigned lineNo, LLVMMetadataRef type) {
+  return fnDIBuilderCreateParameterVariable(
+      diBuilder, scope, name, nameLen, argNo, file, lineNo, type,
+      /*AlwaysPreserve=*/false, LLVMDIFlagZero);
 }
 LLVMMetadataRef LLVM70IRBuilder::createDIExpression(int64_t *ops, size_t count) {
   return fnDIBuilderCreateExpression(diBuilder, ops, count);

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -1211,7 +1211,9 @@ llvm::Error MLIRToLLVM70::translateStoreOp(Operation *op) {
                     .getAddressSpace();
   ptr = b.buildBitCast(ptr, b.ptrTy(elemTy, as), "");
 
-  b.buildStore(val, ptr);
+  LLVMValueRef storeInst = b.buildStore(val, ptr);
+  if (storeOp.getVolatile_())
+    b.setVolatile(storeInst, true);
   return llvm::Error::success();
 }
 
@@ -2509,29 +2511,137 @@ llvm::Error MLIRToLLVM70::translateNVVMOp(Operation *op) {
 // Debug variable declarations
 //===----------------------------------------------------------------------===//
 
+LLVMMetadataRef MLIRToLLVM70::opaqueDIType(uint64_t sizeInBits) {
+  constexpr llvm::StringLiteral name("data");
+  return b.createDIBasicType(name.data(), name.size(), sizeInBits,
+                             llvm::dwarf::DW_ATE_unsigned);
+}
+
+LLVMMetadataRef MLIRToLLVM70::diFileOf(LLVM::DIFileAttr fileAttr) {
+  if (fileAttr && fileAttr.getName())
+    return getOrCreateDIFile(fileAttr.getName().getValue());
+  return getOrCreateDIFile("llvm70_module");
+}
+
+LLVMMetadataRef MLIRToLLVM70::convertDIBasicType(LLVM::DIBasicTypeAttr attr) {
+  llvm::StringRef name = attr.getName() ? attr.getName().getValue() : "";
+  return b.createDIBasicType(name.data(), name.size(), attr.getSizeInBits(),
+                             attr.getEncoding());
+}
+
+LLVMMetadataRef
+MLIRToLLVM70::convertDIDerivedType(LLVM::DIDerivedTypeAttr attr) {
+  LLVMMetadataRef baseType =
+      attr.getBaseType() ? getOrCreateDIType(attr.getBaseType()) : nullptr;
+  llvm::StringRef name = attr.getName() ? attr.getName().getValue() : "";
+  uint64_t size = attr.getSizeInBits();
+
+  switch (attr.getTag()) {
+  case llvm::dwarf::DW_TAG_pointer_type:
+    return b.createDIPointerType(baseType, size ? size : 64,
+                                 attr.getAlignInBits(),
+                                 /*addressSpace=*/0, name.data(), name.size());
+  case llvm::dwarf::DW_TAG_member:
+    return b.createDIMemberType(diCompileUnit, name.data(), name.size(),
+                                diFileOf(attr.getFile()), attr.getLine(), size,
+                                attr.getAlignInBits(), attr.getOffsetInBits(),
+                                baseType);
+  default:
+    return baseType ? baseType : opaqueDIType(size);
+  }
+}
+
+LLVMMetadataRef MLIRToLLVM70::convertDISubrange(LLVM::DISubrangeAttr attr) {
+  int64_t lowerBound = 0;
+  int64_t count = -1;
+  if (auto lb = dyn_cast_or_null<IntegerAttr>(attr.getLowerBound()))
+    lowerBound = lb.getInt();
+  if (auto c = dyn_cast_or_null<IntegerAttr>(attr.getCount()))
+    count = c.getInt();
+  else if (auto ub = dyn_cast_or_null<IntegerAttr>(attr.getUpperBound()))
+    count = ub.getInt() - lowerBound + 1;
+  return b.createDISubrange(lowerBound, count);
+}
+
+LLVMMetadataRef
+MLIRToLLVM70::convertDICompositeType(LLVM::DICompositeTypeAttr attr) {
+  llvm::StringRef name = attr.getName() ? attr.getName().getValue() : "";
+  LLVMMetadataRef diFile = diFileOf(attr.getFile());
+  uint64_t size = attr.getSizeInBits();
+  uint32_t align = static_cast<uint32_t>(attr.getAlignInBits());
+  unsigned tag = attr.getTag();
+
+  if (tag == llvm::dwarf::DW_TAG_array_type) {
+    LLVMMetadataRef elemTy =
+        attr.getBaseType() ? getOrCreateDIType(attr.getBaseType()) : nullptr;
+    if (!elemTy)
+      return opaqueDIType(size);
+    llvm::SmallVector<LLVMMetadataRef> subscripts;
+    for (LLVM::DINodeAttr element : attr.getElements()) {
+      if (auto subrange = dyn_cast<LLVM::DISubrangeAttr>(element))
+        subscripts.push_back(convertDISubrange(subrange));
+    }
+    if (subscripts.empty())
+      subscripts.push_back(b.createDISubrange(0, -1));
+    return b.createDIArrayType(size, align, elemTy, subscripts.data(),
+                               subscripts.size());
+  }
+
+  bool isStructLike = tag == llvm::dwarf::DW_TAG_structure_type ||
+                      tag == llvm::dwarf::DW_TAG_class_type ||
+                      tag == llvm::dwarf::DW_TAG_union_type;
+  if (!isStructLike)
+    return opaqueDIType(size);
+
+  // Create a forward declaration first: translating the members recurses
+  // through getOrCreateDIType and may come back to this same type.
+  LLVMMetadataRef fwdDecl = b.createDIForwardDecl(
+      tag, name.data(), name.size(), diCompileUnit, diFile, attr.getLine(),
+      size, align);
+  diTypeCache[attr] = fwdDecl;
+
+  llvm::SmallVector<LLVMMetadataRef> elements;
+  for (LLVM::DINodeAttr element : attr.getElements()) {
+    if (auto member = dyn_cast<LLVM::DIDerivedTypeAttr>(element)) {
+      if (LLVMMetadataRef converted = getOrCreateDIType(member))
+        elements.push_back(converted);
+    }
+  }
+
+  LLVMMetadataRef composite =
+      tag == llvm::dwarf::DW_TAG_union_type
+          ? b.createDIUnionType(diCompileUnit, name.data(), name.size(), diFile,
+                                attr.getLine(), size, align, elements.data(),
+                                elements.size())
+          : b.createDIStructType(diCompileUnit, name.data(), name.size(),
+                                 diFile, attr.getLine(), size, align,
+                                 elements.data(), elements.size());
+  b.replaceMetadataAllUsesWith(fwdDecl, composite);
+  return composite;
+}
+
 LLVMMetadataRef MLIRToLLVM70::getOrCreateDIType(LLVM::DITypeAttr typeAttr) {
   if (!typeAttr) {
     // Fallback: opaque byte type
     return b.createDIBasicType("byte", 4, 8, llvm::dwarf::DW_ATE_unsigned);
   }
 
-  if (auto basic = dyn_cast<LLVM::DIBasicTypeAttr>(typeAttr)) {
-    llvm::StringRef name = basic.getName() ? basic.getName().getValue() : "";
-    return b.createDIBasicType(name.data(), name.size(), basic.getSizeInBits(),
-                               basic.getEncoding());
-  }
+  auto cached = diTypeCache.find(typeAttr);
+  if (cached != diTypeCache.end())
+    return cached->second;
 
-  if (auto derived = dyn_cast<LLVM::DIDerivedTypeAttr>(typeAttr)) {
-    // For pointer types and other derived types, create a basic type
-    // representing the pointer itself (64-bit address on NVPTX).
-    uint64_t size = derived.getSizeInBits();
-    if (size == 0)
-      size = 64; // NVPTX pointers are 64-bit
-    return b.createDIBasicType("ptr", 3, size, llvm::dwarf::DW_ATE_address);
-  }
+  LLVMMetadataRef result = nullptr;
+  if (auto basic = dyn_cast<LLVM::DIBasicTypeAttr>(typeAttr))
+    result = convertDIBasicType(basic);
+  else if (auto derived = dyn_cast<LLVM::DIDerivedTypeAttr>(typeAttr))
+    result = convertDIDerivedType(derived);
+  else if (auto composite = dyn_cast<LLVM::DICompositeTypeAttr>(typeAttr))
+    result = convertDICompositeType(composite);
+  else
+    result = opaqueDIType(0);
 
-  // Composite or unknown types: fall back to sized opaque type
-  return b.createDIBasicType("data", 4, 0, llvm::dwarf::DW_ATE_unsigned);
+  diTypeCache[typeAttr] = result;
+  return result;
 }
 
 llvm::Error MLIRToLLVM70::translateDbgDeclareOp(Operation *op) {
@@ -2565,9 +2675,12 @@ llvm::Error MLIRToLLVM70::emitDbgIntrinsic(Operation *op, LLVMValueRef val,
   LLVMMetadataRef diType = getOrCreateDIType(varInfo.getType());
   LLVMMetadataRef scope = currentSubprogram ? currentSubprogram : diCompileUnit;
 
+  unsigned argNo = varInfo.getArg();
   LLVMMetadataRef diVar =
-      b.createDIAutoVariable(scope, name.data(), name.size(), diFile, line,
-                              diType, varInfo.getAlignInBits());
+      argNo ? b.createDIParameterVariable(scope, name.data(), name.size(),
+                                          argNo, diFile, line, diType)
+            : b.createDIAutoVariable(scope, name.data(), name.size(), diFile,
+                                     line, diType, varInfo.getAlignInBits());
   LLVMMetadataRef diExpr = b.createDIExpression(nullptr, 0);
 
   auto [filename, opLine, opCol] = extractFileLineCol(op->getLoc());

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -2593,12 +2593,16 @@ MLIRToLLVM70::convertDICompositeType(LLVM::DICompositeTypeAttr attr) {
   if (!isStructLike)
     return opaqueDIType(size);
 
-  // Create a forward declaration first: translating the members recurses
-  // through getOrCreateDIType and may come back to this same type.
-  LLVMMetadataRef fwdDecl = b.createDIForwardDecl(
-      tag, name.data(), name.size(), diCompileUnit, diFile, attr.getLine(),
-      size, align);
-  diTypeCache[attr] = fwdDecl;
+  // A recursive type needs something for its self-references to point at
+  // while its members are being translated.
+  DistinctAttr recId = attr.getRecId();
+  LLVMMetadataRef placeholder = nullptr;
+  if (recId) {
+    placeholder = b.createDIForwardDecl(tag, name.data(), name.size(),
+                                        diCompileUnit, diFile, attr.getLine(),
+                                        size, align);
+    diRecursionStack[recId] = placeholder;
+  }
 
   llvm::SmallVector<LLVMMetadataRef> elements;
   for (LLVM::DINodeAttr element : attr.getElements()) {
@@ -2616,7 +2620,12 @@ MLIRToLLVM70::convertDICompositeType(LLVM::DICompositeTypeAttr attr) {
           : b.createDIStructType(diCompileUnit, name.data(), name.size(),
                                  diFile, attr.getLine(), size, align,
                                  elements.data(), elements.size());
-  b.replaceMetadataAllUsesWith(fwdDecl, composite);
+  if (recId) {
+    // Frees the placeholder, so nothing may hold on to it past this point.
+    b.replaceMetadataAllUsesWith(placeholder, composite);
+    diRecursionStack.erase(recId);
+    diRecursiveTypes[recId] = composite;
+  }
   return composite;
 }
 
@@ -2624,6 +2633,24 @@ LLVMMetadataRef MLIRToLLVM70::getOrCreateDIType(LLVM::DITypeAttr typeAttr) {
   if (!typeAttr) {
     // Fallback: opaque byte type
     return b.createDIBasicType("byte", 4, 8, llvm::dwarf::DW_ATE_unsigned);
+  }
+
+  // A cycle is spelled as a rec-self attribute carrying only the recursion id
+  // of the composite it stands for, so it resolves to that composite rather
+  // than being translated: to its placeholder while the composite is still
+  // being built, to the composite itself afterwards. The placeholder is freed
+  // once the composite is complete, hence no caching here.
+  if (auto composite = dyn_cast<LLVM::DICompositeTypeAttr>(typeAttr)) {
+    if (composite.getIsRecSelf()) {
+      mlir::Attribute recId = composite.getRecId();
+      auto pending = diRecursionStack.find(recId);
+      if (pending != diRecursionStack.end())
+        return pending->second;
+      auto translated = diRecursiveTypes.find(recId);
+      if (translated != diRecursiveTypes.end())
+        return translated->second;
+      return opaqueDIType(composite.getSizeInBits());
+    }
   }
 
   auto cached = diTypeCache.find(typeAttr);
@@ -2640,7 +2667,10 @@ LLVMMetadataRef MLIRToLLVM70::getOrCreateDIType(LLVM::DITypeAttr typeAttr) {
   else
     result = opaqueDIType(0);
 
-  diTypeCache[typeAttr] = result;
+  // Nodes built inside a recursive type get re-uniqued when its placeholder is
+  // replaced, which can free them, so only cache once the type is complete.
+  if (diRecursionStack.empty())
+    diTypeCache[typeAttr] = result;
   return result;
 }
 

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -3294,7 +3294,9 @@ extern "C" __global__ void
         if isinstance(numba_type, types.BaseTuple) and isinstance(value, tuple):
             aggregate = self._materialize_tuple_value(value, numba_type)
             if aggregate is not None:
-                self._emit_dbg_declare(base_name, aggregate, var_attr)
+                self._emit_dbg_declare(
+                    base_name, aggregate, var_attr, volatile=True
+                )
             return
         mlir_value = self._unwrap_mlir_value(value)
         if mlir_value is None:
@@ -3317,7 +3319,9 @@ extern "C" __global__ void
                 case MemRefType():
                     descriptor = self._build_array_debug_descriptor(mlir_value, numba_type)
                     if descriptor is not None:
-                        self._emit_dbg_declare(base_name, descriptor, var_attr)
+                        self._emit_dbg_declare(
+                            base_name, descriptor, var_attr, volatile=True
+                        )
             return
         is_arg = base_name in self._di_builder.arg_names
         is_boolean = isinstance(numba_type, types.Boolean)
@@ -3332,10 +3336,13 @@ extern "C" __global__ void
                 location_expr=self._di_builder.di_expression,
             )
 
-    def _emit_dbg_declare(self, var_name, value, var_attr):
-        """Emit llvm.intr.dbg.declare for a value materialized in stack storage."""
+    def _emit_dbg_declare(self, var_name, value, var_attr, volatile=False):
+        """Emit llvm.intr.dbg.declare for a value materialized in stack storage.
+
+        Pass volatile for aggregate slots: avoid the slot being optimized away.
+        """
         alloca_ptr = self.alloca(value.type)
-        llvm.store(value, alloca_ptr)
+        llvm.store(value, alloca_ptr, volatile_=volatile)
         llvm.intr_dbg_declare(
             alloca_ptr,
             var_attr,

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -3294,9 +3294,7 @@ extern "C" __global__ void
         if isinstance(numba_type, types.BaseTuple) and isinstance(value, tuple):
             aggregate = self._materialize_tuple_value(value, numba_type)
             if aggregate is not None:
-                self._emit_dbg_declare(
-                    base_name, aggregate, var_attr, volatile=True
-                )
+                self._emit_dbg_declare(base_name, aggregate, var_attr, volatile=True)
             return
         mlir_value = self._unwrap_mlir_value(value)
         if mlir_value is None:
@@ -3319,9 +3317,7 @@ extern "C" __global__ void
                 case MemRefType():
                     descriptor = self._build_array_debug_descriptor(mlir_value, numba_type)
                     if descriptor is not None:
-                        self._emit_dbg_declare(
-                            base_name, descriptor, var_attr, volatile=True
-                        )
+                        self._emit_dbg_declare(base_name, descriptor, var_attr, volatile=True)
             return
         is_arg = base_name in self._di_builder.arg_names
         is_boolean = isinstance(numba_type, types.Boolean)

--- a/tests/test_cuda_gdb.py
+++ b/tests/test_cuda_gdb.py
@@ -45,6 +45,12 @@ def _run_under_cuda_gdb(
         line = raw.strip()
         if line:
             ex_args.extend(("-ex", line))
+    # cuda-gdb shells out to cuobjdump to disassemble, and stepping fails
+    # outright against a cuobjdump older than the cubin, so make sure the one
+    # next to cuda-gdb wins over anything else on PATH.
+    env = os.environ.copy()
+    gdb_dir = os.path.dirname(os.path.abspath(CUDA_GDB))
+    env["PATH"] = os.pathsep.join((gdb_dir, env.get("PATH", "")))
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".py", prefix="ncm_gdb_test_", delete=False
     ) as f:
@@ -56,6 +62,7 @@ def _run_under_cuda_gdb(
             capture_output=True,
             text=True,
             timeout=timeout,
+            env=env,
         )
     finally:
         os.unlink(script)
@@ -70,8 +77,9 @@ _KERNEL_SRC = textwrap.dedent("""\
         i = cuda.threadIdx.x
         sum = arg_a + arg_b
         out[i] = sum
+        cuda.syncthreads()
 
-    out = cuda.device_array(1, dtype=np.float32)
+    out = cuda.to_device(np.full(1, -1.0, dtype=np.float32))
     k[1, 1](out, np.float32(1.5), np.float32(2.5))
     cuda.synchronize()
     assert out.copy_to_host()[0] == 4.0, out.copy_to_host()[0]
@@ -90,6 +98,10 @@ def test_cuda_gdb_debug_kernel():
         info args
         info locals
         print sum
+        print out.nitems
+        print out.data[0]
+        next
+        print out.data[0]
         continue
         quit
     """)
@@ -103,10 +115,14 @@ def test_cuda_gdb_debug_kernel():
     testing.filecheck(
         """
         CHECK: CUDA kernel {{[0-9]+}}, grid {{[0-9]+}}, block {{[(][0-9,]+[)]}}, thread {{[(][0-9,]+[)]}}
+        CHECK-DAG: out = {{[{].*}}nitems = 1, itemsize = 4,{{.*}}shape = {1}, strides = {4}{{[}]}}
         CHECK-DAG: arg_b = 2.5
         CHECK-DAG: arg_a = 1.5
         CHECK-DAG: sum = 4
         CHECK: $1 = 4
+        CHECK: $2 = 1
+        CHECK: $3 = -1
+        CHECK: $4 = 4
         """,
         result.stdout,
     )

--- a/tests/test_cuda_gdb.py
+++ b/tests/test_cuda_gdb.py
@@ -80,13 +80,14 @@ _KERNEL_SRC = textwrap.dedent("""\
 
 @requires_cuda_gdb
 def test_cuda_gdb_debug_kernel():
-    """cuda-gdb hits the kernel launch breakpoint and can inspect locals."""
+    """cuda-gdb hits the kernel launch breakpoint and can inspect args and locals."""
     gdb_commands = textwrap.dedent("""\
         set pagination off
         set cuda break_on_launch application
         run
         next
         next
+        info args
         info locals
         print sum
         continue

--- a/tests/test_debuginfo.py
+++ b/tests/test_debuginfo.py
@@ -839,3 +839,35 @@ def test_mlir_scalar_int_arg_type(int_arg, expected_name, size_bits, encoding):
         """,
         mlir,
     )
+
+
+def test_llvm_ir_array_arg_is_parameter_of_descriptor_type():
+    """An array arg is described by its full descriptor type in the LLVM IR."""
+
+    @cuda.jit(debug=True, opt=False)
+    def k(input_arr, output_arr):
+        idx = cuda.grid(1)
+        output_arr[idx] = input_arr[idx] * 2
+
+    sig = (types.int32[:], types.int32[:])
+    k.compile(types.void(*sig))
+    llvm_ir = k.inspect_llvm(sig)
+
+    testing.filecheck(
+        """
+        CHECK: ![[VAR:[0-9]+]] = !DILocalVariable(name: "input_arr", arg: 1,{{.*}}type: ![[TY:[0-9]+]])
+        CHECK: ![[TY]] = {{(distinct )?}}!DICompositeType(tag: DW_TAG_structure_type,{{.*}}size: 448, {{.*}}elements: ![[ELEMS:[0-9]+]])
+        CHECK: ![[ELEMS]] = !{
+        CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "meminfo",{{.*}}size: 64)
+        CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "nitems",{{.*}}offset: 128)
+        CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "itemsize",{{.*}}offset: 192)
+        CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "data",{{.*}}offset: 256)
+        CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "shape",{{.*}}offset: 320)
+        CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "strides",{{.*}}offset: 384)
+        CHECK-DAG: !DIDerivedType(tag: DW_TAG_pointer_type,{{.*}}size: 64
+        CHECK-DAG: !DICompositeType(tag: DW_TAG_array_type,{{.*}}elements: ![[DIMS:[0-9]+]])
+        CHECK-DAG: !DISubrange(count: 1)
+        CHECK-DAG: !DILocalVariable(name: "output_arr", arg: 2,{{.*}}type: ![[TY]])
+        """,
+        llvm_ir,
+    )

--- a/tests/test_debuginfo.py
+++ b/tests/test_debuginfo.py
@@ -3,10 +3,11 @@
 
 import numpy as np
 from enum import IntEnum
+from types import SimpleNamespace
 
 import pytest
 from numba_cuda_mlir import cuda
-from numba_cuda_mlir import types, compiler, testing
+from numba_cuda_mlir import types, compiler, mlir_optimization, testing
 from numba_cuda_mlir.numba_cuda.types.ext_types import bfloat16
 from numba_cuda_mlir.numba_cuda.np import numpy_support
 
@@ -868,6 +869,74 @@ def test_llvm_ir_array_arg_is_parameter_of_descriptor_type():
         CHECK-DAG: !DICompositeType(tag: DW_TAG_array_type,{{.*}}elements: ![[DIMS:[0-9]+]])
         CHECK-DAG: !DISubrange(count: 1)
         CHECK-DAG: !DILocalVariable(name: "output_arr", arg: 2,{{.*}}type: ![[TY]])
+        """,
+        llvm_ir,
+    )
+
+
+# struct Node { int32 value; Node *next; }. MLIR attributes are immutable and
+# uniqued, so #di_node cannot appear inside its own element list; the cycle goes
+# through #di_self instead, a composite carrying nothing but the same
+# recId = distinct[2]<> that #di_node carries. Following "next" leads
+# #di_next -> #di_next_ptr -> #di_self, never back to #di_node itself, so the
+# shared recursion id is all a translator has to reconnect them.
+_RECURSIVE_TYPE_MODULE = """
+#di_file = #llvm.di_file<"test.py" in ".">
+#di_cu = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = Full>
+#di_i32 = #llvm.di_basic_type<tag = DW_TAG_base_type, name = "int32", sizeInBits = 32, encoding = DW_ATE_signed>
+#di_subroutine = #llvm.di_subroutine_type<types = #di_i32>
+#di_subprogram = #llvm.di_subprogram<id = distinct[1]<>, compileUnit = #di_cu, scope = #di_file, name = "rec_kernel", file = #di_file, line = 5, subprogramFlags = "Definition", type = #di_subroutine>
+#di_self = #llvm.di_composite_type<recId = distinct[2]<>, isRecSelf = true>
+#di_next_ptr = #llvm.di_derived_type<tag = DW_TAG_pointer_type, baseType = #di_self, sizeInBits = 64>
+#di_value = #llvm.di_derived_type<tag = DW_TAG_member, name = "value", baseType = #di_i32, sizeInBits = 32>
+#di_next = #llvm.di_derived_type<tag = DW_TAG_member, name = "next", baseType = #di_next_ptr, sizeInBits = 64, offsetInBits = 64>
+#di_node = #llvm.di_composite_type<recId = distinct[2]<>, tag = DW_TAG_structure_type, name = "Node", file = #di_file, line = 3, sizeInBits = 128, elements = #di_value, #di_next>
+#di_var_node = #llvm.di_local_variable<scope = #di_subprogram, name = "node", file = #di_file, line = 5, type = #di_node>
+#di_var_head = #llvm.di_local_variable<scope = #di_subprogram, name = "head", file = #di_file, line = 5, type = #di_next_ptr>
+#loc_fn = loc(fused<#di_subprogram>["test.py":5:0])
+#loc_stmt = loc(fused<#di_subprogram>["test.py":6:0])
+
+module attributes {gpu.container_module} {
+  gpu.module @kernels {
+    llvm.func @rec_kernel(%out: !llvm.ptr<1>) attributes {gpu.kernel} {
+      %one = llvm.mlir.constant(1 : i64) : i64
+      %slot = llvm.alloca %one x !llvm.struct<(i32, ptr)> : (i64) -> !llvm.ptr loc(#loc_stmt)
+      llvm.intr.dbg.declare #di_var_node = %slot : !llvm.ptr loc(#loc_stmt)
+      %head = llvm.alloca %one x !llvm.ptr : (i64) -> !llvm.ptr loc(#loc_stmt)
+      llvm.intr.dbg.declare #di_var_head = %head : !llvm.ptr loc(#loc_stmt)
+      %c = llvm.mlir.constant(42 : i32) : i32
+      llvm.store %c, %out : i32, !llvm.ptr<1> loc(#loc_stmt)
+      llvm.return loc(#loc_stmt)
+    } loc(#loc_fn)
+  }
+}
+"""
+
+
+def test_recursive_type_refers_back_to_itself():
+    """A type that reaches itself survives translation instead of going opaque.
+
+    The "head" variable reaches the cycle without going through the composite,
+    which is the case that regresses if self-references are only resolved while
+    the composite is being translated.
+    """
+    options = {"debug": True, "opt": False}
+    cres = SimpleNamespace(
+        metadata={
+            "mlir_module_optimized": _RECURSIVE_TYPE_MODULE,
+            "targetoptions": options,
+        }
+    )
+    llvm_ir = mlir_optimization.get_llvmir(cres, options)
+
+    testing.filecheck(
+        """
+        CHECK: ![[NODE:[0-9]+]] = {{(distinct )?}}!DICompositeType(tag: DW_TAG_structure_type, name: "Node",{{.*}}size: 128, elements: ![[ELEMS:[0-9]+]])
+        CHECK: ![[ELEMS]] = !{![[VALUE:[0-9]+]], ![[NEXT:[0-9]+]]}
+        CHECK: ![[VALUE]] = !DIDerivedType(tag: DW_TAG_member, name: "value",{{.*}}size: 32)
+        CHECK: ![[NEXT]] = !DIDerivedType(tag: DW_TAG_member, name: "next",{{.*}}baseType: ![[PTR:[0-9]+]], size: 64, offset: 64)
+        CHECK: ![[PTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[NODE]], size: 64
+        CHECK: !DILocalVariable(name: "head",{{.*}}type: ![[PTR]])
         """,
         llvm_ir,
     )


### PR DESCRIPTION
Array arguments were missing from a kernel's DWARF under `debug=True`: no `DW_TAG_formal_parameter` and no descriptor struct.

When emitting full debug info, adding volative store to prevent the aggregate slots of array descriptors from being optimized away, together with the `dbg.declare` even at `opt=0`, by libnvvm.

Also, enhancing the LLVM70 translator with the capability of converting and building parameter di type and composite di type.

A new LLVM IR test is added.

