### PR TITLE
Use one host independent NVPTX data layout

### DIFF
--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -66,7 +66,7 @@ jobs:
         if: steps.gha-cache.outputs.cache-hit != 'true'
         run: |
           export PATH="$(dirname $PY):$PATH"
-          "${PY}" -m pip install pybind11 nanobind numpy ninja cmake awscli "typing-extensions; python_version < '3.12'"
+          "${PY}" -m pip install pybind11 "nanobind~=2.9" numpy ninja cmake awscli "typing-extensions; python_version < '3.12'"
           chmod +x ci/*.sh
 
       - name: Install sccache
@@ -251,7 +251,7 @@ jobs:
         if: steps.gha-cache.outputs.cache-hit != 'true'
         run: |
           export PATH="$(dirname $PY):$PATH"
-          "${PY}" -m pip install pybind11 nanobind numpy ninja cmake awscli
+          "${PY}" -m pip install pybind11 "nanobind~=2.9" numpy ninja cmake awscli
           chmod +x ci/*.sh
 
       - name: Install sccache

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -114,8 +114,10 @@ LIBLLVM7=$PWD/llvm7-install/lib/libLLVM-7.so \
 If you need to modify LLVM/MLIR or want to build without cached artifacts:
 
 ```shell
-# Install build prerequisites for the LLVM build scripts
-pip install pybind11 nanobind numpy ninja cmake sccache
+# Install build prerequisites for the LLVM build scripts.
+# MLIR asks for nanobind 2.9 and nanobind's CMake config only accepts a
+# matching major version, so 3.x fails the configure step outright.
+pip install pybind11 "nanobind~=2.9" numpy ninja cmake sccache
 
 # Build modern LLVM + MLIR (uses ci/llvm-version.env for the commit)
 ci/build-llvm-modern.sh    # produces llvm-modern-install/

--- a/cext/mlir-modern/ModernBridgeSmoke.cpp
+++ b/cext/mlir-modern/ModernBridgeSmoke.cpp
@@ -112,9 +112,12 @@ static int run_concurrent_version_cases(const char *mlir) {
     return failures.load(std::memory_order_relaxed) == 0 ? 0 : 1;
 }
 
+// The llvm.data_layout in the fixtures below must stay identical to
+// NVPTX64_DATALAYOUT in src/numba_cuda_mlir/lowering_utilities/llvm_utils.py,
+// otherwise this smoke test stops exercising what the package actually emits.
 static const char simple_kernel[] = R"MLIR(
 gpu.module @kernels attributes {
-  llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128",
+  llvm.data_layout = "e-p:64:64:64-p6:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64-a:8:8",
   llvm.target_triple = "nvptx64-nvidia-cuda"
 } {
   llvm.func @simple_kernel() attributes {gpu.kernel} {
@@ -132,7 +135,7 @@ int main() {
 
     static const char nvvm_intrinsics[] = R"MLIR(
 gpu.module @kernels attributes {
-  llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128",
+  llvm.data_layout = "e-p:64:64:64-p6:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64-a:8:8",
   llvm.target_triple = "nvptx64-nvidia-cuda"
 } {
   llvm.func @intrinsic_kernel() attributes {gpu.kernel} {
@@ -149,7 +152,7 @@ gpu.module @kernels attributes {
 
     static const char atomics[] = R"MLIR(
 gpu.module @kernels attributes {
-  llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128",
+  llvm.data_layout = "e-p:64:64:64-p6:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64-a:8:8",
   llvm.target_triple = "nvptx64-nvidia-cuda"
 } {
   llvm.func @atomic_kernel(%p32: !llvm.ptr<1>, %p64: !llvm.ptr<1>) attributes {gpu.kernel} {
@@ -165,7 +168,7 @@ gpu.module @kernels attributes {
 
     static const char downgrade[] = R"MLIR(
 gpu.module @kernels attributes {
-  llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128",
+  llvm.data_layout = "e-p:64:64:64-p6:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64-a:8:8",
   llvm.target_triple = "nvptx64-nvidia-cuda"
 } {
   llvm.func @downgrade_kernel() attributes {gpu.kernel} {

--- a/ci/windows-llvm-container-build.ps1
+++ b/ci/windows-llvm-container-build.ps1
@@ -34,7 +34,9 @@ Write-Host "Using Python: $pythonExe"
 & $pythonExe -m pip install --upgrade pip
 
 if ($Mode -eq 'modern') {
-    $pkgs = @('pybind11', 'nanobind', 'numpy', 'ninja', 'cmake', 'awscli')
+    # MLIR asks for nanobind 2.9 and nanobind's CMake config only accepts a
+    # matching major version, so 3.x fails the configure step outright.
+    $pkgs = @('pybind11', 'nanobind~=2.9', 'numpy', 'ninja', 'cmake', 'awscli')
     & $pythonExe -m pip install @pkgs
     if ([version]($spec.TrimEnd('t').Trim()) -lt [version]'3.12') {
         & $pythonExe -m pip install 'typing-extensions'

--- a/src/numba_cuda_mlir/lowering_utilities/llvm_utils.py
+++ b/src/numba_cuda_mlir/lowering_utilities/llvm_utils.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 import ctypes
 import os
-import platform
 
 from numba_cuda_mlir._threading import _LockedCounter
 
-if platform.machine() in ("ARM64", "AMD64"):
-    NVPTX64_DATALAYOUT = "e-p:64:64:64-p6:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64-a:8:8"
-else:
-    NVPTX64_DATALAYOUT = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128"
+NVPTX64_DATALAYOUT = (
+    "e-p:64:64:64-p6:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64"
+    "-i128:128:128-f32:32:32-f64:64:64-f128:128:128-v16:16:16-v32:32:32"
+    "-v64:64:64-v128:128:128-n16:32:64-a:8:8"
+)
 NVPTX64_TRIPLE = "nvptx64-nvidia-cuda"
 
 

--- a/src/numba_cuda_mlir/numba_cuda/cudadrv/nvvm.py
+++ b/src/numba_cuda_mlir/numba_cuda/cudadrv/nvvm.py
@@ -48,11 +48,16 @@ NVVM_ERROR_COMPILATION
 for i, k in enumerate(RESULT_CODE_NAMES):
     setattr(sys.modules[__name__], k, i)
 
-_datalayout = (
-    "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-"
-    "i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-"
-    "v64:64:64-v128:128:128-n16:32:64"
-)
+
+def _get_datalayout():
+    """Return the one NVPTX data layout used across the package.
+
+    Imported lazily because lowering_utilities imports back into this package,
+    so a module-level import here is circular.
+    """
+    from numba_cuda_mlir.lowering_utilities.llvm_utils import NVPTX64_DATALAYOUT
+
+    return NVPTX64_DATALAYOUT
 
 
 def is_available():
@@ -173,7 +178,7 @@ class NVVM:
 
     @property
     def data_layout(self):
-        return _datalayout
+        return _get_datalayout()
 
     def get_version(self):
         major = c_int()
@@ -204,7 +209,7 @@ class NVVM:
         """
 
         precheck_nvvm_ir = """target triple = "nvptx64-unknown-cuda"
-        target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"
+        target datalayout = "{datalayout}"
 
         define void @dummy_kernel() {{
         entry:
@@ -228,6 +233,7 @@ class NVVM:
 
             # Add the test program to the compilation unit
             precheck_nvvm_ir = precheck_nvvm_ir.format(
+                datalayout=_get_datalayout(),
                 major=self._majorIR,
                 minor=self._minorIR,
                 debug_major=self._majorDbg,

--- a/tests/numba_cuda_tests/cudadrv/test_nvvm_driver.py
+++ b/tests/numba_cuda_tests/cudadrv/test_nvvm_driver.py
@@ -54,6 +54,14 @@ class TestNvvmDriver(unittest.TestCase):
         for arch in nvrtc.get_supported_ccs():
             self._test_nvvm_support(arch=arch)
 
+    def test_check_options_probe_module_is_accepted(self):
+        # check_options() compiles a probe module and reports False when that
+        # compile fails, so it cannot distinguish an unsupported option from a
+        # probe libNVVM refuses to accept. A stale data layout in the probe
+        # would therefore report every option as unsupported, silently.
+        self.assertTrue(NVVM().check_options([]))
+        self.assertFalse(NVVM().check_options([b"-made-up-option=2"]))
+
 
 class TestLibDevice(unittest.TestCase):
     def test_libdevice_load(self):

--- a/tests/test_datalayout.py
+++ b/tests/test_datalayout.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import re
+from unittest import mock
+
+from numba_cuda_mlir.lowering_utilities import llvm_utils
+from numba_cuda_mlir.numba_cuda.cudadrv.nvvm import NVVM
+
+
+def _datalayout_for_host(machine):
+    """Return NVPTX64_DATALAYOUT as a fresh import of llvm_utils would define it.
+
+    Executed into a throwaway namespace so the real module, which caches loaded
+    CAPI handles at import time, is left untouched.
+    """
+    spec = importlib.util.spec_from_file_location("_llvm_utils_host_probe", llvm_utils.__file__)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch("platform.machine", return_value=machine):
+        spec.loader.exec_module(module)
+    return module.NVPTX64_DATALAYOUT
+
+
+def test_datalayout_does_not_vary_by_host_platform():
+    # The data layout describes the nvptx64 device ABI, so what the host reports
+    # through platform.machine() must not influence it.
+    layouts = {m: _datalayout_for_host(m) for m in ("x86_64", "aarch64", "AMD64", "ARM64")}
+    assert set(layouts.values()) == {llvm_utils.NVPTX64_DATALAYOUT}, (
+        f"data layout varies by host platform: {layouts}"
+    )
+
+
+def test_datalayout_declares_no_stack_alignment():
+    # "S<n>" is a stack natural alignment, a host-ABI property. Device code has
+    # no such requirement and libNVVM's target does not declare one, so
+    # declaring it here is a mismatch libNVVM rejects.
+    assert re.search(r"-S\d", llvm_utils.NVPTX64_DATALAYOUT) is None
+
+
+def test_nvvm_reports_the_same_datalayout():
+    # Read the getter off the class so this does not require libNVVM to be
+    # installed; it ignores self.
+    assert NVVM.data_layout.fget(None) == llvm_utils.NVPTX64_DATALAYOUT

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -319,6 +319,7 @@ def test_nvvm_ir_version_adaptation_is_thread_safe():
     from numba_cuda_mlir._mlir.dialects import gpu, llvm
     from numba_cuda_mlir.lowering_utilities.llvm_utils import (
         LLVM_C_LIB_PATH,
+        NVPTX64_DATALAYOUT,
         translate_to_llvmir,
     )
 
@@ -328,7 +329,7 @@ def test_nvvm_ir_version_adaptation_is_thread_safe():
     module_text = """
     module {
       gpu.module @kernels attributes {
-        llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128",
+        llvm.data_layout = "__DATALAYOUT__",
         llvm.target_triple = "nvptx64-nvidia-cuda"
       } {
         llvm.func @simple_kernel() attributes {gpu.kernel} {
@@ -336,7 +337,7 @@ def test_nvvm_ir_version_adaptation_is_thread_safe():
         }
       }
     }
-    """
+    """.replace("__DATALAYOUT__", NVPTX64_DATALAYOUT)
 
     def make_llvm_module():
         with ir.Context():


### PR DESCRIPTION
Revises the data layout describing the device ABI and normalizes it across all hosts.