### PR TITLE
Serialize MLIR target initialization

### DIFF
--- a/src/numba_cuda_mlir/_threading.py
+++ b/src/numba_cuda_mlir/_threading.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+
+
+class _LockedCounter:
+    def __init__(self, start=0):
+        self._value = start
+        self._lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self._lock:
+            value = self._value
+            self._value += 1
+            return value

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -1496,8 +1496,6 @@ class MLIRTarget(TargetDescriptor):
                     except Exception:
                         self._typingctx_initialized = False
                         raise
-                    else:
-                        self._typingctx_initialized = True
 
                 if not self._targetctx_initialized:
                     try:
@@ -1505,12 +1503,12 @@ class MLIRTarget(TargetDescriptor):
                     except Exception:
                         self._targetctx_initialized = False
                         raise
-                    else:
-                        self._targetctx_initialized = True
 
                 from numba_cuda_mlir.numba_cuda.typing.templates import builtin_registry
 
                 self.typing_context.install_registry(builtin_registry)
+                self._typingctx_initialized = True
+                self._targetctx_initialized = True
             finally:
                 self._initializing = False
 

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -1221,10 +1221,9 @@ class MLIRTargetContext(BaseContext):
 
     @override
     def refresh(self):
-        with self._registry_lock:
-            if self._registries_unchanged():
-                return
-            self.load_additional_registries()
+        if self._registries_unchanged():
+            return
+        self.load_additional_registries()
 
     def get_overload_builder(self, fn, sig):
         """Return an MLIR builder for an overloaded function, or None.

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -1462,6 +1462,7 @@ class MLIRTarget(TargetDescriptor):
         self._typingctx_initialized = False
         self._targetctx_initialized = False
         self._initializing = False
+        self._initialization_lock = threading.RLock()
         super().__init__(name)
 
     @property
@@ -1480,34 +1481,37 @@ class MLIRTarget(TargetDescriptor):
     def ensure_initialized(self):
         if self._typingctx_initialized and self._targetctx_initialized:
             return
-        if self._initializing:
-            return
+        with self._initialization_lock:
+            if self._typingctx_initialized and self._targetctx_initialized:
+                return
+            if self._initializing:
+                return
 
-        self._initializing = True
-        try:
-            if not self._typingctx_initialized:
-                try:
-                    self.typing_context.refresh()
-                except Exception:
-                    self._typingctx_initialized = False
-                    raise
-                else:
-                    self._typingctx_initialized = True
+            self._initializing = True
+            try:
+                if not self._typingctx_initialized:
+                    try:
+                        self.typing_context.refresh()
+                    except Exception:
+                        self._typingctx_initialized = False
+                        raise
+                    else:
+                        self._typingctx_initialized = True
 
-            if not self._targetctx_initialized:
-                try:
-                    self.target_context.refresh()
-                except Exception:
-                    self._targetctx_initialized = False
-                    raise
-                else:
-                    self._targetctx_initialized = True
+                if not self._targetctx_initialized:
+                    try:
+                        self.target_context.refresh()
+                    except Exception:
+                        self._targetctx_initialized = False
+                        raise
+                    else:
+                        self._targetctx_initialized = True
 
-            from numba_cuda_mlir.numba_cuda.typing.templates import builtin_registry
+                from numba_cuda_mlir.numba_cuda.typing.templates import builtin_registry
 
-            self.typing_context.install_registry(builtin_registry)
-        finally:
-            self._initializing = False
+                self.typing_context.install_registry(builtin_registry)
+            finally:
+                self._initializing = False
 
     def refresh_registries(self, *, typing=True, target=True):
         if self._initializing:

--- a/src/numba_cuda_mlir/descriptor.py
+++ b/src/numba_cuda_mlir/descriptor.py
@@ -1221,9 +1221,10 @@ class MLIRTargetContext(BaseContext):
 
     @override
     def refresh(self):
-        if self._registries_unchanged():
-            return
-        self.load_additional_registries()
+        with self._registry_lock:
+            if self._registries_unchanged():
+                return
+            self.load_additional_registries()
 
     def get_overload_builder(self, fn, sig):
         """Return an MLIR builder for an overloaded function, or None.
@@ -1514,18 +1515,19 @@ class MLIRTarget(TargetDescriptor):
                 self._initializing = False
 
     def refresh_registries(self, *, typing=True, target=True):
-        if self._initializing:
-            return
-        self._initializing = True
-        try:
-            if typing:
-                self.typing_context.refresh()
-                self._typingctx_initialized = True
-            if target:
-                self.target_context.refresh()
-                self._targetctx_initialized = True
-        finally:
-            self._initializing = False
+        with self._initialization_lock:
+            if self._initializing:
+                return
+            self._initializing = True
+            try:
+                if typing:
+                    self.typing_context.refresh()
+                    self._typingctx_initialized = True
+                if target:
+                    self.target_context.refresh()
+                    self._targetctx_initialized = True
+            finally:
+                self._initializing = False
 
 
 mlir_target = MLIRTarget("numba_cuda_mlir")

--- a/src/numba_cuda_mlir/lowering_utilities/llvm_utils.py
+++ b/src/numba_cuda_mlir/lowering_utilities/llvm_utils.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import ctypes
-import itertools
 import os
 import platform
+
+from numba_cuda_mlir._threading import _LockedCounter
 
 if platform.machine() in ("ARM64", "AMD64"):
     NVPTX64_DATALAYOUT = "e-p:64:64:64-p6:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64-a:8:8"
@@ -47,7 +48,7 @@ MODERN_TO_NVVM_BRIDGE_LIB_PATH = _find_modern_to_nvvm_bridge_lib()
 
 _capi = None
 _modern_to_nvvm_bridge = None
-_modern_bridge_dump_counter = itertools.count()
+_modern_bridge_dump_counter = _LockedCounter()
 
 
 def _load_capi_library(path: str, label: str):

