### PR TITLE
Compute CFGraph topological order without recursion

### DIFF
--- a/src/numba_cuda_mlir/numba_cuda/core/controlflow.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/controlflow.py
@@ -641,15 +641,19 @@ class CFGraph:
         post_order = []
         seen = set()
 
-        def _dfs_rec(node):
+        # Successors pushed in reverse so the stack visits them in iteration order.
+        def visit(node):
             if node not in seen:
                 seen.add(node)
-                for dest in succs[node]:
-                    if (node, dest) not in back_edges:
-                        _dfs_rec(dest)
-                post_order.append(node)
+                stack.append((post_order.append, node))
+                forward = [dest for dest in succs[node] if (node, dest) not in back_edges]
+                stack.extend((visit, dest) for dest in reversed(forward))
 
-        _dfs_rec(self._entry_point)
+        stack = [(visit, self._entry_point)]
+        while stack:
+            cb, node = stack.pop()
+            cb(node)
+
         post_order.reverse()
         return post_order
 

--- a/tests/numba_cuda_tests/cudapy/test_flow_control.py
+++ b/tests/numba_cuda_tests/cudapy/test_flow_control.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import pytest
+import inspect
 import itertools
+import sys
 
 import unittest
 from numba_cuda_mlir import cuda
@@ -630,6 +632,33 @@ class TestCFGraph(NumbaCUDATestCase):
                 [0, 10, 13, 26, 19, 6],
             ),
         )
+
+    def test_topo_order_deep_graph(self):
+        # Diamond chain longer than the recursion limit.
+        n_diamonds = 2000
+        adj = {}
+        for i in range(n_diamonds):
+            head, body, join = 2 * i, 2 * i + 1, 2 * i + 2
+            adj[head] = [body, join]
+            adj[body] = [join]
+        adj[2 * n_diamonds] = []
+        g = self.from_adj_list(adj)
+        g.set_entry_point(0)
+        g.process()
+
+        current_depth = len(inspect.stack())
+        old_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(current_depth + 200)
+        try:
+            order = g.topo_order()
+        finally:
+            sys.setrecursionlimit(old_limit)
+
+        self.assertEqual(sorted(order), sorted(adj))
+        position = {node: i for i, node in enumerate(order)}
+        for src, dests in adj.items():
+            for dest in dests:
+                self.assertLess(position[src], position[dest])
 
     def test_topo_sort(self):
         def check_topo_sort(nodes, expected):


### PR DESCRIPTION
# Compute `CFGraph` topological order without recursion

## Summary

`CFGraph._find_topo_order` recursed once per basic block along the longest path through the control-flow graph. Kernels with more than about 1000 sequential blocks failed to compile with `RecursionError`. The traversal now runs on an explicit stack and produces the same order as before.

## The problem

Every kernel's CFG is topologically ordered during with-lifting. The order was computed by a recursive depth-first search, so its Python stack depth equalled the length of the longest forward path through the graph. A straight-line kernel of `if` blocks is one long path:

```python
lines = ["def kernel(arr, out):", "    i = cuda.grid(1)"]
for k in range(1500):
    lines.append(f"    if arr[i] > {k}.0:")
    lines.append("        out[i] += 1.0")
exec("\n".join(lines))
cuda.jit("void(float32[:], float32[:])")(kernel)
```

```
  File ".../numba_cuda/core/controlflow.py", line 649, in _dfs_rec
    _dfs_rec(dest)
  [Previous line repeated 975 more times]
RecursionError: maximum recursion depth exceeded
```

Kernels produced by `consteval` unrolling reach this size routinely.

## The fix

`_find_topo_order` runs the same depth-first search on an explicit stack of `(callback, node)` pairs, the shape `_find_postorder` already uses. Successors are pushed in reverse so nodes are visited in the same order as the recursive search, and `topo_order()` returns the same list as before for every graph that compiled.

numba/numba#10482, which fixes numba/numba#5611, removes the same recursion. Its traversal marks a node seen when it is pushed rather than when it is visited, which changes the emitted order and can place a node before one of its predecessors: on the graph `0 -> 1, 0 -> 2, 2 -> 1` it yields `[0, 1, 2]`. This change marks at visit time, so the order is identical to the recursive search and the existing `test_topo_order` assertions are unchanged.

## Tests

One added to `tests/numba_cuda_tests/cudapy/test_flow_control.py`:

- `test_topo_order_deep_graph`: a chain of 2000 diamonds (4001 nodes) is ordered under a recursion limit 200 frames above the test's own depth, with every node present and every edge pointing forward

`test_flow_control.py`: 61 passed, 4 xfailed. The generated 1500-block kernel above compiles and runs. On 500 random CFGs with loops the new order matches the recursive order exactly.

Full suite: 4515 passed, 177 skipped, 300 xfailed, 0 failed.
