### PR TITLE
Repair statement bodies emptied by AST transforms

### DIFF
--- a/src/numba_cuda_mlir/ast_transforms/__init__.py
+++ b/src/numba_cuda_mlir/ast_transforms/__init__.py
@@ -9,6 +9,7 @@ from numba_cuda_mlir.ast_transforms.common import get_function_ast, recompile_fu
 from numba_cuda_mlir.ast_transforms.comprehension import ComprehensionPass
 from numba_cuda_mlir.ast_transforms.consteval import ConstevalError, ConstevalPass
 from numba_cuda_mlir.ast_transforms.constant_if import ConstantIfPass
+from numba_cuda_mlir.ast_transforms.empty_body import EmptyBodyRepairPass
 from numba_cuda_mlir.ast_transforms.pipeline import (
     ASTTransformPass,
     ASTTransformPipeline,
@@ -63,6 +64,7 @@ def create_default_pipeline() -> ASTTransformPipeline:
     pipeline.add_pass(ConstantIfPass())
     pipeline.add_pass(ComprehensionPass())
     pipeline.add_pass(NoneStatementRemovalPass())
+    pipeline.add_pass(EmptyBodyRepairPass())
     return pipeline
 
 

--- a/src/numba_cuda_mlir/ast_transforms/empty_body.py
+++ b/src/numba_cuda_mlir/ast_transforms/empty_body.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Empty statement body repair pass
+import ast
+
+from numba_cuda_mlir.ast_transforms.pipeline import ASTTransformPass, TransformContext
+
+
+class EmptyBodyRepairer(ast.NodeTransformer):
+    """Fill empty statement bodies with ``pass``."""
+
+    def __init__(self):
+        self.modified = False
+
+    def generic_visit(self, node: ast.AST) -> ast.AST:
+        node = super().generic_visit(node)
+        body = getattr(node, "body", None)
+        if isinstance(body, list) and not body:
+            node.body = [ast.copy_location(ast.Pass(), node)]
+            self.modified = True
+        return node
+
+
+def repair_empty_bodies(tree: ast.Module) -> tuple[ast.Module, bool]:
+    """Insert ``pass`` into every empty statement body; returns (tree, was_modified)."""
+    repairer = EmptyBodyRepairer()
+    new_tree = repairer.visit(tree)
+    ast.fix_missing_locations(new_tree)
+    return new_tree, repairer.modified
+
+
+class EmptyBodyRepairPass(ASTTransformPass):
+    """Pipeline pass that fills statement bodies emptied by earlier passes with ``pass``."""
+
+    @property
+    def name(self) -> str:
+        return "EmptyBodyRepair"
+
+    def transform(self, tree: ast.Module, context: TransformContext) -> tuple[ast.Module, bool]:
+        return repair_empty_bodies(tree)

--- a/tests/ast_transforms/test_empty_body_repair.py
+++ b/tests/ast_transforms/test_empty_body_repair.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import ast
+
+import numba_cuda_mlir
+from numba_cuda_mlir.ast_transforms.empty_body import repair_empty_bodies
+from numba_cuda_mlir.cuda.experimental import consteval
+from numba_cuda_mlir import cuda
+import numpy as np
+
+
+def test_repair_inserts_pass_into_empty_bodies():
+    """Emptied if and for bodies each receive a single pass and compile."""
+    tree = ast.parse("def f(x):\n    if x:\n        pass\n    for i in x:\n        pass\n")
+    tree.body[0].body[0].body = []
+    tree.body[0].body[1].body = []
+    tree, modified = repair_empty_bodies(tree)
+    assert modified
+    compile(tree, "<test>", "exec")
+    assert isinstance(tree.body[0].body[0].body[0], ast.Pass)
+    assert isinstance(tree.body[0].body[1].body[0], ast.Pass)
+
+
+def test_repair_leaves_populated_bodies_alone():
+    """Bodies that still hold statements are not touched."""
+    tree = ast.parse("def f(x):\n    if x:\n        return 1\n    return 2\n")
+    tree, modified = repair_empty_bodies(tree)
+    assert not modified
+    assert ast.unparse(tree) == "def f(x):\n    if x:\n        return 1\n    return 2"
+
+
+def test_zero_trip_loop_as_only_statement():
+    """A zero-trip consteval loop that is the whole kernel body compiles to pass."""
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        for j in consteval(range(0)):
+            arr[j] = 1.0
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert source is not None
+    assert source.splitlines()[-2:] == ["def kernel(arr):", "    pass"]
+
+
+def test_false_if_as_only_statement_in_loop():
+    """A folded-away if that was the whole loop body leaves a pass loop body."""
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        i = cuda.threadIdx.x
+        for j in range(2):
+            if consteval(False):
+                arr[i] = 999.0
+        arr[i] = 1.0
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert source is not None
+    assert "for j in range(2):\n        pass" in source
+    assert "999.0" not in source
+
+    a = np.zeros(32, dtype=np.float32)
+    d_a = cuda.to_device(a)
+    kernel[1, 32](d_a)
+    result = d_a.copy_to_host()
+
+    assert all(result == 1.0)
+
+
+def test_consteval_block_as_only_statement_in_if():
+    """A removed consteval block that was the whole if body leaves a pass if body."""
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        i = cuda.threadIdx.x
+        if i > 0:
+            with consteval():
+                _unused = 1
+        arr[i] = 1.0
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert source is not None
+    assert "if i > 0:\n        pass" in source
+    assert "with consteval" not in source
+
+    a = np.zeros(32, dtype=np.float32)
+    d_a = cuda.to_device(a)
+    kernel[1, 32](d_a)
+    result = d_a.copy_to_host()
+
+    assert all(result == 1.0)
+
+
+def test_none_statement_as_only_statement_in_if():
+    """A removed None statement that was the whole if body leaves a pass if body."""
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        i = cuda.threadIdx.x
+        if i > 0:
+            consteval(None)
+        arr[i] = 1.0
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert source is not None
+    assert "if i > 0:\n        pass" in source
+    assert "None" not in source
+
+
+def test_repair_runs_after_all_passes():
+    """Unrolling empties the if body, folding empties the kernel body, one pass remains."""
+
+    @numba_cuda_mlir.cuda.jit
+    def kernel(arr):
+        if consteval(True):
+            for j in consteval(range(0)):
+                arr[j] = 1.0
+
+    cres = kernel.compile("void(float32[:])")
+    source = cres.metadata["transformed_source"]
+    assert source is not None
+    assert source.splitlines()[-2:] == ["def kernel(arr):", "    pass"]


### PR DESCRIPTION
# Repair statement bodies emptied by AST transforms

## Summary

A transform that removed the only statement in a body left that body empty, and `compile()` rejected the function. The pipeline now ends with a pass that fills each emptied body with `pass`.

## The problem

Four transforms delete statements outright: unrolling a loop over an empty iterable, folding a constant `if` with no branch to keep, removing a `with consteval():` block, and removing a bare `None` statement. Each returns an empty list in place of the statement. When nothing else shares the body, the enclosing function, loop, `if`, or `with` is left with no statements, and Python's compiler refuses the tree:

```python
@cuda.jit
def kernel(arr):
    for j in consteval(range(0)):
        arr[j] = 1.0
```

unrolled to

```python
def kernel(arr):
```

and compilation failed with

```
ValueError: empty body on FunctionDef
```

The same happens one level down: `if consteval(False):` as the only statement of a loop body gives `ValueError: empty body on For`. A zero-trip loop already compiled when another statement shared its body, so the failure depended on what surrounded the removed statement, not on which transform removed it.

## The fix

`EmptyBodyRepairPass` runs last in `create_default_pipeline`. It walks the tree and inserts a single `pass` into any statement body that is an empty list, so the example becomes

```python
def kernel(arr):
    pass
```

A `body` list is the only child `compile()` requires to be non-empty; an empty `orelse` is legal, so the pass leaves it alone. It reports no modification when it finds nothing to fill, so it never triggers a recompile by itself.

## Tests

Seven in `tests/ast_transforms/test_empty_body_repair.py`, asserting on `transformed_source` and on results:

- `test_repair_inserts_pass_into_empty_bodies` and `test_repair_leaves_populated_bodies_alone`: the repair function on its own
- `test_zero_trip_loop_as_only_statement`: a kernel body emptied by unrolling compiles to `pass`
- `test_false_if_as_only_statement_in_loop`: a loop body emptied by constant-if folding
- `test_consteval_block_as_only_statement_in_if`: an `if` body emptied by block removal
- `test_none_statement_as_only_statement_in_if`: an `if` body emptied by `None` removal
- `test_repair_runs_after_all_passes`: unrolling empties an `if`, folding then empties the kernel, one `pass` remains

Full suite: 4521 passed, 177 skipped, 300 xfailed, 0 failed.