--- a/src/numba_cuda_mlir/lowering_utilities/string.py
+++ b/src/numba_cuda_mlir/lowering_utilities/string.py
@@ -10,15 +10,15 @@ that accept both ``UnicodeType`` and ``StringLiteral`` operands).
 """
 
 import sys
-import itertools
 
 from numba_cuda_mlir._mlir.extras import types as T
 from numba_cuda_mlir._mlir import ir
 from numba_cuda_mlir.mlir.dialect_exts import llvm
 from numba_cuda_mlir.lowering_utilities import constant
+from numba_cuda_mlir._threading import _LockedCounter
 
 _HASH_WIDTH = 64 if sys.maxsize > 2**32 else 32
-_counter = itertools.count(1)
+_counter = _LockedCounter(1)
 
 
 def materialize_string_constant_if_needed(gpu_module, val):

--- a/src/numba_cuda_mlir/mlir_optimization.py
+++ b/src/numba_cuda_mlir/mlir_optimization.py
@@ -3,13 +3,13 @@
 
 import ctypes
 import functools
-import itertools
 import os
 import sys
 from io import StringIO
 from pathlib import Path
 
 from numba_cuda_mlir._mlir.passmanager import PassManager
+from numba_cuda_mlir._threading import _LockedCounter
 from numba_cuda_mlir._mlir.dialects import llvm
 from numba_cuda_mlir.tools import generate_mangled_name
 from numba_cuda_mlir._mlir import ir
@@ -301,7 +301,7 @@ def _call_llvm70_capi(module, target_options, gen_lto=False, gen_llvmir=False) -
             lib.llvm70_free(nvvm_out)
 
 
-_nvvm_dump_counter = itertools.count()
+_nvvm_dump_counter = _LockedCounter()
 _BITCODE_MAGIC = b"BC\xc0\xde"
 
 

--- a/src/numba_cuda_mlir/numba_cuda/core/base.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/base.py
@@ -403,11 +403,7 @@ class BaseContext:
             ):
                 return
 
-            try:
-                loader = self._registries[registry]
-            except KeyError:
-                loader = RegistryLoader(registry)
-                self._registries[registry] = loader
+            loader = self._registries.setdefault(registry, RegistryLoader(registry))
             self.insert_func_defn(loader.new_registrations("functions"))
             self._insert_getattr_defn(loader.new_registrations("getattrs"))
             self._insert_setattr_defn(loader.new_registrations("setattrs"))
@@ -447,11 +443,7 @@ class BaseContext:
                 except (AttributeError, IndexError):
                     return True
 
-            try:
-                loader = self._registries[registry]
-            except KeyError:
-                loader = RegistryLoader(registry)
-                self._registries[registry] = loader
+            loader = self._registries.setdefault(registry, RegistryLoader(registry))
 
             # Filter registrations
             funcs = [

--- a/src/numba_cuda_mlir/numba_cuda/core/base.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/base.py
@@ -8,6 +8,7 @@ import sys
 from itertools import permutations, takewhile
 from contextlib import contextmanager
 from functools import cached_property
+import threading
 
 
 class _LLVMLiteRemoved:
@@ -246,6 +247,7 @@ class BaseContext:
     fndesc = None
 
     def __init__(self, typing_context, target):
+        self._registry_lock = threading.RLock()
         self.address_size = utils.MACHINE_BITS
         self.typing_context = typing_context
         self.target_name = target
@@ -282,30 +284,32 @@ class BaseContext:
         """
 
     def _registries_unchanged(self):
-        for registry, _loader in self._registries.items():
-            reg_id = id(registry)
-            current = getattr(registry, "_version", None)
-            if current is None:
-                return False
-            if current != self._registry_versions.get(reg_id, -1):
-                return False
-        return bool(self._registries)
+        with self._registry_lock:
+            for registry in self._registries:
+                reg_id = id(registry)
+                current = getattr(registry, "_version", None)
+                if current is None:
+                    return False
+                if current != self._registry_versions.get(reg_id, -1):
+                    return False
+            return bool(self._registries)
 
     def refresh(self):
         """
         Refresh target context with new declarations from known registries.
         Useful for third-party extensions.
         """
-        if self._registries_unchanged():
-            return
-        # load target specific registries
-        self.load_additional_registries()
+        with self._registry_lock:
+            if self._registries_unchanged():
+                return
+            # load target specific registries
+            self.load_additional_registries()
 
-        # Populate the builtin registry, this has to happen after loading
-        # additional registries as some of the "additional" registries write
-        # their implementations into the builtin_registry and would be missed if
-        # this ran first.
-        self.install_registry(builtin_registry)
+            # Populate the builtin registry, this has to happen after loading
+            # additional registries as some of the "additional" registries write
+            # their implementations into the builtin_registry and would be missed if
+            # this ran first.
+            self.install_registry(builtin_registry)
 
     def load_additional_registries(self):
         """
@@ -391,26 +395,27 @@ class BaseContext:
         Install a *registry* (a imputils.Registry instance) of function
         and attribute implementations.
         """
-        reg_id = id(registry)
-        current_version = getattr(registry, "_version", None)
-        if current_version is not None and current_version == self._registry_versions.get(
-            reg_id, -1
-        ):
-            return
+        with self._registry_lock:
+            reg_id = id(registry)
+            current_version = getattr(registry, "_version", None)
+            if current_version is not None and current_version == self._registry_versions.get(
+                reg_id, -1
+            ):
+                return
 
-        try:
-            loader = self._registries[registry]
-        except KeyError:
-            loader = RegistryLoader(registry)
-            self._registries[registry] = loader
-        self.insert_func_defn(loader.new_registrations("functions"))
-        self._insert_getattr_defn(loader.new_registrations("getattrs"))
-        self._insert_setattr_defn(loader.new_registrations("setattrs"))
-        self._insert_cast_defn(loader.new_registrations("casts"))
-        self._insert_get_constant_defn(loader.new_registrations("constants"))
+            try:
+                loader = self._registries[registry]
+            except KeyError:
+                loader = RegistryLoader(registry)
+                self._registries[registry] = loader
+            self.insert_func_defn(loader.new_registrations("functions"))
+            self._insert_getattr_defn(loader.new_registrations("getattrs"))
+            self._insert_setattr_defn(loader.new_registrations("setattrs"))
+            self._insert_cast_defn(loader.new_registrations("casts"))
+            self._insert_get_constant_defn(loader.new_registrations("constants"))
 
-        if current_version is not None:
-            self._registry_versions[reg_id] = current_version
+            if current_version is not None:
+                self._registry_versions[reg_id] = current_version
 
     def install_external_registry(self, registry):
         """
@@ -426,54 +431,58 @@ class BaseContext:
         always set impl.__module__ = "numba.*" regardless of where they are called from.
         """
 
-        def is_external(obj):
-            """Check if object is from outside numba.* namespace."""
+        with self._registry_lock:
+
+            def is_external(obj):
+                """Check if object is from outside numba.* namespace."""
+                try:
+                    return not obj.__module__.startswith("numba.")
+                except AttributeError:
+                    return True
+
+            def is_external_type_sig(sig):
+                """Check if type in signature is from outside numba.* namespace."""
+                try:
+                    return sig and is_external(sig[0])
+                except (AttributeError, IndexError):
+                    return True
+
             try:
