### PR TITLE
Fix skip condition when `cuobjdump` can't be found.

### DIFF
--- a/tests/numba_cuda_tests/cudadrv/test_nvjitlink.py
+++ b/tests/numba_cuda_tests/cudadrv/test_nvjitlink.py
@@ -13,6 +13,17 @@ from numba_cuda_mlir.testing import NumbaCUDATestCase
 import os
 import io
 import contextlib
+import shutil
+
+
+def _skip_reason_if_no_cuobjdump():
+    """Return a skip reason if `cuobjdump` is unavailable, else None.
+    """
+    if os.getenv("NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY") is not None:
+        return "wheel-only environment does not ship cuobjdump"
+    if shutil.which("cuobjdump") is None:
+        return "cuobjdump not found on PATH"
+    return None
 
 
 @unittest.skipIf(not _have_nvjitlink(), "nvJitLink not installed or new enough (>12.3)")
@@ -108,11 +119,9 @@ class TestLinkerDumpAssembly(NumbaCUDATestCase):
 
         for file in files:
             with self.subTest(file=file):
-                if (
-                    file in binaries.require_cuobjdump
-                    and os.getenv("NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY") is not None
-                ):
-                    self.skipTest("wheel-only environments do not have cuobjdump")
+                if file in binaries.require_cuobjdump:
+                    if reason := _skip_reason_if_no_cuobjdump():
+                        self.skipTest(reason)
 
                 f = io.StringIO()
                 with contextlib.redirect_stdout(f):
@@ -142,11 +151,9 @@ class TestLinkerDumpAssembly(NumbaCUDATestCase):
 
         for file in files:
             with self.subTest(file=file):
-                if (
-                    file in binaries.require_cuobjdump
-                    and os.getenv("NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY") is not None
-                ):
-                    self.skipTest("wheel-only environments do not have cuobjdump")
+                if file in binaries.require_cuobjdump:
+                    if reason := _skip_reason_if_no_cuobjdump():
+                        self.skipTest(reason)
 
                 sig = "uint32(uint32, uint32)"
                 add_from_numba = cuda.declare_device("add_from_numba", sig)

--- a/tests/numba_cuda_tests/cudadrv/test_nvjitlink.py
+++ b/tests/numba_cuda_tests/cudadrv/test_nvjitlink.py
@@ -17,8 +17,7 @@ import shutil
 
 
 def _skip_reason_if_no_cuobjdump():
-    """Return a skip reason if `cuobjdump` is unavailable, else None.
-    """
+    """Return a skip reason if `cuobjdump` is unavailable, else None."""
     if os.getenv("NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY") is not None:
         return "wheel-only environment does not ship cuobjdump"
     if shutil.which("cuobjdump") is None:


### PR DESCRIPTION
Closes https://github.com/NVIDIA/numba-cuda-mlir/issues/286

We can't use "is this a wheel only environment" as a proxy for knowing if `cuobjdump` is installed, we need to actually check if its there, otherwise anyone not setting the variable that indicates we're in a wheel env won't get the right skip.

The more robust fix for this is a redo of the way `numba-cuda-mlir` finds all of its binary utilities (not libraries). This will be documented/fixed separately both on the cuda-pathfinder and numba-cuda-mlir side. 