### PR TITLE
Apply AST transforms to inlined device functions

### DIFF
--- a/src/numba_cuda_mlir/ast_transforms/__init__.py
+++ b/src/numba_cuda_mlir/ast_transforms/__init__.py
@@ -3,6 +3,7 @@
 # AST transformation passes for numba_cuda_mlir
 # These run before Numba's IR conversion
 import ast
+import inspect
 from typing import Callable
 
 from numba_cuda_mlir.ast_transforms.common import get_function_ast, recompile_function
@@ -17,6 +18,7 @@ from numba_cuda_mlir.ast_transforms.pipeline import (
 
 __all__ = [
     "apply_ast_transforms",
+    "transform_inline_callee",
     "ConstevalError",
     "ASTTransformPass",
     "ASTTransformPipeline",
@@ -127,3 +129,26 @@ def apply_ast_transforms(
         func = recompile_function(func, tree, context.stored_values)
 
     return func, transformed_source
+
+
+# Options taken from the callee's decorator; all others come from the caller.
+_CALLEE_AST_OPTIONS = ("experimental_ast_transforms", "dump_ast", "dump_ast_after_all")
+# Stands in for each parameter of an inlined callee, whose types are unknown.
+_INLINEE_PARAMETER = object()
+
+
+def transform_inline_callee(
+    pyfunc: Callable, callee_targetoptions: dict, caller_targetoptions: dict
+) -> Callable:
+    """Apply the callee's AST transforms under the caller's options; parameters resolve to a placeholder."""
+    if not callee_targetoptions.get("experimental_ast_transforms", False):
+        return pyfunc
+
+    targetoptions = dict(caller_targetoptions)
+    for name in _CALLEE_AST_OPTIONS:
+        if name in callee_targetoptions:
+            targetoptions[name] = callee_targetoptions[name]
+
+    argtypes = (_INLINEE_PARAMETER,) * len(inspect.signature(pyfunc).parameters)
+    transformed, _ = apply_ast_transforms(pyfunc, targetoptions, argtypes)
+    return transformed

--- a/src/numba_cuda_mlir/ast_transforms/common.py
+++ b/src/numba_cuda_mlir/ast_transforms/common.py
@@ -43,6 +43,8 @@ def recompile_function(func: Callable, tree: ast.Module, stored_values: dict = N
         stored_values: Dict of name -> value for complex objects that need to be
             injected into the function's globals
     """
+    # Shift the dedented tree's line numbers to the function's position in its file.
+    ast.increment_lineno(tree, func.__code__.co_firstlineno - 1)
     code = compile(tree, inspect.getfile(func), "exec")
 
     # Find the function's code object in the compiled module

--- a/src/numba_cuda_mlir/cuda/experimental/__init__.py
+++ b/src/numba_cuda_mlir/cuda/experimental/__init__.py
@@ -59,6 +59,10 @@ def consteval(value=None):
         with consteval():
             config = load_config()
             N = config["block_size"]
+
+    Inlined device functions (``inline=True``) are transformed when their own
+    decorator enables the AST transforms; inside them ``current_target_options()``
+    is the calling kernel's options and parameter names do not resolve to types.
     """
     if value is None:
         return _ConstevalContextManager()

--- a/src/numba_cuda_mlir/mlir_compiler.py
+++ b/src/numba_cuda_mlir/mlir_compiler.py
@@ -60,7 +60,7 @@ from numba_cuda_mlir._launch_config import (
     _LAUNCH_CONFIG_TRACKER_OPTION,
 )
 from numba_cuda_mlir.decorators import mlir_jit
-from numba_cuda_mlir.ast_transforms import apply_ast_transforms
+from numba_cuda_mlir.ast_transforms import apply_ast_transforms, transform_inline_callee
 from numba_cuda_mlir.errors import (
     InternalCompilerError,
     UserFacingInternalCompilerError,
@@ -299,6 +299,7 @@ def get_compiler_class(
             super().__init__(typingctx, targetctx, library, args, return_type, flags, locals)
             # Attach options early so all passes can see them via state.metadata
             self.state.metadata["targetoptions"] = targetoptions
+            self.state.metadata["inlinee_transform"] = transform_inline_callee
             if launch_config_tracker is not None:
                 self.state.metadata[_LAUNCH_CONFIG_TRACKER_METADATA_KEY] = launch_config_tracker
 

--- a/src/numba_cuda_mlir/numba_cuda/core/inline_closurecall.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/inline_closurecall.py
@@ -261,6 +261,8 @@ class InlineWorker:
         validator=callee_ir_validator,
         typemap=None,
         calltypes=None,
+        targetoptions=None,
+        inlinee_transform=None,
     ):
         """
         Instantiate a new InlineWorker, all arguments are optional though some
@@ -270,6 +272,7 @@ class InlineWorker:
         is a function taking Numba IR and validating it for use when inlining
         (this is optional and really to just provide better error messages about
         things which the inliner cannot handle like yield in closure).
+        inlinee_transform(func, callee_targetoptions, targetoptions) runs on chosen inlinees.
         """
 
         def check(arg, name):
@@ -298,6 +301,8 @@ class InlineWorker:
         self.pipeline = pipeline
         self.flags = flags
         self.validator = validator
+        self.targetoptions = targetoptions
+        self.inlinee_transform = inlinee_transform
         self.debug_print = _make_debug_print("InlineWorker")
 
         # check whether this inliner can also support typemap and calltypes
@@ -443,6 +448,12 @@ class InlineWorker:
         freevars = function.__code__.co_freevars
         return self.inline_ir(caller_ir, block, i, callee_ir, freevars, arg_typs=arg_typs)
 
+    def transform_inlinee(self, function, callee_targetoptions):
+        """Apply the configured target-specific transform to an inlinee."""
+        if self.inlinee_transform is None:
+            return function
+        return self.inlinee_transform(function, callee_targetoptions, self.targetoptions)
+
     def run_untyped_passes(self, func, enable_ssa=False):
         """
         Run the compiler frontend's untyped passes over the given Python
@@ -472,6 +483,10 @@ class InlineWorker:
         state.status = _CompileStatus(False)
         state.return_type = None
         state.metadata = {}
+        if self.targetoptions is not None:
+            state.metadata["targetoptions"] = self.targetoptions
+        if self.inlinee_transform is not None:
+            state.metadata["inlinee_transform"] = self.inlinee_transform
 
         ExtractByteCode().run_pass(state)
         # This is a lie, just need *some* args for the case where an obj mode

--- a/src/numba_cuda_mlir/numba_cuda/core/untyped_passes.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/untyped_passes.py
@@ -347,6 +347,8 @@ class InlineInlinables(FunctionPass):
             state.pipeline,
             state.flags,
             validator=inline_closurecall.callee_ir_validator,
+            targetoptions=state.metadata.get("targetoptions"),
+            inlinee_transform=state.metadata.get("inlinee_transform"),
         )
 
         modified = False
@@ -443,6 +445,7 @@ class InlineInlinables(FunctionPass):
                             do_inline = inline_type(expr, state.func_ir, py_func_ir)
                         # if do_inline is True then inline!
                         if do_inline:
+                            pyfunc = inline_worker.transform_inlinee(pyfunc, topt)
                             _, _, _, new_blocks = inline_worker.inline_function(
                                 state.func_ir,
                                 block,

--- a/tests/ast_transforms/test_consteval.py
+++ b/tests/ast_transforms/test_consteval.py
@@ -1190,3 +1190,21 @@ def test_consteval_block_unit_function_call():
 
     # 3*4+1 = 13
     assert "result = 13" in source
+
+
+def test_recompiled_function_keeps_source_lines():
+    """Unit test: a recompiled function keeps its original file line numbers."""
+    import inspect
+    from numba_cuda_mlir.ast_transforms import apply_ast_transforms
+
+    def probe(out):
+        out[0] = consteval(1)
+        return out
+
+    transformed, source = apply_ast_transforms(probe, {"experimental_ast_transforms": True})
+    assert source is not None
+    lines, first = inspect.getsourcelines(probe)
+    assign_line = first + next(i for i, ln in enumerate(lines) if "consteval(1)" in ln)
+    assert transformed.__code__.co_firstlineno == probe.__code__.co_firstlineno
+    transformed_lines = {line for _, _, line in transformed.__code__.co_lines() if line}
+    assert assign_line in transformed_lines

--- a/tests/ast_transforms/test_inlined_callees.py
+++ b/tests/ast_transforms/test_inlined_callees.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+import pytest
+
+from numba_cuda_mlir import cuda, mlir_compiler
+from numba_cuda_mlir.ast_transforms import ConstevalError
+from numba_cuda_mlir.cuda.experimental import consteval, current_target_options
+from numba_cuda_mlir.errors import TypingError
+
+
+def _kernel_chip(kernel) -> str:
+    (cres,) = kernel.overloads.values()
+    return cres.metadata["targetoptions"]["chip"]
+
+
+def test_inlined_callee_consteval_loop():
+    n = 4
+
+    @cuda.jit(device=True, inline=True)
+    def fill(out, base):
+        for i in consteval(range(n)):
+            out[i] = base + i
+
+    @cuda.jit
+    def kernel(out):
+        fill(out, 10)
+
+    out = cuda.to_device(np.zeros(8, dtype=np.int32))
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out.copy_to_host(), [10, 11, 12, 13, 0, 0, 0, 0])
+
+
+def test_nested_inlined_callees_transform():
+    n = 3
+
+    @cuda.jit(device=True, inline=True)
+    def inner(out, base):
+        for i in consteval(range(n)):
+            out[i] = base * consteval(10**i)
+
+    @cuda.jit(device=True, inline=True)
+    def outer(out):
+        inner(out, 2)
+        out[n] = consteval(n * 100)
+
+    @cuda.jit
+    def kernel(out):
+        outer(out)
+
+    out = cuda.to_device(np.zeros(4, dtype=np.int32))
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out.copy_to_host(), [2, 20, 200, 300])
+
+
+def test_inlined_callee_sees_caller_target_options():
+    @cuda.jit(device=True, inline=True)
+    def inner(out):
+        chip = consteval(current_target_options()["chip"])
+        out[1] = consteval(int(chip[3:]))
+
+    @cuda.jit(device=True, inline=True)
+    def outer(out):
+        chip = consteval(current_target_options()["chip"])
+        out[0] = consteval(int(chip[3:]))
+        inner(out)
+
+    @cuda.jit
+    def kernel(out):
+        outer(out)
+
+    out = cuda.to_device(np.zeros(2, dtype=np.int32))
+    kernel[1, 1](out)
+    expected = int(_kernel_chip(kernel)[3:])
+    np.testing.assert_array_equal(out.copy_to_host(), [expected, expected])
+
+
+def test_inlined_callee_parameter_types_unavailable():
+    @cuda.jit(device=True, inline=True)
+    def callee(out):
+        out[0] = consteval(out.ndim)
+
+    @cuda.jit
+    def kernel(out):
+        callee(out)
+
+    with pytest.raises(ConstevalError, match="Cannot evaluate consteval argument"):
+        kernel.compile("void(int32[:])")
+
+
+_shadowed = 3
+
+
+def test_inlined_callee_parameter_shadows_global():
+    @cuda.jit(device=True, inline=True)
+    def callee(out, _shadowed):
+        for i in consteval(range(_shadowed)):
+            out[i] = 1
+
+    @cuda.jit
+    def kernel(out):
+        callee(out, 5)
+
+    with pytest.raises(ConstevalError, match="Cannot evaluate consteval argument"):
+        kernel.compile("void(int32[:])")
+
+
+def test_callee_option_controls_transform():
+    n = 2
+
+    @cuda.jit(device=True, inline=True, experimental_ast_transforms=False)
+    def callee(out):
+        for i in consteval(range(n)):
+            out[i] = 1
+
+    @cuda.jit(experimental_ast_transforms=True)
+    def kernel(out):
+        callee(out)
+
+    with pytest.raises(TypingError, match="consteval"):
+        kernel.compile("void(int32[:])")
+
+
+def test_rejected_cost_model_does_not_transform(monkeypatch):
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("rejected inlinee was transformed")
+
+    monkeypatch.setattr(mlir_compiler, "transform_inline_callee", fail_if_called)
+
+    def never_inline(expr, caller_info, callee_info):
+        return False
+
+    @cuda.jit(device=True, inline=never_inline)
+    def callee(out):
+        out[0] = 1
+
+    @cuda.jit
+    def kernel(out):
+        callee(out)
+
+    kernel.compile("void(int32[:])")


### PR DESCRIPTION
# Apply AST transforms to inlined device functions

## Summary

A device function declared `inline=True` was spliced into its caller from its original bytecode, so `consteval` inside it was never transformed. Inlined callees now go through the AST transform pipeline before the inliner builds their Numba IR, the same way a kernel does.

numba/numba#5673 introduced `InlineWorker` so that every inlinee runs the full untyped pipeline and is transformed as though it were compiled directly. This repository runs AST transforms ahead of that pipeline, and this change extends the same rule to them.

## The problem

Kernels and non-inlined device functions are transformed in `compile_mlir`, before the compiler front end sees them. `InlineInlinables` takes a different route: it reads the callee's `py_func` and runs the untyped pipeline on its bytecode directly. `apply_ast_transforms` never ran on that function:

```python
n = 4

@cuda.jit(device=True, inline=True)
def fill(out, base):
    for i in consteval(range(n)):
        out[i] = base + i

@cuda.jit
def kernel(out):
    fill(out, 10)
```

failed in type inference:

```
TypingError: Untyped global name 'consteval': Cannot determine Numba type of <class 'function'>
    for i in consteval(range(n)):
```

Every `consteval` form inside an inlined callee failed this way: loops, expressions, `with consteval():` blocks and `current_target_options()`.

## The fix

`InlineWorker` gains two optional arguments: `targetoptions`, the caller's jit options, and `inlinee_transform`, a callback `(function, callee_targetoptions, targetoptions) -> function`. `InlineInlinables` reads both from `state.metadata` and calls the callback through `inline_worker.transform_inlinee` inside `if do_inline`, immediately before `inline_function`, so a callable cost model still evaluates the original function and a rejected inline is never transformed. The worker writes both values into the metadata of every callee state it builds, so a callee inlined inside another inlined callee is transformed the same way.

The MLIR compiler registers the callback, `ast_transforms.transform_inline_callee`, in `state.metadata` next to `targetoptions`; the generic pass carries no AST policy. The callback runs `apply_ast_transforms` with the caller's options, taking only `experimental_ast_transforms`, `dump_ast` and `dump_ast_after_all` from the callee's own decorator. Inside a transformed callee `current_target_options()` is therefore the calling kernel's option set. Every parameter name resolves to a placeholder object rather than a type, so a `consteval` expression that uses one raises `ConstevalError` instead of reading a same-named global.

`recompile_function` now shifts the dedented AST to the function's `co_firstlineno` before compiling it, so any transformed function's code object reports the lines of its defining file. This applies to kernels as well as inlined callees.

## Tests

Seven added in `tests/ast_transforms/test_inlined_callees.py`:

- `test_inlined_callee_consteval_loop`: a `consteval(range(n))` loop in an inlined callee unrolls and runs
- `test_nested_inlined_callees_transform`: a callee inlined inside another inlined callee is transformed
- `test_inlined_callee_sees_caller_target_options`: `current_target_options()` in nested callees reads the kernel's `chip`
- `test_inlined_callee_parameter_types_unavailable`: a parameter attribute in `consteval` raises `ConstevalError`
- `test_inlined_callee_parameter_shadows_global`: a parameter named like a module global raises `ConstevalError` rather than reading the global
- `test_callee_option_controls_transform`: a callee with `experimental_ast_transforms=False` is left alone and fails with the `TypingError` above
- `test_rejected_cost_model_does_not_transform`: a cost model returning `False` never invokes the transform

One added in `tests/ast_transforms/test_consteval.py`:

- `test_recompiled_function_keeps_source_lines`: a recompiled function keeps `co_firstlineno` and the original line of its transformed statement

Full suite: 4522 passed, 177 skipped, 300 xfailed, 0 failed. Six of the seven callee tests and the line-number test fail on `main`; `test_callee_option_controls_transform` passes there by construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying AST transformations to inlined device functions, including nested inlining.
  * Inlined functions now inherit the calling kernel’s target options while respecting their own transformation settings.
  * Added support for compile-time evaluation within inlined callees.

* **Bug Fixes**
  * Preserved original source line information for transformed and recompiled functions.

* **Documentation**
  * Clarified compile-time evaluation behavior for inline device functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->