-                return not obj.__module__.startswith("numba.")
-            except AttributeError:
-                return True
+                loader = self._registries[registry]
+            except KeyError:
+                loader = RegistryLoader(registry)
+                self._registries[registry] = loader
 
-        def is_external_type_sig(sig):
-            """Check if type in signature is from outside numba.* namespace."""
-            try:
-                return sig and is_external(sig[0])
-            except (AttributeError, IndexError):
-                return True
+            # Filter registrations
+            funcs = [
+                (impl, func, sig)
+                for impl, func, sig in loader.new_registrations("functions")
+                if is_external(impl)
+            ]
+            getattrs = [
+                (impl, attr, sig)
+                for impl, attr, sig in loader.new_registrations("getattrs")
+                if is_external_type_sig(sig)
+            ]
+            setattrs = [
+                (impl, attr, sig)
+                for impl, attr, sig in loader.new_registrations("setattrs")
+                if is_external_type_sig(sig)
+            ]
+            casts = [
+                (impl, sig) for impl, sig in loader.new_registrations("casts") if is_external(impl)
+            ]
+            constants = [
+                (impl, sig)
+                for impl, sig in loader.new_registrations("constants")
+                if is_external(impl)
+            ]
 
-        try:
-            loader = self._registries[registry]
-        except KeyError:
-            loader = RegistryLoader(registry)
-            self._registries[registry] = loader
-
-        # Filter registrations
-        funcs = [
-            (impl, func, sig)
-            for impl, func, sig in loader.new_registrations("functions")
-            if is_external(impl)
-        ]
-        getattrs = [
-            (impl, attr, sig)
-            for impl, attr, sig in loader.new_registrations("getattrs")
-            if is_external_type_sig(sig)
-        ]
-        setattrs = [
-            (impl, attr, sig)
-            for impl, attr, sig in loader.new_registrations("setattrs")
-            if is_external_type_sig(sig)
-        ]
-        casts = [
-            (impl, sig) for impl, sig in loader.new_registrations("casts") if is_external(impl)
-        ]
-        constants = [
-            (impl, sig) for impl, sig in loader.new_registrations("constants") if is_external(impl)
-        ]
-
-        self.insert_func_defn(funcs)
-        self._insert_getattr_defn(getattrs)
-        self._insert_setattr_defn(setattrs)
-        self._insert_cast_defn(casts)
-        self._insert_get_constant_defn(constants)
+            self.insert_func_defn(funcs)
+            self._insert_getattr_defn(getattrs)
+            self._insert_setattr_defn(setattrs)
+            self._insert_cast_defn(casts)
+            self._insert_get_constant_defn(constants)
 
     def insert_func_defn(self, defns):
         buckets = defaultdict(list)

--- a/src/numba_cuda_mlir/numba_cuda/core/bytecode.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/bytecode.py
@@ -4,7 +4,6 @@
 from collections import namedtuple, OrderedDict
 import dis
 import inspect
-import itertools
 
 from types import CodeType, ModuleType
 
@@ -12,6 +11,7 @@ from numba_cuda_mlir.numba_cuda.core import errors
 from numba_cuda_mlir.numba_cuda import serialize
 from numba_cuda_mlir.numba_cuda import utils
 from numba_cuda_mlir.numba_cuda.utils import PYVERSION
+from numba_cuda_mlir._threading import _LockedCounter
 
 
 if PYVERSION in ((3, 12), (3, 13), (3, 14)):
@@ -650,7 +650,7 @@ class FunctionIdentity(serialize.ReduceMixin):
     (the two might be distinct).
     """
 
-    _unique_ids = itertools.count(1)
+    _unique_ids = _LockedCounter(1)
 
     @classmethod
     def from_function(cls, pyfunc):

--- a/src/numba_cuda_mlir/numba_cuda/core/event.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/event.py
@@ -182,6 +182,7 @@ class Event:
 
 
 _registered = defaultdict(list)
+_registered_lock = threading.RLock()
 
 
 def register(kind, listener):
@@ -194,7 +195,8 @@ def register(kind, listener):
     """
     assert isinstance(listener, Listener)
     kind = _guard_kind(kind)
-    _registered[kind].append(listener)
+    with _registered_lock:
+        _registered[kind].append(listener)
 
 
 def unregister(kind, listener):
@@ -207,8 +209,9 @@ def unregister(kind, listener):
     """
     assert isinstance(listener, Listener)
     kind = _guard_kind(kind)
-    lst = _registered[kind]
-    lst.remove(listener)
+    with _registered_lock:
+        lst = _registered[kind]
+        lst.remove(listener)
 
 
 def broadcast(event):
@@ -218,7 +221,9 @@ def broadcast(event):
     ----------
     event : Event
     """
-    for listener in _registered[event.kind]:
+    with _registered_lock:
+        listeners = tuple(_registered[event.kind])
+    for listener in listeners:
         listener.notify(event)
 
 

--- a/src/numba_cuda_mlir/numba_cuda/core/imputils.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/imputils.py
@@ -8,6 +8,7 @@ Utilities to simplify the boilerplate for native lowering.
 import collections
 import contextlib
 from enum import Enum
+import threading
 
 from numba_cuda_mlir.numba_cuda import typing, cgutils
 from numba_cuda_mlir.numba_cuda import types
@@ -28,6 +29,12 @@ class Registry:
         self.casts = []
         self.constants = []
         self._version = 0
+        self._lock = threading.RLock()
+
+    def _append(self, name, item):
+        with self._lock:
+            getattr(self, name).append(item)
+            self._version += 1
 
     def lower(self, func, *argtys):
         """
@@ -40,16 +47,15 @@ class Registry:
         """
 
         def decorate(impl):
-            self.functions.append((impl, func, argtys))
-            self._version += 1
+            self._append("functions", (impl, func, argtys))
             return impl
 
         return decorate
 
     def _decorate_attr(self, impl, ty, attr, impl_list, decorator):
         real_impl = decorator(impl, ty, attr)
-        impl_list.append((real_impl, attr, real_impl.signature))
-        self._version += 1
+        name = "getattrs" if impl_list is self.getattrs else "setattrs"
+        self._append(name, (real_impl, attr, real_impl.signature))
         return impl
 
     def lower_getattr(self, ty, attr):
@@ -112,8 +118,7 @@ class Registry:
         """
 
         def decorate(impl):
-            self.casts.append((impl, (fromty, toty)))
-            self._version += 1
+            self._append("casts", (impl, (fromty, toty)))
             return impl
 
         return decorate
@@ -127,8 +132,7 @@ class Registry:
         """
 
         def decorate(impl):
-            self.constants.append((impl, (ty,)))
-            self._version += 1
+            self._append("constants", (impl, (ty,)))
             return impl
 
         return decorate

--- a/src/numba_cuda_mlir/numba_cuda/descriptor.py
+++ b/src/numba_cuda_mlir/numba_cuda/descriptor.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import threading
+
 from numba_cuda_mlir.numba_cuda.core.options import TargetOptions
 from .target import CUDATargetContext, CUDATypingContext
 
@@ -22,6 +24,7 @@ class CUDATarget:
         self._typingctx_initializing = False
         self._targetctx_initializing = False
         self._initializing = False
+        self._initialization_lock = threading.RLock()
         self._target_name = name
 
     @property
@@ -37,75 +40,80 @@ class CUDATarget:
         return self._targetctx
 
     def _seed_target_registry(self):
-        if self.target_context._registries:
-            return
-        from numba_cuda_mlir.numba_cuda.core.imputils import builtin_registry
+        with self.target_context._registry_lock:
+            if self.target_context._registries:
+                return
+            from numba_cuda_mlir.numba_cuda.core.imputils import builtin_registry
 
-        self.target_context.install_registry(builtin_registry)
+            self.target_context.install_registry(builtin_registry)
 
     def ensure_initialized(self):
         if self._typingctx_initialized and self._targetctx_initialized:
             return
-        if self._initializing:
-            return
+        with self._initialization_lock:
+            if self._typingctx_initialized and self._targetctx_initialized:
+                return
+            if self._initializing:
+                return
 
-        self._initializing = True
-        try:
-            self._seed_target_registry()
+            self._initializing = True
+            try:
+                self._seed_target_registry()
 
-            if not self._typingctx_initialized:
-                self._typingctx_initializing = True
-                try:
-                    self.typing_context.refresh()
-                except Exception:
-                    self._typingctx_initialized = False
-                    raise
-                else:
-                    self._typingctx_initialized = True
-                finally:
-                    self._typingctx_initializing = False
+                if not self._typingctx_initialized:
+                    self._typingctx_initializing = True
+                    try:
+                        self.typing_context.refresh()
+                    except Exception:
+                        self._typingctx_initialized = False
+                        raise
+                    else:
+                        self._typingctx_initialized = True
+                    finally:
+                        self._typingctx_initializing = False
 
-            if not self._targetctx_initialized:
-                self._targetctx_initializing = True
-                try:
-                    self.target_context.refresh()
-                except Exception:
-                    self._targetctx_initialized = False
-                    raise
-                else:
-                    self._targetctx_initialized = True
-                finally:
-                    self._targetctx_initializing = False
+                if not self._targetctx_initialized:
+                    self._targetctx_initializing = True
+                    try:
+                        self.target_context.refresh()
+                    except Exception:
+                        self._targetctx_initialized = False
+                        raise
+                    else:
+                        self._targetctx_initialized = True
+                    finally:
+                        self._targetctx_initializing = False
 
-            from numba_cuda_mlir.device_declarations import (
-                apply_device_declarations,
-            )
-            from numba_cuda_mlir.numba_cuda.typing.templates import builtin_registry
-
-            self.typing_context.install_registry(builtin_registry)
-            apply_device_declarations(self.typing_context, self.target_context)
-        finally:
-            self._initializing = False
-
-    def refresh_registries(self, *, typing=True, target=True):
-        if self._initializing:
-            return
-        self._initializing = True
-        try:
-            if typing:
-                self.typing_context.refresh()
-                self._typingctx_initialized = True
-            if target:
-                self.target_context.refresh()
-                self._targetctx_initialized = True
-            if typing and target:
                 from numba_cuda_mlir.device_declarations import (
                     apply_device_declarations,
                 )
+                from numba_cuda_mlir.numba_cuda.typing.templates import builtin_registry
 
+                self.typing_context.install_registry(builtin_registry)
                 apply_device_declarations(self.typing_context, self.target_context)
-        finally:
-            self._initializing = False
+            finally:
+                self._initializing = False
+
+    def refresh_registries(self, *, typing=True, target=True):
+        with self._initialization_lock:
+            if self._initializing:
+                return
+            self._initializing = True
+            try:
+                if typing:
+                    self.typing_context.refresh()
+                    self._typingctx_initialized = True
+                if target:
+                    self.target_context.refresh()
+                    self._targetctx_initialized = True
+                if typing and target:
+                    from numba_cuda_mlir.device_declarations import (
+                        apply_device_declarations,
+                    )
+
+                    apply_device_declarations(self.typing_context, self.target_context)
+            finally:
+                self._initializing = False
 
 
 cuda_target = CUDATarget("cuda")

--- a/src/numba_cuda_mlir/numba_cuda/descriptor.py
+++ b/src/numba_cuda_mlir/numba_cuda/descriptor.py
@@ -67,8 +67,6 @@ class CUDATarget:
                     except Exception:
                         self._typingctx_initialized = False
                         raise
-                    else:
-                        self._typingctx_initialized = True
                     finally:
                         self._typingctx_initializing = False
 
@@ -79,8 +77,6 @@ class CUDATarget:
                     except Exception:
                         self._targetctx_initialized = False
                         raise
-                    else:
-                        self._targetctx_initialized = True
                     finally:
                         self._targetctx_initializing = False
 
@@ -91,6 +87,8 @@ class CUDATarget:
 
                 self.typing_context.install_registry(builtin_registry)
                 apply_device_declarations(self.typing_context, self.target_context)
+                self._typingctx_initialized = True
+                self._targetctx_initialized = True
             finally:
                 self._initializing = False
 
@@ -102,16 +100,18 @@ class CUDATarget:
             try:
                 if typing:
                     self.typing_context.refresh()
-                    self._typingctx_initialized = True
                 if target:
                     self.target_context.refresh()
-                    self._targetctx_initialized = True
                 if typing and target:
                     from numba_cuda_mlir.device_declarations import (
                         apply_device_declarations,
                     )
 
                     apply_device_declarations(self.typing_context, self.target_context)
+                if typing:
+                    self._typingctx_initialized = True
+                if target:
+                    self._targetctx_initialized = True
             finally:
                 self._initializing = False
 

--- a/src/numba_cuda_mlir/numba_cuda/types/abstract.py
+++ b/src/numba_cuda_mlir/numba_cuda/types/abstract.py
@@ -3,13 +3,14 @@
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import Dict as ptDict, Type as ptType
-import itertools
+import threading
 import weakref
 from functools import cached_property
 
 import numpy as np
 
 from numba_cuda_mlir.numba_cuda.utils import get_hashable_key
+from numba_cuda_mlir._threading import _LockedCounter
 
 # Types are added to a global registry (_typecache) in order to assign
 # them unique integer codes for fast matching in _dispatcher.c.
@@ -18,7 +19,7 @@ from numba_cuda_mlir.numba_cuda.utils import get_hashable_key
 # long as necessary to keep a stable type code.
 # NOTE: some types can still be made immortal elsewhere (for example
 # in _dispatcher.c's internal caches).
-_typecodes = itertools.count()
+_typecodes = _LockedCounter()
 
 
 def _autoincr():
@@ -29,10 +30,12 @@ def _autoincr():
 
 
 _typecache: ptDict[weakref.ref, weakref.ref] = {}
+_typecache_lock = threading.RLock()
 
 
-def _on_type_disposal(wr, _pop=_typecache.pop):
-    _pop(wr, None)
+def _on_type_disposal(wr):
+    with _typecache_lock:
+        _typecache.pop(wr, None)
 
 
 class _TypeMetaclass(ABCMeta):
@@ -55,14 +58,15 @@ class _TypeMetaclass(ABCMeta):
     def _intern(cls, inst):
         # Try to intern the created instance
         wr = weakref.ref(inst, _on_type_disposal)
-        orig = _typecache.get(wr)
-        orig = orig and orig()
-        if orig is not None:
-            return orig
-        else:
-            inst._code = _autoincr()
-            _typecache[wr] = wr
-            return inst
+        with _typecache_lock:
+            orig = _typecache.get(wr)
+            orig = orig and orig()
+            if orig is not None:
+                return orig
+            else:
+                inst._code = _autoincr()
+                _typecache[wr] = wr
+                return inst
 
     def __call__(cls, *args, **kwargs):
         """

--- a/src/numba_cuda_mlir/numba_cuda/typing/context.py
+++ b/src/numba_cuda_mlir/numba_cuda/typing/context.py
@@ -48,8 +48,16 @@ class CallStack(Sequence):
     """
 
     def __init__(self):
-        self._stack = []
-        self._lock = threading.RLock()
+        self._tls = threading.local()
+
+    @property
+    def _stack(self):
+        try:
+            return self._tls.stack
+        except AttributeError:
+            stack = []
+            self._tls.stack = stack
+            return stack
 
     def __getitem__(self, index):
         """
@@ -67,13 +75,11 @@ class CallStack(Sequence):
         if self.match(func_id.func, args):
             msg = "compiler re-entrant to the same function signature"
             raise errors.NumbaRuntimeError(msg)
-        self._lock.acquire()
         self._stack.append(CallFrame(target, typeinfer, func_id, args))
         try:
             yield
         finally:
             self._stack.pop()
-            self._lock.release()
 
     def finditer(self, py_func):
         """
@@ -135,6 +141,7 @@ class BaseContext:
     """A typing context for storing function typing constrain template."""
 
     def __init__(self):
+        self._registry_lock = threading.RLock()
         # A list of installed registries
         self._registries = {}
         self._registry_versions = {}
@@ -154,24 +161,26 @@ class BaseContext:
         """
 
     def _registries_unchanged(self):
-        for registry, _loader in self._registries.items():
-            reg_id = id(registry)
-            current = getattr(registry, "_version", None)
-            if current is None:
-                return False
-            if current != self._registry_versions.get(reg_id, -1):
-                return False
-        return bool(self._registries)
+        with self._registry_lock:
+            for registry in self._registries:
+                reg_id = id(registry)
+                current = getattr(registry, "_version", None)
+                if current is None:
+                    return False
+                if current != self._registry_versions.get(reg_id, -1):
+                    return False
+            return bool(self._registries)
 
     def refresh(self):
         """
         Refresh context with new declarations from known registries.
         Useful for third-party extensions.
         """
-        if self._registries_unchanged():
-            return
-        self.load_additional_registries()
-        self._load_builtins()
+        with self._registry_lock:
+            if self._registries_unchanged():
+                return
+            self.load_additional_registries()
+            self._load_builtins()
 
     def explain_function_type(self, func):
         """
@@ -442,77 +451,78 @@ class BaseContext:
             a shared registry like Numba's typing registry (builtin_registry).
 
         """
-        reg_id = id(registry)
-        current_version = getattr(registry, "_version", None)
-        if current_version is not None and current_version == self._registry_versions.get(
-            reg_id, -1
-        ):
-            return
+        with self._registry_lock:
+            reg_id = id(registry)
+            current_version = getattr(registry, "_version", None)
+            if current_version is not None and current_version == self._registry_versions.get(
+                reg_id, -1
+            ):
+                return
 
-        try:
-            loader = self._registries[registry]
-        except KeyError:
-            loader = templates.RegistryLoader(registry)
-            self._registries[registry] = loader
-
-        def is_for_this_target(ftcls):
-            metadata = getattr(ftcls, "metadata", None)
-            if metadata is None:
-                return True
-
-            target_str = metadata.get("target")
-            if target_str is None:
-                return True
-
-            # Accept both "cuda" and "generic" targets
-            if target_str in ("cuda", "generic"):
-                return True
-
-            return False
-
-        def is_external(obj):
-            """Check if obj is from outside numba.* namespace."""
             try:
-                is_numba_module = obj.__module__.startswith("numba.")
-                is_test_module = obj.__module__.startswith("numba.cuda.tests.")
-                return not is_numba_module or is_test_module
-            except AttributeError:
-                return True
+                loader = self._registries[registry]
+            except KeyError:
+                loader = templates.RegistryLoader(registry)
+                self._registries[registry] = loader
 
-        for ftcls in loader.new_registrations("functions"):
-            if not is_for_this_target(ftcls):
-                continue
-            # If external_defs_only, install templates only from external modules
-            if external_defs_only and not is_external(ftcls):
-                continue
-            self.insert_function(ftcls(self))
-        for ftcls in loader.new_registrations("attributes"):
-            if not is_for_this_target(ftcls):
-                continue
-            # If external_defs_only, check if the type being registered is external
-            if external_defs_only:
-                key = getattr(ftcls, "key", None)
-                if key is not None and not is_external(key):
-                    continue
-            self.insert_attributes(ftcls(self))
-        for gv, gty in loader.new_registrations("globals"):
-            # If external_defs_only, check the global value's module
-            if external_defs_only:
-                if hasattr(gv, "__module__") and not is_external(gv):
-                    continue
-            existing = self._lookup_global(gv)
-            if existing is None:
-                self.insert_global(gv, gty)
-            else:
-                # A type was already inserted, see if we can add to it
-                newty = existing.augment(gty)
-                if newty is None:
-                    raise TypeError("cannot augment %s with %s" % (existing, gty))
-                self._remove_global(gv)
-                self._insert_global(gv, newty)
+            def is_for_this_target(ftcls):
+                metadata = getattr(ftcls, "metadata", None)
+                if metadata is None:
+                    return True
 
-        if current_version is not None:
-            self._registry_versions[reg_id] = current_version
+                target_str = metadata.get("target")
+                if target_str is None:
+                    return True
+
+                # Accept both "cuda" and "generic" targets
+                if target_str in ("cuda", "generic"):
+                    return True
+
+                return False
+
+            def is_external(obj):
+                """Check if obj is from outside numba.* namespace."""
+                try:
+                    is_numba_module = obj.__module__.startswith("numba.")
+                    is_test_module = obj.__module__.startswith("numba.cuda.tests.")
+                    return not is_numba_module or is_test_module
+                except AttributeError:
+                    return True
+
+            for ftcls in loader.new_registrations("functions"):
+                if not is_for_this_target(ftcls):
+                    continue
+                # If external_defs_only, install templates only from external modules
+                if external_defs_only and not is_external(ftcls):
+                    continue
+                self.insert_function(ftcls(self))
+            for ftcls in loader.new_registrations("attributes"):
+                if not is_for_this_target(ftcls):
+                    continue
+                # If external_defs_only, check if the type being registered is external
+                if external_defs_only:
+                    key = getattr(ftcls, "key", None)
+                    if key is not None and not is_external(key):
+                        continue
+                self.insert_attributes(ftcls(self))
+            for gv, gty in loader.new_registrations("globals"):
+                # If external_defs_only, check the global value's module
+                if external_defs_only:
+                    if hasattr(gv, "__module__") and not is_external(gv):
+                        continue
+                existing = self._lookup_global(gv)
+                if existing is None:
+                    self.insert_global(gv, gty)
+                else:
+                    # A type was already inserted, see if we can add to it
+                    newty = existing.augment(gty)
+                    if newty is None:
+                        raise TypeError("cannot augment %s with %s" % (existing, gty))
+                    self._remove_global(gv)
+                    self._insert_global(gv, newty)
+
+            if current_version is not None:
+                self._registry_versions[reg_id] = current_version
 
     def _lookup_global(self, gv):
         """

--- a/src/numba_cuda_mlir/numba_cuda/typing/templates.py
+++ b/src/numba_cuda_mlir/numba_cuda/typing/templates.py
@@ -10,6 +10,7 @@ import functools
 import sys
 import inspect
 import os.path
+import threading
 from collections import namedtuple
 from collections.abc import Sequence
 from types import MethodType, FunctionType, MappingProxyType
@@ -1016,8 +1017,8 @@ class _TemplateTargetHelperMixin:
         # =====================================================================
 
         # Pick a registry in which to install intrinsics
-        registries = iter(tgtctx._registries)
-        reg = next(registries)
+        with tgtctx._registry_lock:
+            reg = next(iter(tgtctx._registries))
         proxy = _TargetRegistryProxy(reg, tgtctx)
         _TemplateTargetHelperMixin._cached_target_registry_proxy = proxy
         return proxy
@@ -1335,15 +1336,19 @@ class Registry:
         self.attributes = []
         self.globals = []
         self._version = 0
+        self._lock = threading.RLock()
+
+    def _append(self, name, item):
+        with self._lock:
+            getattr(self, name).append(item)
+            self._version += 1
 
     def register(self, item):
-        self.functions.append(item)
-        self._version += 1
+        self._append("functions", item)
         return item
 
     def register_attr(self, item):
-        self.attributes.append(item)
-        self._version += 1
+        self._append("attributes", item)
         return item
 
     def register_global(self, val=None, typ=None, **kwargs):
@@ -1360,8 +1365,7 @@ class Registry:
             # register_global(val, typ)
             assert val is not None
             assert not kwargs
-            self.globals.append((val, typ))
-            self._version += 1
+            self._append("globals", (val, typ))
         else:
 
             def decorate(cls, typing_key):
@@ -1372,8 +1376,7 @@ class Registry:
                     typ = types.Function(Template)
                 else:
                     raise TypeError("cannot infer type for global value %r")
-                self.globals.append((val, typ))
-                self._version += 1
+                self._append("globals", (val, typ))
                 return cls
 
             # register_global(val, typing_key=None)(<template class>)
@@ -1412,13 +1415,25 @@ class BaseRegistryLoader:
     """
 
     def __init__(self, registry):
-        self._registrations = dict(
-            (name, utils.stream_list(getattr(registry, name))) for name in self.registry_items
-        )
+        self._registry = registry
+        self._positions = dict.fromkeys(self.registry_items, 0)
 
     def new_registrations(self, name):
-        for item in next(self._registrations[name]):
+        def snapshot():
+            registrations = getattr(self._registry, name)
+            start = self._positions[name]
+            stop = len(registrations)
+            return registrations[start:stop], stop
+
+        lock = getattr(self._registry, "_lock", None)
+        if lock is None:
+            items, stop = snapshot()
+        else:
+            with lock:
+                items, stop = snapshot()
+        for item in items:
             yield item
+        self._positions[name] = stop
 
 
 class RegistryLoader(BaseRegistryLoader):

--- a/src/numba_cuda_mlir/numba_cuda/utils.py
+++ b/src/numba_cuda_mlir/numba_cuda/utils.py
@@ -380,26 +380,6 @@ def bit_length(intval):
         return len(bin(-intval - 1)) - 2
 
 
-def stream_list(lst):
-    """
-    Given a list, return an infinite iterator of iterators.
-    Each iterator iterates over the list from the last seen point up to
-    the current end-of-list.
-
-    In effect, each iterator will give the newly appended elements from the
-    previous iterator instantiation time.
-    """
-
-    def sublist_iterator(start, stop):
-        return iter(lst[start:stop])
-
-    start = 0
-    while True:
-        stop = len(lst)
-        yield sublist_iterator(start, stop)
-        start = stop
-
-
 class BenchmarkResult:
     def __init__(self, func, records, loop):
         self.func = func

--- a/tests/test_descriptor_launch_config.py
+++ b/tests/test_descriptor_launch_config.py
@@ -101,6 +101,62 @@ def restore_compile_arg_types():
     descriptor_mod._compile_arg_types.__dict__.update(state)
 
 
+def test_target_initialization_waits_for_concurrent_initialization():
+    class Context:
+        def __init__(self, started=None, release=None):
+            self.started = started
+            self.release = release
+            self.refresh_count = 0
+            self.registry_count = 0
+
+        def refresh(self):
+            self.refresh_count += 1
+            if self.started is not None:
+                self.started.set()
+                assert self.release.wait(timeout=10)
+
+        def install_registry(self, registry):
+            self.registry_count += 1
+
+    initialized = threading.Event()
+    release_initialization = threading.Event()
+    target = descriptor_mod.MLIRTarget("test_target_initialization")
+    typing_context = Context(initialized, release_initialization)
+    target_context = Context()
+    target._typingctx = typing_context
+    target._targetctx = target_context
+    errors = []
+    second_finished = threading.Event()
+
+    def ensure_initialized(finished=None):
+        try:
+            target.ensure_initialized()
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            if finished is not None:
+                finished.set()
+
+    first = threading.Thread(target=ensure_initialized)
+    first.start()
+    assert initialized.wait(timeout=10)
+
+    second = threading.Thread(target=ensure_initialized, args=(second_finished,))
+    second.start()
+    assert not second_finished.wait(timeout=0.1)
+
+    release_initialization.set()
+    first.join(timeout=10)
+    second.join(timeout=10)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert typing_context.refresh_count == 1
+    assert target_context.refresh_count == 1
+    assert typing_context.registry_count == 1
+
+
 def test_arg_marshaller_exposes_launch_config_during_launch():
     dispatcher = _Dispatcher()
     launch_config = {

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -46,6 +46,46 @@ def _require_free_threaded_python():
         pytest.skip("requires a free-threaded CPython build")
 
 
+def test_concurrent_cold_cuda_compile():
+    result = _run_python(
+        """
+        from concurrent.futures import ThreadPoolExecutor
+        import threading
+
+        from numba_cuda_mlir import cuda, types
+
+        def add(a, b):
+            return a + b
+
+        workers = 4
+        start = threading.Barrier(workers, timeout=60)
+
+        def compile_add():
+            start.wait()
+            cuda.compile(
+                add,
+                (types.int32, types.int32),
+                device=True,
+                cc=(8, 9),
+                abi="c",
+                abi_info={"abi_name": "add"},
+                output="ltoir",
+            )
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [executor.submit(compile_add) for _ in range(workers)]
+            for future in futures:
+                future.result()
+
+        print("concurrent-compile-ok")
+        """,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "concurrent-compile-ok" in result.stdout
+
+
 def test_imports_do_not_enable_gil_by_default():
     _require_free_threaded_python()
 

--- a/tests/test_shared_iterators.py
+++ b/tests/test_shared_iterators.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+import threading
+
+from numba_cuda_mlir._threading import _LockedCounter
+from numba_cuda_mlir.numba_cuda.core import event
+from numba_cuda_mlir.numba_cuda.core.base import BaseContext as LoweringContext
+from numba_cuda_mlir.numba_cuda.core.imputils import Registry as LoweringRegistry
+from numba_cuda_mlir.numba_cuda.descriptor import CUDATarget
+from numba_cuda_mlir.numba_cuda.typing.context import BaseContext as TypingContext
+from numba_cuda_mlir.numba_cuda.typing.context import CallStack
+from numba_cuda_mlir.numba_cuda.typing.templates import Registry as TypingRegistry
+from numba_cuda_mlir.numba_cuda.typing.templates import RegistryLoader
+from numba_cuda_mlir.numba_cuda.types import Type
+
+
+def test_locked_counter_is_unique_across_threads():
+    counter = _LockedCounter(3)
+    workers = 8
+    values_per_worker = 100
+    start = threading.Barrier(workers)
+
+    def count():
+        start.wait()
+        return [next(counter) for _ in range(values_per_worker)]
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        values = [
+            value for result in executor.map(lambda _: count(), range(workers)) for value in result
+        ]
+
+    assert sorted(values) == list(range(3, 3 + workers * values_per_worker))
+
+
+def test_registry_loader_does_not_commit_a_partial_window():
+    registry = TypingRegistry()
+
+    class Template:
+        pass
+
+    registry.register(Template)
+    loader = RegistryLoader(registry)
+    registrations = loader.new_registrations("functions")
+
+    assert next(registrations) is Template
+    registrations.close()
+    assert list(loader.new_registrations("functions")) == [Template]
+
+
+def test_typing_registry_installation_is_atomic():
+    initialized = threading.Event()
+    release_initialization = threading.Event()
+    second_finished = threading.Event()
+    key = object()
+
+    class Template:
+        def __init__(self, context):
+            initialized.set()
+            assert release_initialization.wait(timeout=10)
+            self.key = key
+
+    registry = TypingRegistry()
+    registry.register(Template)
+    context = TypingContext()
+    errors = []
+
+    def install(finished=None):
+        try:
+            context.install_registry(registry)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            if finished is not None:
+                finished.set()
+
+    first = threading.Thread(target=install)
+    first.start()
+    assert initialized.wait(timeout=10)
+
+    second = threading.Thread(target=install, args=(second_finished,))
+    second.start()
+    assert not second_finished.wait(timeout=0.1)
+
+    release_initialization.set()
+    first.join(timeout=10)
+    second.join(timeout=10)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert len(context._functions[key]) == 1
+
+
+def test_lowering_registry_installation_is_atomic():
+    registry = LoweringRegistry()
+
+    @registry.lower("test_op")
+    def lower_test_op(context, builder, signature, args):
+        pass
+
+    context = object.__new__(LoweringContext)
+    context._registry_lock = threading.RLock()
+    context._registries = {}
+    context._registry_versions = {}
+    initialized = threading.Event()
+    release_initialization = threading.Event()
+    second_finished = threading.Event()
+    installed = []
+    errors = []
+
+    def insert_func_defn(definitions):
+        definitions = list(definitions)
+        initialized.set()
+        assert release_initialization.wait(timeout=10)
+        installed.extend(definitions)
+
+    context.insert_func_defn = insert_func_defn
+    context._insert_getattr_defn = lambda definitions: list(definitions)
+    context._insert_setattr_defn = lambda definitions: list(definitions)
+    context._insert_cast_defn = lambda definitions: list(definitions)
+    context._insert_get_constant_defn = lambda definitions: list(definitions)
+
+    def install(finished=None):
+        try:
+            context.install_registry(registry)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            if finished is not None:
+                finished.set()
+
+    first = threading.Thread(target=install)
+    first.start()
+    assert initialized.wait(timeout=10)
+
+    second = threading.Thread(target=install, args=(second_finished,))
+    second.start()
+    assert not second_finished.wait(timeout=0.1)
+
+    release_initialization.set()
+    first.join(timeout=10)
+    second.join(timeout=10)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert installed == [(lower_test_op, "test_op", ())]
+
+
+def test_cuda_target_initialization_waits_for_concurrent_initialization(monkeypatch):
+    class Context:
+        def __init__(self, started=None, release=None):
+            self.started = started
+            self.release = release
+            self.refresh_count = 0
+            self.registry_count = 0
+
+        def refresh(self):
+            self.refresh_count += 1
+            if self.started is not None:
+                self.started.set()
+                assert self.release.wait(timeout=10)
+
+        def install_registry(self, registry):
+            self.registry_count += 1
+
+    from numba_cuda_mlir import device_declarations
+
+    initialized = threading.Event()
+    release_initialization = threading.Event()
+    second_finished = threading.Event()
+    target = CUDATarget("test_cuda_target_initialization")
+    typing_context = Context(initialized, release_initialization)
+    target_context = Context()
+    target._typingctx = typing_context
+    target._targetctx = target_context
+    errors = []
+
+    monkeypatch.setattr(target, "_seed_target_registry", lambda: None)
+    monkeypatch.setattr(device_declarations, "apply_device_declarations", lambda *args: None)
+
+    def ensure_initialized(finished=None):
+        try:
+            target.ensure_initialized()
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            if finished is not None:
+                finished.set()
+
+    first = threading.Thread(target=ensure_initialized)
+    first.start()
+    assert initialized.wait(timeout=10)
+
+    second = threading.Thread(target=ensure_initialized, args=(second_finished,))
+    second.start()
+    assert not second_finished.wait(timeout=0.1)
+
+    release_initialization.set()
+    first.join(timeout=10)
+    second.join(timeout=10)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert typing_context.refresh_count == 1
+    assert target_context.refresh_count == 1
+    assert typing_context.registry_count == 1
+
+
+def test_call_stack_is_thread_local():
+    callstack = CallStack()
+    functions = [lambda: None, lambda: None]
+    start = threading.Barrier(2)
+
+    def inspect_stack(worker):
+        func = functions[worker]
+        other_func = functions[1 - worker]
+        func_id = SimpleNamespace(func=func)
+        with callstack.register("target", None, func_id, (worker,)):
+            start.wait()
+            frame = callstack.findfirst(func)
+            return len(callstack), frame.args, callstack.findfirst(other_func)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(inspect_stack, range(2)))
+
+    assert results == [(1, (0,), None), (1, (1,), None)]
+    assert len(callstack) == 0
+
+
+def test_event_broadcast_uses_listener_snapshot():
+    kind = "test-shared-iterator-broadcast"
+    notified = threading.Event()
+    release_notification = threading.Event()
+
+    class Listener(event.Listener):
+        def on_start(self, evt):
+            notified.set()
+            assert release_notification.wait(timeout=10)
+
+        def on_end(self, evt):
+            pass
+
+    listener = Listener()
+    event.register(kind, listener)
+    broadcaster = threading.Thread(
+        target=event.broadcast,
+        args=(event.Event(kind, event.EventStatus.START),),
+    )
+    broadcaster.start()
+    assert notified.wait(timeout=10)
+
+    event.unregister(kind, listener)
+    release_notification.set()
+    broadcaster.join(timeout=10)
+
+    assert not broadcaster.is_alive()
+
+
+def test_type_interning_is_atomic():
+    class SharedType(Type):
+        def __init__(self):
+            super().__init__(name="shared-iterator-test-type")
+
+    workers = 8
+    start = threading.Barrier(workers)
+
+    def make_type():
+        start.wait()
+        return SharedType()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        instances = list(executor.map(lambda _: make_type(), range(workers)))
+
+    assert all(instance is instances[0] for instance in instances)
+    assert all(instance._code == instances[0]._code for instance in instances)

--- a/tests/test_shared_iterators.py
+++ b/tests/test_shared_iterators.py
@@ -211,6 +211,58 @@ def test_cuda_target_initialization_waits_for_concurrent_initialization(monkeypa
     assert typing_context.registry_count == 1
 
 
+def test_cuda_target_initialization_waits_for_declaration_application(monkeypatch):
+    class Context:
+        def refresh(self):
+            pass
+
+        def install_registry(self, registry):
+            pass
+
+    from numba_cuda_mlir import device_declarations
+
+    declarations_started = threading.Event()
+    release_declarations = threading.Event()
+    second_finished = threading.Event()
+    target = CUDATarget("test_cuda_target_declaration_application")
+    target._typingctx = Context()
+    target._targetctx = Context()
+    errors = []
+
+    monkeypatch.setattr(target, "_seed_target_registry", lambda: None)
+
+    def apply_declarations(*args):
+        declarations_started.set()
+        assert release_declarations.wait(timeout=10)
+
+    monkeypatch.setattr(device_declarations, "apply_device_declarations", apply_declarations)
+
+    def ensure_initialized(finished=None):
+        try:
+            target.ensure_initialized()
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            if finished is not None:
+                finished.set()
+
+    first = threading.Thread(target=ensure_initialized)
+    first.start()
+    assert declarations_started.wait(timeout=10)
+
+    second = threading.Thread(target=ensure_initialized, args=(second_finished,))
+    second.start()
+    assert not second_finished.wait(timeout=0.1)
+
+    release_declarations.set()
+    first.join(timeout=10)
+    second.join(timeout=10)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+
+
 def test_call_stack_is_thread_local():
     callstack = CallStack()
     functions = [lambda: None, lambda: None]


### PR DESCRIPTION
Prevents cold-start races where concurrent threads observe partial registry
state during MLIR target initialization.

**Changes:**
- `descriptor.py` — serialize `ensure_initialized` and `refresh_registries`
  behind an `RLock`; concurrent callers wait rather than racing on registry
  population
- `numba_cuda/descriptor.py` — serialize typing-context refresh under the
  target context lock; add test covering concurrent initialization and
  declaration application
- `_threading.py` (new) — `_LockedCounter` wrapper for explicit thread-safe
  counting without relying on the GIL
- `numba_cuda/core/base.py`, `typing/context.py`, `typing/templates.py`,
  `numba_cuda/descriptor.py` — add `_registry_lock` guards around registry
  reads/writes; use `dict.setdefault` for `RegistryLoader` creation so
  concurrent loaders are deduplicated atomically rather than via try/except
- `numba_cuda/core/event.py` — snapshot listener list before broadcasting so
  mid-broadcast unregistration is safe
- `numba_cuda/types/abstract.py` — make type interning atomic
- `test_free_threading.py` (new) — unit tests for call-stack thread-locality,
  event broadcast safety, and type-interning atomicity
- `test_shared_iterators.py` (new) — tests for concurrent target
  initialization, declaration-application serialization, and registry refresh