### PR TITLE
Preserve signedness in integer-float conversions

### DIFF
--- a/src/numba_cuda_mlir/lowering/builtins.py
+++ b/src/numba_cuda_mlir/lowering/builtins.py
@@ -449,8 +449,14 @@ def lower_broadcasted_div(builder, target, args, kwargs):
 def type_convert(builder, target, args, kwargs):
     target_numba_ty = builder.get_numba_type(target)
     to_type = builder.get_mlir_type(target)
-    to_signed = isinstance(target_numba_ty, types.Integer) and target_numba_ty.signed
     source_numba_ty = builder.get_numba_type(args[0])
+    signed = (
+        source_numba_ty.signed
+        if isinstance(source_numba_ty, types.Integer)
+        else target_numba_ty.signed
+        if isinstance(target_numba_ty, types.Integer)
+        else False
+    )
 
     if isinstance(target_numba_ty, (types.IntegerLiteral, types.Literal)):
         result = constant(target_numba_ty.literal_value, to_type)
@@ -474,7 +480,7 @@ def type_convert(builder, target, args, kwargs):
         value = convert(
             value,
             to_type,
-            signed=to_signed and not isinstance(source_numba_ty, types.Boolean),
+            signed=signed and not isinstance(source_numba_ty, types.Boolean),
         )
     builder.store_var(target, value)
 

--- a/src/numba_cuda_mlir/lowering/builtins.py
+++ b/src/numba_cuda_mlir/lowering/builtins.py
@@ -473,7 +473,7 @@ def type_convert(builder, target, args, kwargs):
     if isinstance(value.type, ir.BF16Type) and isinstance(to_type, ir.IntegerType):
         value = (
             arith.fptosi(out=to_type, in_=value)
-            if to_type.width > 1
+            if signed
             else arith.fptoui(out=to_type, in_=value)
         )
     else:

--- a/src/numba_cuda_mlir/lowering/builtins.py
+++ b/src/numba_cuda_mlir/lowering/builtins.py
@@ -18,6 +18,7 @@ from numba_cuda_mlir.lowering_utilities import (
     tensor_to_memref,
     simple_scalar_conversion_op,
     expensive_coerce_tensor_type,
+    get_conversion_signedness,
     try_extract_constant,
 )
 from numba_cuda_mlir.logging import trace
@@ -450,13 +451,7 @@ def type_convert(builder, target, args, kwargs):
     target_numba_ty = builder.get_numba_type(target)
     to_type = builder.get_mlir_type(target)
     source_numba_ty = builder.get_numba_type(args[0])
-    signed = (
-        source_numba_ty.signed
-        if isinstance(source_numba_ty, types.Integer)
-        else target_numba_ty.signed
-        if isinstance(target_numba_ty, types.Integer)
-        else False
-    )
+    signed = get_conversion_signedness(source_numba_ty, target_numba_ty)
 
     if isinstance(target_numba_ty, (types.IntegerLiteral, types.Literal)):
         result = constant(target_numba_ty.literal_value, to_type)
@@ -478,7 +473,7 @@ def type_convert(builder, target, args, kwargs):
         value = convert(
             value,
             to_type,
-            signed=signed and not isinstance(source_numba_ty, types.Boolean),
+            signed=signed,
         )
     builder.store_var(target, value)
 

--- a/src/numba_cuda_mlir/lowering/builtins.py
+++ b/src/numba_cuda_mlir/lowering/builtins.py
@@ -472,9 +472,7 @@ def type_convert(builder, target, args, kwargs):
 
     if isinstance(value.type, ir.BF16Type) and isinstance(to_type, ir.IntegerType):
         value = (
-            arith.fptosi(out=to_type, in_=value)
-            if signed
-            else arith.fptoui(out=to_type, in_=value)
+            arith.fptosi(out=to_type, in_=value) if signed else arith.fptoui(out=to_type, in_=value)
         )
     else:
         value = convert(

--- a/src/numba_cuda_mlir/lowering/cmath.py
+++ b/src/numba_cuda_mlir/lowering/cmath.py
@@ -28,6 +28,7 @@ from numba_cuda_mlir.logging import trace
 from numba_cuda_mlir.lowering_utilities import (
     convert,
     DeferredMethodCall,
+    get_conversion_signedness,
     get_or_insert_function,
 )
 from numba_cuda_mlir.descriptor import MLIRTargetContext
@@ -56,8 +57,18 @@ def complex_constructor_2args_cg(mlir_lower, target, args, kwargs):
     target_mlir_type = mlir_lower.get_mlir_type(target_type)
     element_type = target_mlir_type.element_type
     # Convert to target element type
-    real = convert(real, element_type)
-    imag = convert(imag, element_type)
+    real_type = mlir_lower.get_numba_type(args[0].name)
+    imag_type = mlir_lower.get_numba_type(args[1].name)
+    real = convert(
+        real,
+        element_type,
+        signed=get_conversion_signedness(real_type, target_type),
+    )
+    imag = convert(
+        imag,
+        element_type,
+        signed=get_conversion_signedness(imag_type, target_type),
+    )
     result = complex_dialect.create_(target_mlir_type, real, imag)
     mlir_lower.store_var(target, result)
 
@@ -74,7 +85,12 @@ def complex_constructor_1arg_cg(mlir_lower, target, args, kwargs):
     target_mlir_type = mlir_lower.get_mlir_type(target_type)
     element_type = target_mlir_type.element_type
     # Convert to target element type
-    real = convert(real, element_type)
+    source_type = mlir_lower.get_numba_type(args[0].name)
+    real = convert(
+        real,
+        element_type,
+        signed=get_conversion_signedness(source_type, target_type),
+    )
     zero = arith.constant(result=element_type, value=0.0)
     result = complex_dialect.create_(target_mlir_type, real, zero)
     mlir_lower.store_var(target, result)

--- a/src/numba_cuda_mlir/lowering/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/lowering/cuda_vector_types.py
@@ -44,7 +44,7 @@ def _build_vector_from_scalars(scalars: list, vec_type: ir.VectorType) -> ir.Val
         )
 
     # Convert all scalars to the target element type before building the vector.
-    converted = [convert(s, elem_type) for s in scalars]
+    converted = [convert(s, elem_type, signed=signed) for s, signed in scalars]
 
     # Use vector.from_elements to build the vector.
     return vector.from_elements(vec_type, converted)
@@ -78,12 +78,25 @@ def _constructor_lowering(lower_ctx: MLIRLower, target, args: list[Any], kwargs)
         arg_type = lower_ctx.get_numba_type(arg.name)
 
         if isinstance(arg_type, VectorType):
-            scalars.extend(_extract_vector_elements(val))
+            if isinstance(arg_type.dtype, types.Integer):
+                signed = arg_type.dtype.signed
+            elif isinstance(target_type.dtype, types.Integer):
+                signed = target_type.dtype.signed
+            else:
+                signed = None
+            scalars.extend((scalar, signed) for scalar in _extract_vector_elements(val))
         elif isinstance(arg_type, types.Complex):
-            scalars.append(complex_dialect.re(val))
-            scalars.append(complex_dialect.im(val))
+            scalars.append((complex_dialect.re(val), None))
+            scalars.append((complex_dialect.im(val), None))
         else:
-            scalars.append(val)
+            signed = (
+                arg_type.signed
+                if isinstance(arg_type, types.Integer)
+                else target_type.dtype.signed
+                if isinstance(target_type.dtype, types.Integer)
+                else None
+            )
+            scalars.append((val, signed))
 
     if len(scalars) == 1 and num_elements > 1:
         scalars = scalars * num_elements

--- a/src/numba_cuda_mlir/lowering/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/lowering/cuda_vector_types.py
@@ -136,20 +136,22 @@ def _make_vector_binop_lowering(op):
         target_type = lower_ctx.get_numba_type(target.name)
         mlir_target_type = to_mlir_type(target_type)
         elem_type = mlir_target_type.element_type
+        lhs_signed = get_conversion_signedness(lhs_type, target_type)
+        rhs_signed = get_conversion_signedness(rhs_type, target_type)
 
         if isinstance(lhs_type, VectorType):
             if not isinstance(rhs_type, VectorType):
                 # rhs is scalar, broadcast it
-                rhs_val = convert(rhs, elem_type)
+                rhs_val = convert(rhs, elem_type, signed=rhs_signed)
                 rhs = vector.broadcast(mlir_target_type, rhs_val)
             else:
-                rhs = convert(rhs, mlir_target_type)
-            lhs = convert(lhs, mlir_target_type)
+                rhs = convert(rhs, mlir_target_type, signed=rhs_signed)
+            lhs = convert(lhs, mlir_target_type, signed=lhs_signed)
         else:
             # lhs is scalar, broadcast it
-            lhs_val = convert(lhs, elem_type)
+            lhs_val = convert(lhs, elem_type, signed=lhs_signed)
             lhs = vector.broadcast(mlir_target_type, lhs_val)
-            rhs = convert(rhs, mlir_target_type)
+            rhs = convert(rhs, mlir_target_type, signed=rhs_signed)
 
         if isinstance(elem_type, ir.IntegerType):
             result = iop(lhs, rhs)
@@ -222,12 +224,14 @@ def _vector_to_complex_cast(lower_ctx: MLIRLower, target, args: list[Any]):
     target_type = lower_ctx.get_numba_type(target.name)
     mlir_target_type = lower_ctx.get_mlir_type(target_type)
     val = lower_ctx.load_var(args[0])
+    source_type = lower_ctx.get_numba_type(args[0].name)
+    signed = get_conversion_signedness(source_type, target_type)
 
     real = vector.extract(val, [], [0])
     imag = vector.extract(val, [], [1])
 
-    real = convert(real, mlir_target_type.element_type)
-    imag = convert(imag, mlir_target_type.element_type)
+    real = convert(real, mlir_target_type.element_type, signed=signed)
+    imag = convert(imag, mlir_target_type.element_type, signed=signed)
 
     result = complex_dialect.create_(
         complex=mlir_target_type,

--- a/src/numba_cuda_mlir/lowering/cuda_vector_types.py
+++ b/src/numba_cuda_mlir/lowering/cuda_vector_types.py
@@ -14,7 +14,11 @@ registry = LoweringRegistry()
 _raw_lower = registry.lower
 lower_getattr = registry.lower_getattr
 from numba_cuda_mlir.mlir_lowering import MLIRLower
-from numba_cuda_mlir.lowering_utilities import convert, _get_mlir_bin_op_for_operator
+from numba_cuda_mlir.lowering_utilities import (
+    convert,
+    get_conversion_signedness,
+    _get_mlir_bin_op_for_operator,
+)
 from numba_cuda_mlir.lowering_utilities.type_conversions import to_mlir_type
 from numba_cuda_mlir.cuda.vector_types import _vector_types
 from numba_cuda_mlir.type_defs.vector_types import VectorType
@@ -76,26 +80,14 @@ def _constructor_lowering(lower_ctx: MLIRLower, target, args: list[Any], kwargs)
     for arg in args:
         val = lower_ctx.load_var(arg)
         arg_type = lower_ctx.get_numba_type(arg.name)
+        signed = get_conversion_signedness(arg_type, target_type)
 
         if isinstance(arg_type, VectorType):
-            if isinstance(arg_type.dtype, types.Integer):
-                signed = arg_type.dtype.signed
-            elif isinstance(target_type.dtype, types.Integer):
-                signed = target_type.dtype.signed
-            else:
-                signed = None
             scalars.extend((scalar, signed) for scalar in _extract_vector_elements(val))
         elif isinstance(arg_type, types.Complex):
-            scalars.append((complex_dialect.re(val), None))
-            scalars.append((complex_dialect.im(val), None))
+            scalars.append((complex_dialect.re(val), signed))
+            scalars.append((complex_dialect.im(val), signed))
         else:
-            signed = (
-                arg_type.signed
-                if isinstance(arg_type, types.Integer)
-                else target_type.dtype.signed
-                if isinstance(target_type.dtype, types.Integer)
-                else None
-            )
             scalars.append((val, signed))
 
     if len(scalars) == 1 and num_elements > 1:

--- a/src/numba_cuda_mlir/lowering/math.py
+++ b/src/numba_cuda_mlir/lowering/math.py
@@ -72,16 +72,26 @@ def _get_float_of_same_size_as(ty: ir.Type) -> ir.Type:
             raise ValueError(f"Unsupported type: {ty}")
 
 
-def _cast_to_float_of_same_size(value: ir.Value) -> ir.Value:
+def _cast_to_float_of_same_size(value: ir.Value, source_type: types.Type | None = None) -> ir.Value:
     float_type = _get_float_of_same_size_as(value.type)
-    return lowering_utilities.convert(value, float_type)
+    signed = None
+    if source_type is not None:
+        target_type = types.float32 if float_type == T.f32() else types.float64
+        signed = get_conversion_signedness(source_type, target_type)
+    return lowering_utilities.convert(value, float_type, signed=signed)
 
 
-def _ensure_float(value: ir.Value) -> ir.Value:
+def _ensure_float(value: ir.Value, source_type: types.Type | None = None) -> ir.Value:
     """Ensure value is floating-point, converting integers to floats if needed."""
     if isinstance(value.type, ir.IntegerType) or isinstance(value.type, ir.IndexType):
-        return _cast_to_float_of_same_size(value)
+        return _cast_to_float_of_same_size(value, source_type)
     return value
+
+
+def _load_as_float(mlir_lower, operand: numba_ir.Var) -> ir.Value:
+    """Load a math operand as a float, interpreting integers per their signedness."""
+    value = mlir_lower.load_var(operand)
+    return _ensure_float(value, mlir_lower.get_numba_type(operand.name))
 
 
 def _is_integer_type(ty: ir.Type) -> bool:
@@ -580,7 +590,7 @@ def math_ceil_cg(mlir_lower, target, args, kwargs):
     value = mlir_lower.load_var(args[0])
     if _is_integer_type(value.type):
         # ceil of an integer is the integer itself, but convert to float for return type
-        result = _cast_to_float_of_same_size(value)
+        result = _cast_to_float_of_same_size(value, mlir_lower.get_numba_type(args[0].name))
     else:
         result = math_dialect.ceil(value)
     mlir_lower.store_var(target, result)
@@ -592,7 +602,7 @@ def math_floor_cg(mlir_lower, target, args, kwargs):
     value = mlir_lower.load_var(args[0])
     if _is_integer_type(value.type):
         # floor of an integer is the integer itself, but convert to float for return type
-        result = _cast_to_float_of_same_size(value)
+        result = _cast_to_float_of_same_size(value, mlir_lower.get_numba_type(args[0].name))
     else:
         result = math_dialect.floor(value)
     mlir_lower.store_var(target, result)
@@ -604,7 +614,7 @@ def math_trunc_cg(mlir_lower, target, args, kwargs):
     value = mlir_lower.load_var(args[0])
     if _is_integer_type(value.type):
         # trunc of an integer is the integer itself, but convert to float for return type
-        result = _cast_to_float_of_same_size(value)
+        result = _cast_to_float_of_same_size(value, mlir_lower.get_numba_type(args[0].name))
     else:
         result = math_dialect.trunc(value)
     mlir_lower.store_var(target, result)
@@ -613,7 +623,7 @@ def math_trunc_cg(mlir_lower, target, args, kwargs):
 @lower(math.sin, types.Number)
 def math_sin_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_sin does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.sin(value)
     mlir_lower.store_var(target, result)
 
@@ -621,7 +631,7 @@ def math_sin_cg(mlir_lower, target, args, kwargs):
 @lower(math.cos, types.Number)
 def math_cos_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_cos does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.cos(value)
     mlir_lower.store_var(target, result)
 
@@ -629,7 +639,7 @@ def math_cos_cg(mlir_lower, target, args, kwargs):
 @lower(math.tan, types.Number)
 def math_tan_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_tan does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.tan(value)
     mlir_lower.store_var(target, result)
 
@@ -637,7 +647,7 @@ def math_tan_cg(mlir_lower, target, args, kwargs):
 @lower(math.sqrt, types.Number)
 def math_sqrt_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_sqrt does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.sqrt(value)
     mlir_lower.store_var(target, result)
 
@@ -645,7 +655,7 @@ def math_sqrt_cg(mlir_lower, target, args, kwargs):
 @lower(math.exp, types.Number)
 def math_exp_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_exp does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.exp(value)
     mlir_lower.store_var(target, result)
 
@@ -653,7 +663,7 @@ def math_exp_cg(mlir_lower, target, args, kwargs):
 @lower(math.log, types.Number)
 def math_log_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_log does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.log(value)
     mlir_lower.store_var(target, result)
 
@@ -661,7 +671,7 @@ def math_log_cg(mlir_lower, target, args, kwargs):
 @lower(math.log2, types.Number)
 def math_log2_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_log2 does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.log2(value)
     mlir_lower.store_var(target, result)
 
@@ -669,7 +679,7 @@ def math_log2_cg(mlir_lower, target, args, kwargs):
 @lower(math.log10, types.Number)
 def math_log10_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_log10 does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.log10(value)
     mlir_lower.store_var(target, result)
 
@@ -677,7 +687,7 @@ def math_log10_cg(mlir_lower, target, args, kwargs):
 @lower(math.fabs, types.Number)
 def math_fabs_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_fabs does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.absf(value)
     mlir_lower.store_var(target, result)
 
@@ -716,7 +726,7 @@ if hasattr(math, "exp2"):
     @lower(math.exp2, types.Number)
     def math_exp2_cg(mlir_lower, target, args, kwargs):
         assert not kwargs, "math_exp2 does not accept any keyword arguments"
-        value = _ensure_float(mlir_lower.load_var(args[0]))
+        value = _load_as_float(mlir_lower, args[0])
         result = math_dialect.exp2(value)
         mlir_lower.store_var(target, result)
 
@@ -724,7 +734,7 @@ if hasattr(math, "exp2"):
 @lower(math.tanh, types.Number)
 def math_tanh_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_tanh does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.tanh(value)
     mlir_lower.store_var(target, result)
 
@@ -732,7 +742,7 @@ def math_tanh_cg(mlir_lower, target, args, kwargs):
 @lower(math.sinh, types.Number)
 def math_sinh_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_sinh does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.sinh(value)
     mlir_lower.store_var(target, result)
 
@@ -740,7 +750,7 @@ def math_sinh_cg(mlir_lower, target, args, kwargs):
 @lower(math.cosh, types.Number)
 def math_cosh_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_cosh does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.cosh(value)
     mlir_lower.store_var(target, result)
 
@@ -748,7 +758,7 @@ def math_cosh_cg(mlir_lower, target, args, kwargs):
 @lower(math.asin, types.Number)
 def math_asin_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_asin does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.asin(value)
     mlir_lower.store_var(target, result)
 
@@ -756,7 +766,7 @@ def math_asin_cg(mlir_lower, target, args, kwargs):
 @lower(math.acos, types.Number)
 def math_acos_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_acos does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.acos(value)
     mlir_lower.store_var(target, result)
 
@@ -764,7 +774,7 @@ def math_acos_cg(mlir_lower, target, args, kwargs):
 @lower(math.atan, types.Number)
 def math_atan_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_atan does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.atan(value)
     mlir_lower.store_var(target, result)
 
@@ -772,7 +782,7 @@ def math_atan_cg(mlir_lower, target, args, kwargs):
 @lower(math.asinh, types.Number)
 def math_asinh_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_asinh does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.asinh(value)
     mlir_lower.store_var(target, result)
 
@@ -780,7 +790,7 @@ def math_asinh_cg(mlir_lower, target, args, kwargs):
 @lower(math.acosh, types.Number)
 def math_acosh_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_acosh does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.acosh(value)
     mlir_lower.store_var(target, result)
 
@@ -788,7 +798,7 @@ def math_acosh_cg(mlir_lower, target, args, kwargs):
 @lower(math.atanh, types.Number)
 def math_atanh_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_atanh does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.atanh(value)
     mlir_lower.store_var(target, result)
 
@@ -810,8 +820,8 @@ def math_isinf_cg(mlir_lower, target, args, kwargs):
 def math_copysign_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_copysign does not accept any keyword arguments"
     assert len(args) == 2, "math_copysign expects 2 arguments"
-    x = _ensure_float(mlir_lower.load_var(args[0]))
-    y = _ensure_float(mlir_lower.load_var(args[1]))
+    x = _load_as_float(mlir_lower, args[0])
+    y = _load_as_float(mlir_lower, args[1])
     # Ensure both have the same type
     unified_type = lowering_utilities.numpy_implicit_type_promotion(x.type, y.type)
     x = convert(x, unified_type)
@@ -824,8 +834,8 @@ def math_copysign_cg(mlir_lower, target, args, kwargs):
 def math_atan2_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_atan2 does not accept any keyword arguments"
     assert len(args) == 2, "math_atan2 expects 2 arguments"
-    y = _ensure_float(mlir_lower.load_var(args[0]))
-    x = _ensure_float(mlir_lower.load_var(args[1]))
+    y = _load_as_float(mlir_lower, args[0])
+    x = _load_as_float(mlir_lower, args[1])
     # Ensure both have the same type
     unified_type = lowering_utilities.numpy_implicit_type_promotion(y.type, x.type)
     y = convert(y, unified_type)
@@ -839,8 +849,8 @@ def math_hypot_cg(mlir_lower, target, args, kwargs):
     """hypot(x, y) = sqrt(x^2 + y^2), computed in float64 for precision"""
     assert not kwargs, "math_hypot does not accept any keyword arguments"
     assert len(args) == 2, "math_hypot expects 2 arguments"
-    x = _ensure_float(mlir_lower.load_var(args[0]))
-    y = _ensure_float(mlir_lower.load_var(args[1]))
+    x = _load_as_float(mlir_lower, args[0])
+    y = _load_as_float(mlir_lower, args[1])
     unified_type = lowering_utilities.numpy_implicit_type_promotion(x.type, y.type)
     x = convert(x, unified_type)
     y = convert(y, unified_type)
@@ -864,7 +874,7 @@ def math_hypot_cg(mlir_lower, target, args, kwargs):
 def math_log1p_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_log1p does not accept any keyword arguments"
     assert len(args) == 1, "math_log1p expects 1 argument"
-    x = _ensure_float(mlir_lower.load_var(args[0]))
+    x = _load_as_float(mlir_lower, args[0])
     result = math_dialect.log1p(x)
     mlir_lower.store_var(target, result)
 
@@ -1174,7 +1184,7 @@ def math_ldexp_cg(mlir_lower, target, args, kwargs):
 @lower(math.expm1, types.Number)
 def math_expm1_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_expm1 does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.expm1(value)
     mlir_lower.store_var(target, result)
 
@@ -1183,7 +1193,7 @@ def math_expm1_cg(mlir_lower, target, args, kwargs):
 def math_degrees_cg(mlir_lower, target, args, kwargs):
     """Convert radians to degrees: x * (180 / pi)"""
     assert not kwargs, "math_degrees does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     # 180 / pi = 57.29577951308232
     factor = lowering_utilities.constant(57.29577951308232, value.type)
     result = arith.mulf(value, factor)
@@ -1194,7 +1204,7 @@ def math_degrees_cg(mlir_lower, target, args, kwargs):
 def math_radians_cg(mlir_lower, target, args, kwargs):
     """Convert degrees to radians: x * (pi / 180)"""
     assert not kwargs, "math_radians does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     # pi / 180 = 0.017453292519943295
     factor = lowering_utilities.constant(0.017453292519943295, value.type)
     result = arith.mulf(value, factor)
@@ -1204,7 +1214,7 @@ def math_radians_cg(mlir_lower, target, args, kwargs):
 @lower(math.erf, types.Number)
 def math_erf_cg(mlir_lower, target, args, kwargs):
     assert not kwargs, "math_erf does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = math_dialect.erf(value)
     mlir_lower.store_var(target, result)
 
@@ -1213,7 +1223,7 @@ def math_erf_cg(mlir_lower, target, args, kwargs):
 def math_erfc_cg(mlir_lower, target, args, kwargs):
     """erfc(x) = complementary error function, using libdevice for precision"""
     assert not kwargs, "math_erfc does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = _call_libdevice_unary(mlir_lower, value, "__nv_erfc", "__nv_erfcf")
     mlir_lower.store_var(target, result)
 
@@ -1222,7 +1232,7 @@ def math_erfc_cg(mlir_lower, target, args, kwargs):
 def math_gamma_cg(mlir_lower, target, args, kwargs):
     """Lower math.gamma using libdevice tgamma"""
     assert not kwargs, "math_gamma does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = _call_libdevice_unary(mlir_lower, value, "__nv_tgamma", "__nv_tgammaf")
     mlir_lower.store_var(target, result)
 
@@ -1231,7 +1241,7 @@ def math_gamma_cg(mlir_lower, target, args, kwargs):
 def math_lgamma_cg(mlir_lower, target, args, kwargs):
     """Lower math.lgamma using libdevice lgamma"""
     assert not kwargs, "math_lgamma does not accept any keyword arguments"
-    value = _ensure_float(mlir_lower.load_var(args[0]))
+    value = _load_as_float(mlir_lower, args[0])
     result = _call_libdevice_unary(mlir_lower, value, "__nv_lgamma", "__nv_lgammaf")
     mlir_lower.store_var(target, result)
 
@@ -1241,8 +1251,8 @@ def math_fmod_cg(mlir_lower, target, args, kwargs):
     """fmod(x, y) - floating point remainder with sign of x (truncated division)"""
     assert not kwargs, "math_fmod does not accept any keyword arguments"
     assert len(args) == 2, "math_fmod expects 2 arguments"
-    x = _ensure_float(mlir_lower.load_var(args[0]))
-    y = _ensure_float(mlir_lower.load_var(args[1]))
+    x = _load_as_float(mlir_lower, args[0])
+    y = _load_as_float(mlir_lower, args[1])
     unified_type = lowering_utilities.numpy_implicit_type_promotion(x.type, y.type)
     x = convert(x, unified_type)
     y = convert(y, unified_type)
@@ -1260,8 +1270,8 @@ def math_remainder_cg(mlir_lower, target, args, kwargs):
     """IEEE 754 remainder: x - round(x/y) * y"""
     assert not kwargs, "math_remainder does not accept any keyword arguments"
     assert len(args) == 2, "math_remainder expects 2 arguments"
-    x = _ensure_float(mlir_lower.load_var(args[0]))
-    y = _ensure_float(mlir_lower.load_var(args[1]))
+    x = _load_as_float(mlir_lower, args[0])
+    y = _load_as_float(mlir_lower, args[1])
     unified_type = lowering_utilities.numpy_implicit_type_promotion(x.type, y.type)
     x = convert(x, unified_type)
     y = convert(y, unified_type)
@@ -1278,8 +1288,8 @@ def math_pow_cg(mlir_lower, target, args, kwargs):
     """math.pow(x, y) - x raised to power y"""
     assert not kwargs, "math_pow does not accept any keyword arguments"
     assert len(args) == 2, "math_pow expects 2 arguments"
-    x = _ensure_float(mlir_lower.load_var(args[0]))
-    y = _ensure_float(mlir_lower.load_var(args[1]))
+    x = _load_as_float(mlir_lower, args[0])
+    y = _load_as_float(mlir_lower, args[1])
     unified_type = lowering_utilities.numpy_implicit_type_promotion(x.type, y.type)
     x = convert(x, unified_type)
     y = convert(y, unified_type)
@@ -1292,8 +1302,8 @@ def math_nextafter_cg(mlir_lower, target, args, kwargs):
     """nextafter(x, y) - next representable floating-point value after x towards y"""
     assert not kwargs, "math_nextafter does not accept any keyword arguments"
     assert len(args) == 2, "math_nextafter expects 2 arguments"
-    x = _ensure_float(mlir_lower.load_var(args[0]))
-    y = _ensure_float(mlir_lower.load_var(args[1]))
+    x = _load_as_float(mlir_lower, args[0])
+    y = _load_as_float(mlir_lower, args[1])
     unified_type = lowering_utilities.numpy_implicit_type_promotion(x.type, y.type)
     x = convert(x, unified_type)
     y = convert(y, unified_type)

--- a/src/numba_cuda_mlir/lowering/math.py
+++ b/src/numba_cuda_mlir/lowering/math.py
@@ -60,10 +60,11 @@ def _get_float_of_same_size_as(ty: ir.Type) -> ir.Type:
             return T.f64()
         case ir.IntegerType():
             match ty.width:
-                case 32:
-                    return T.f32()
                 case 64:
                     return T.f64()
+                case 1 | 8 | 16 | 32:
+                    # f32 represents every value of these widths exactly.
+                    return T.f32()
                 case _:
                     raise ValueError(f"Unsupported integer type width: {ty.width}")
         case ir.FloatType():

--- a/src/numba_cuda_mlir/lowering/math.py
+++ b/src/numba_cuda_mlir/lowering/math.py
@@ -63,7 +63,6 @@ def _get_float_of_same_size_as(ty: ir.Type) -> ir.Type:
                 case 64:
                     return T.f64()
                 case 1 | 8 | 16 | 32:
-                    # f32 represents every value of these widths exactly.
                     return T.f32()
                 case _:
                     raise ValueError(f"Unsupported integer type width: {ty.width}")

--- a/src/numba_cuda_mlir/lowering/math.py
+++ b/src/numba_cuda_mlir/lowering/math.py
@@ -7,6 +7,7 @@ from numba_cuda_mlir import lowering_utilities
 from numba_cuda_mlir.lowering_utilities import (
     numpy_implicit_type_promotion,
     convert,
+    get_conversion_signedness,
     get_or_insert_function,
 )
 from numba_cuda_mlir.logging import trace
@@ -311,14 +312,15 @@ def pow_cg(builder, target, args, kwargs):
     builder.store_var(target, res)
 
 
-def _convert_integer_operand(value, source_type, target_type):
-    if isinstance(target_type, ir.FloatType):
-        return (
-            arith.sitofp(out=target_type, in_=value)
-            if source_type.signed
-            else arith.uitofp(out=target_type, in_=value)
-        )
-    return lowering_utilities.convert(value, target_type, signed=source_type.signed)
+def _convert_operand(value, source_type, target_type, target_mlir_type):
+    signed = get_conversion_signedness(source_type, target_type)
+    return lowering_utilities.convert(value, target_mlir_type, signed=signed)
+
+
+def _load_and_convert_operand(builder, operand, target_type, target_mlir_type):
+    source_type = builder.get_numba_type(operand.name)
+    value = builder.load_var(operand)
+    return _convert_operand(value, source_type, target_type, target_mlir_type)
 
 
 def _bin_op_cg(op, builder, target, args, kwargs):
@@ -389,11 +391,11 @@ def _bin_op_cg(op, builder, target, args, kwargs):
         info, op = found_op
         assert op is not None, "Expected operation"
         if info.cast_to_return_type:
-            lhs = lowering_utilities.convert(lhs, target_mlir_type)
-            rhs = lowering_utilities.convert(rhs, target_mlir_type)
+            lhs = _convert_operand(lhs, lhs_type, target_type, target_mlir_type)
+            rhs = _convert_operand(rhs, rhs_type, target_type, target_mlir_type)
         elif promoted_numba_type is not None:
-            lhs = _convert_integer_operand(lhs, lhs_type, unified_type)
-            rhs = _convert_integer_operand(rhs, rhs_type, unified_type)
+            lhs = _convert_operand(lhs, lhs_type, promoted_numba_type, unified_type)
+            rhs = _convert_operand(rhs, rhs_type, promoted_numba_type, unified_type)
         else:
             lhs, rhs = lowering_utilities.coerce_numpy_scalars_for_binary_op(lhs, rhs)
         res = op(lhs, rhs)
@@ -874,17 +876,13 @@ def mod_cg(builder, target, args, kwargs):
     assert len(args) == 2, "mod_cg expects 2 arguments"
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
-    # MLIR integer types here are signless; signedness must come from the
-    # Numba type so that operand widening sign-extends signed values.
-    # Non-integer targets keep convert's unsigned default.
-    signed = isinstance(target_type, types.Integer) and target_type.signed
     lhs, rhs = args
-    lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type, signed=signed)
-    rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type, signed=signed)
+    lhs = _load_and_convert_operand(builder, lhs, target_type, target_mlir_type)
+    rhs = _load_and_convert_operand(builder, rhs, target_type, target_mlir_type)
 
     match target_mlir_type:
         case ir.IntegerType():
-            if signed:
+            if target_type.signed:
                 # Python floored modulo: the result takes the sign of the
                 # divisor. arith.remsi truncates toward zero, so add the
                 # divisor when the remainder is nonzero and its sign
@@ -916,8 +914,8 @@ def lshift_cg(builder, target, args, kwargs):
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
     lhs, rhs = args
-    lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type)
-    rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type)
+    lhs = _load_and_convert_operand(builder, lhs, target_type, target_mlir_type)
+    rhs = _load_and_convert_operand(builder, rhs, target_type, target_mlir_type)
     result = arith.shli(lhs, rhs)
     builder.store_var(target, result)
 
@@ -930,8 +928,8 @@ def rshift_cg(builder, target, args, kwargs):
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
     lhs, rhs = args
-    lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type)
-    rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type)
+    lhs = _load_and_convert_operand(builder, lhs, target_type, target_mlir_type)
+    rhs = _load_and_convert_operand(builder, rhs, target_type, target_mlir_type)
     # Use unsigned right shift for unsigned types, signed for signed types
     if target_type.signed:
         result = arith.shrsi(lhs, rhs)
@@ -962,8 +960,8 @@ def and_cg(builder, target, args, kwargs):
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
     lhs, rhs = args
-    lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type)
-    rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type)
+    lhs = _load_and_convert_operand(builder, lhs, target_type, target_mlir_type)
+    rhs = _load_and_convert_operand(builder, rhs, target_type, target_mlir_type)
     result = arith.andi(lhs, rhs)
     builder.store_var(target, result)
 
@@ -978,8 +976,8 @@ def or_cg(builder, target, args, kwargs):
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
     lhs, rhs = args
-    lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type)
-    rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type)
+    lhs = _load_and_convert_operand(builder, lhs, target_type, target_mlir_type)
+    rhs = _load_and_convert_operand(builder, rhs, target_type, target_mlir_type)
     result = arith.ori(lhs, rhs)
     builder.store_var(target, result)
 
@@ -994,8 +992,8 @@ def xor_cg(builder, target, args, kwargs):
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
     lhs, rhs = args
-    lhs = lowering_utilities.convert(builder.load_var(lhs), target_mlir_type)
-    rhs = lowering_utilities.convert(builder.load_var(rhs), target_mlir_type)
+    lhs = _load_and_convert_operand(builder, lhs, target_type, target_mlir_type)
+    rhs = _load_and_convert_operand(builder, rhs, target_type, target_mlir_type)
     result = arith.xori(lhs, rhs)
     builder.store_var(target, result)
 
@@ -1008,7 +1006,7 @@ def invert_cg(builder, target, args, kwargs):
     assert len(args) == 1, "invert_cg expects 1 argument"
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
-    operand = lowering_utilities.convert(builder.load_var(args[0]), target_mlir_type)
+    operand = _load_and_convert_operand(builder, args[0], target_type, target_mlir_type)
     fill = 1 if isinstance(target_type, types.Boolean) else -1
     all_ones = lowering_utilities.constant(fill, target_mlir_type)
     result = arith.xori(operand, all_ones)
@@ -1023,24 +1021,18 @@ def floordiv_cg(builder, target, args, kwargs):
     target_type = builder.get_numba_type(target.name)
     target_mlir_type = builder.get_mlir_type(target_type)
     lhs, rhs = args
-    lhs, rhs = builder.load_var(lhs), builder.load_var(rhs)
+    lhs = _load_and_convert_operand(builder, lhs, target_type, target_mlir_type)
+    rhs = _load_and_convert_operand(builder, rhs, target_type, target_mlir_type)
 
     match target_mlir_type:
         case ir.FloatType():
             # For floats: floor(a / b)
-            lhs = lowering_utilities.convert(lhs, target_mlir_type)
-            rhs = lowering_utilities.convert(rhs, target_mlir_type)
             div_result = arith.divf(lhs, rhs)
             result = math_dialect.floor(div_result)
         case ir.IntegerType():
-            # MLIR integer types here are signless (is_signed is always
-            # False), so signedness must come from the Numba type — both
-            # for the widening conversion (extsi vs extui) and for the
-            # choice of division op.
-            signed = target_type.signed
-            lhs = lowering_utilities.convert(lhs, target_mlir_type, signed=signed)
-            rhs = lowering_utilities.convert(rhs, target_mlir_type, signed=signed)
-            if signed:
+            # Result type selects signed or unsigned floor division. Operand
+            # conversion signedness was handled independently above.
+            if target_type.signed:
                 result = arith.floordivsi(lhs, rhs)
             else:
                 # For unsigned, regular division is the same as floor division

--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -1581,6 +1581,15 @@ def lower_array_setitem(builder: MLIRLower, target, args, kwargs):
     index = builder.load_var(args[1])
     index = lowering_utilities.index_of(index)
     value = builder.load_var(args[2])
+    value_numba_type = builder.get_numba_type(args[2].name)
+    if isinstance(value_numba_type, types.Integer):
+        signed = value_numba_type.signed
+    elif isinstance(value_numba_type, types.Boolean):
+        signed = False
+    elif isinstance(array_numba_type.dtype, types.Integer):
+        signed = array_numba_type.dtype.signed
+    else:
+        signed = None
     mrt = array.type
     if mrt.rank == 1:
         lowering_utilities.array_element_value_store(
@@ -1589,6 +1598,7 @@ def lower_array_setitem(builder: MLIRLower, target, args, kwargs):
             [index],
             value,
             dynamic_shared_memory=builder._is_dynamic_shared_memory(array),
+            signed=signed,
         )
     else:
         rankm1 = mrt.rank - 1
@@ -1605,6 +1615,7 @@ def lower_array_setitem(builder: MLIRLower, target, args, kwargs):
                 [index] + list(indices),
                 value,
                 dynamic_shared_memory=builder._is_dynamic_shared_memory(array),
+                signed=signed,
             )
 
 

--- a/src/numba_cuda_mlir/lowering/numpy.py
+++ b/src/numba_cuda_mlir/lowering/numpy.py
@@ -51,6 +51,7 @@ from numba_cuda_mlir.lowering_utilities import (
     try_extract_constant,
     NdIterIterObject,
     is_nonelike,
+    get_conversion_signedness,
     storage_itemsize_bytes,
 )
 from numba_cuda_mlir.mlir_lowering import KERNEL_ERROR_CODES
@@ -1582,14 +1583,7 @@ def lower_array_setitem(builder: MLIRLower, target, args, kwargs):
     index = lowering_utilities.index_of(index)
     value = builder.load_var(args[2])
     value_numba_type = builder.get_numba_type(args[2].name)
-    if isinstance(value_numba_type, types.Integer):
-        signed = value_numba_type.signed
-    elif isinstance(value_numba_type, types.Boolean):
-        signed = False
-    elif isinstance(array_numba_type.dtype, types.Integer):
-        signed = array_numba_type.dtype.signed
-    else:
-        signed = None
+    signed = get_conversion_signedness(value_numba_type, array_numba_type.dtype)
     mrt = array.type
     if mrt.rank == 1:
         lowering_utilities.array_element_value_store(

--- a/src/numba_cuda_mlir/lowering_utilities/__init__.py
+++ b/src/numba_cuda_mlir/lowering_utilities/__init__.py
@@ -347,14 +347,16 @@ def _integer_storage_type_for_value(numba_type: types.Type, value_type: ir.Type)
     return ir.IntegerType.get_signless(_numba_type_bitwidth(numba_type, value_type))
 
 
-def value_to_storage(numba_type: types.Type, value: ir.Value) -> ir.Value:
+def value_to_storage(
+    numba_type: types.Type, value: ir.Value, *, signed: bool | None = None
+) -> ir.Value:
     """Convert a source-level value to its memory/ABI storage representation."""
     storage_type = get_storage_type(numba_type)
     value_type = get_value_type(numba_type)
     if getattr(value, "type", None) == storage_type and value_type == storage_type:
         return value
     if getattr(value, "type", None) != value_type:
-        value = convert(value, value_type)
+        value = convert(value, value_type, signed=signed)
     if value_type == storage_type:
         return value
 
@@ -371,7 +373,7 @@ def value_to_storage(numba_type: types.Type, value: ir.Value) -> ir.Value:
             return arith.extui(out=storage_type, in_=bits)
         return arith.trunci(out=storage_type, in_=bits)
 
-    return convert(value, storage_type)
+    return convert(value, storage_type, signed=signed)
 
 
 def storage_to_value(numba_type: types.Type, value: ir.Value) -> ir.Value:
@@ -426,8 +428,9 @@ def array_element_value_store(
     value: ir.Value,
     *,
     dynamic_shared_memory: bool = False,
+    signed: bool | None = None,
 ):
-    stored = value_to_storage(array_type.dtype, value)
+    stored = value_to_storage(array_type.dtype, value, signed=signed)
     if dynamic_shared_memory:
         ptr = memref_to_llvm_ptr(array, list(indices), stored.type)
         llvm_ptr_store(stored, ptr)
@@ -851,14 +854,14 @@ def _convert_integer_to_integer(
     return value
 
 
-def convert(value, target_type, *, signed: bool = False):
+def convert(value, target_type, *, signed: bool | None = None):
     if getattr(value, "type", None) == target_type:
         return value
     return ensure_verifies(unverified_convert(value, target_type, signed=signed))
 
 
 @singledispatch
-def unverified_convert(value, target_type, *, signed: bool = False):
+def unverified_convert(value, target_type, *, signed: bool | None = None):
     raise NotImplementedError(f"Not implemented for type {type(value)}")
 
 
@@ -909,7 +912,7 @@ def unverified_basic_mlir_convert(
     value,
     target_type: ir.Type,
     *,
-    signed: bool = False,
+    signed: bool | None = None,
 ) -> ir.Value:
     from numba_cuda_mlir._mlir.dialects import (
         complex as complex_dialect,
@@ -924,6 +927,10 @@ def unverified_basic_mlir_convert(
         return constant(value, target_type)
     value_type = value.type
     trace("value_type: %s, target_type: %s", value_type, target_type)
+
+    def use_signed_conversion(default: bool) -> bool:
+        return default if signed is None else signed
+
     match value_type, target_type:
         case ir.Type() as x, ir.Type() as y if x == y:
             trace("value_type == target_type, returning value")
@@ -966,13 +973,13 @@ def unverified_basic_mlir_convert(
             elif isinstance(elem1, ir.IntegerType) and isinstance(elem2, ir.FloatType):
                 return (
                     arith.sitofp(out=target_type, in_=value)
-                    if elem1.width > 1
+                    if use_signed_conversion(elem1.width > 1)
                     else arith.uitofp(out=target_type, in_=value)
                 )
             elif isinstance(elem1, ir.FloatType) and isinstance(elem2, ir.IntegerType):
                 return (
                     arith.fptosi(out=target_type, in_=value)
-                    if elem2.width > 1
+                    if use_signed_conversion(elem2.width > 1)
                     else arith.fptoui(out=target_type, in_=value)
                 )
             else:
@@ -980,7 +987,7 @@ def unverified_basic_mlir_convert(
         case ir.IntegerType(), ir.FloatType():
             return (
                 arith.sitofp(out=target_type, in_=value)
-                if value_type.width > 1
+                if use_signed_conversion(value_type.width > 1)
                 else arith.uitofp(out=target_type, in_=value)
             )
         case ir.BF16Type(), ir.IntegerType() if target_type.width == 16:
@@ -990,7 +997,7 @@ def unverified_basic_mlir_convert(
         case ir.FloatType(), ir.IntegerType():
             return (
                 arith.fptosi(out=target_type, in_=value)
-                if target_type.width > 1
+                if use_signed_conversion(target_type.width > 1)
                 else arith.fptoui(out=target_type, in_=value)
             )
         case ir.IntegerType(), ir.ComplexType():

--- a/src/numba_cuda_mlir/lowering_utilities/__init__.py
+++ b/src/numba_cuda_mlir/lowering_utilities/__init__.py
@@ -995,7 +995,11 @@ def unverified_basic_mlir_convert(
                 if elem1.width > elem2.width:
                     return arith.trunci(out=target_type, in_=value)
                 else:
-                    return arith.extsi(out=target_type, in_=value)
+                    return (
+                        arith.extsi(out=target_type, in_=value)
+                        if use_signed_conversion(elem1.width > 1)
+                        else arith.extui(out=target_type, in_=value)
+                    )
             elif isinstance(elem1, ir.IntegerType) and isinstance(elem2, ir.FloatType):
                 return (
                     arith.sitofp(out=target_type, in_=value)
@@ -1016,11 +1020,7 @@ def unverified_basic_mlir_convert(
                 if use_signed_conversion(value_type.width > 1)
                 else arith.uitofp(out=target_type, in_=value)
             )
-        case ir.BF16Type(), ir.IntegerType() if target_type.width == 16:
-            # bf16 to int16/uint16: use bitcast to preserve bit pattern
-            trace("bf16 -> i16 bitcast conversion")
-            return arith.bitcast(out=target_type, in_=value)
-        case ir.FloatType(), ir.IntegerType():
+        case (ir.FloatType() | ir.BF16Type()), ir.IntegerType():
             return (
                 arith.fptosi(out=target_type, in_=value)
                 if use_signed_conversion(target_type.width > 1)
@@ -1031,7 +1031,7 @@ def unverified_basic_mlir_convert(
             float_type = target_type.element_type
             float_val = (
                 arith.sitofp(out=float_type, in_=value)
-                if value_type.width > 1
+                if use_signed_conversion(value_type.width > 1)
                 else arith.uitofp(out=float_type, in_=value)
             )
             zero = arith.constant(result=float_type, value=0.0)

--- a/src/numba_cuda_mlir/lowering_utilities/__init__.py
+++ b/src/numba_cuda_mlir/lowering_utilities/__init__.py
@@ -336,6 +336,32 @@ def _is_bool_numba_type(numba_type: types.Type) -> bool:
     return isinstance(numba_type, (types.Boolean, types.BooleanLiteral))
 
 
+def get_conversion_signedness(source_type: types.Type, target_type: types.Type) -> bool | None:
+    """Return integer signedness required to convert between semantic types.
+
+    Integer sources determine how their bits are interpreted. Otherwise, an
+    integer target determines which float-to-integer conversion is required.
+    MLIR integer types are signless, so callers must make this decision while
+    the corresponding Numba types are still available.
+    """
+    from numba_cuda_mlir.type_defs.vector_types import VectorType
+
+    if isinstance(source_type, VectorType):
+        source_type = source_type.dtype
+    if isinstance(target_type, VectorType):
+        target_type = target_type.dtype
+
+    if _is_bool_numba_type(source_type):
+        return False
+    if isinstance(source_type, types.Integer):
+        return source_type.signed
+    if _is_bool_numba_type(target_type):
+        return False
+    if isinstance(target_type, types.Integer):
+        return target_type.signed
+    return None
+
+
 def _is_float_storage_numba_type(numba_type: types.Type) -> bool:
     from numba_cuda_mlir.type_defs import float_types
     from numba_cuda_mlir.numba_cuda.types.ext_types import Bfloat16
@@ -800,7 +826,7 @@ def convert_tuple_like(values: list[ir.Value], target_type: ir.Type) -> ir.Value
 
 
 def _convert_integer_to_integer(
-    value: ir.Value, target_type: ir.IntegerType, *, signed: bool = False
+    value: ir.Value, target_type: ir.IntegerType, *, signed: bool | None = None
 ) -> ir.Value:
     """
     If possible, we perform the conversion on the types as they are given to us.

--- a/src/numba_cuda_mlir/lowering_utilities/__init__.py
+++ b/src/numba_cuda_mlir/lowering_utilities/__init__.py
@@ -1020,7 +1020,7 @@ def unverified_basic_mlir_convert(
                 if use_signed_conversion(value_type.width > 1)
                 else arith.uitofp(out=target_type, in_=value)
             )
-        case (ir.FloatType() | ir.BF16Type()), ir.IntegerType():
+        case ((ir.FloatType() | ir.BF16Type()), ir.IntegerType()):
             return (
                 arith.fptosi(out=target_type, in_=value)
                 if use_signed_conversion(target_type.width > 1)

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -45,6 +45,7 @@ from numba_cuda_mlir.lowering_utilities import (
     lookup_callee_in_module,
     get_func_type,
     get_type_size_bytes,
+    get_conversion_signedness,
     storage_itemsize_bytes,
 )
 from numba_cuda_mlir.compiler import (
@@ -2505,16 +2506,7 @@ extern "C" __global__ void
             return cast_impl(self.context, self, source_type, target_type, value)
         if isinstance(source_type, types.BaseTuple) and isinstance(target_type, types.BaseTuple):
             return self._lower_tuple_cast(source_type, target_type, value)
-        if isinstance(source_type, types.Integer):
-            signed = source_type.signed
-        elif isinstance(source_type, VectorType) and isinstance(source_type.dtype, types.Integer):
-            signed = source_type.dtype.signed
-        elif isinstance(target_type, types.Integer):
-            signed = target_type.signed
-        elif isinstance(target_type, VectorType) and isinstance(target_type.dtype, types.Integer):
-            signed = target_type.dtype.signed
-        else:
-            signed = False
+        signed = get_conversion_signedness(source_type, target_type)
         return convert(value, self.get_mlir_type(target_type), signed=signed)
 
     def _tuple_element_types(self, tuple_type):

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -2504,7 +2504,14 @@ extern "C" __global__ void
             return cast_impl(self.context, self, source_type, target_type, value)
         if isinstance(source_type, types.BaseTuple) and isinstance(target_type, types.BaseTuple):
             return self._lower_tuple_cast(source_type, target_type, value)
-        return self.mlir_convert(value, self.get_mlir_type(target_type))
+        signed = (
+            source_type.signed
+            if isinstance(source_type, types.Integer)
+            else target_type.signed
+            if isinstance(target_type, types.Integer)
+            else False
+        )
+        return convert(value, self.get_mlir_type(target_type), signed=signed)
 
     def _tuple_element_types(self, tuple_type):
         if isinstance(tuple_type, types.UniTuple):

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -82,6 +82,7 @@ from numba_cuda_mlir.linker import Linker, resolve_link_plan
 from numba_cuda_mlir.memory_management.nrt_mlir import emit_nrt_functions
 from numba_cuda_mlir.nrt_context import MLIRNRTContext
 from numba_cuda_mlir.type_defs.aggregate_types import AggregateType, UnionType
+from numba_cuda_mlir.type_defs.vector_types import VectorType
 from numba_cuda_mlir.types import Record
 
 ERROR_CODE_GLOBAL_NAME = "__numba_cuda_mlir_error_code"
@@ -2504,13 +2505,16 @@ extern "C" __global__ void
             return cast_impl(self.context, self, source_type, target_type, value)
         if isinstance(source_type, types.BaseTuple) and isinstance(target_type, types.BaseTuple):
             return self._lower_tuple_cast(source_type, target_type, value)
-        signed = (
-            source_type.signed
-            if isinstance(source_type, types.Integer)
-            else target_type.signed
-            if isinstance(target_type, types.Integer)
-            else False
-        )
+        if isinstance(source_type, types.Integer):
+            signed = source_type.signed
+        elif isinstance(source_type, VectorType) and isinstance(source_type.dtype, types.Integer):
+            signed = source_type.dtype.signed
+        elif isinstance(target_type, types.Integer):
+            signed = target_type.signed
+        elif isinstance(target_type, VectorType) and isinstance(target_type.dtype, types.Integer):
+            signed = target_type.dtype.signed
+        else:
+            signed = False
         return convert(value, self.get_mlir_type(target_type), signed=signed)
 
     def _tuple_element_types(self, tuple_type):

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -83,7 +83,6 @@ from numba_cuda_mlir.linker import Linker, resolve_link_plan
 from numba_cuda_mlir.memory_management.nrt_mlir import emit_nrt_functions
 from numba_cuda_mlir.nrt_context import MLIRNRTContext
 from numba_cuda_mlir.type_defs.aggregate_types import AggregateType, UnionType
-from numba_cuda_mlir.type_defs.vector_types import VectorType
 from numba_cuda_mlir.types import Record
 
 ERROR_CODE_GLOBAL_NAME = "__numba_cuda_mlir_error_code"

--- a/tests/numba_cuda_tests/cudapy/test_bfloat16.py
+++ b/tests/numba_cuda_tests/cudapy/test_bfloat16.py
@@ -349,6 +349,7 @@ class TestBfloat16HighLevelBindings(NumbaCUDATestCase):
         self.assertAlmostEqual(out[2], 2.0, delta=1e-3)
         self.assertAlmostEqual(out[3], 2.0, delta=1e-3)
 
+    @pytest.mark.xfail(reason="https://github.com/NVIDIA/numba-cuda-mlir/issues/305")
     def test_bfloat16_as_bitcast(self):
         self.skip_unsupported()
 

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -159,3 +159,34 @@ def test_complex_constructor_2args(complex_type):
     kernel[1, 1](out)
 
     np.testing.assert_equal(out[0], np.complex128(1.5 - 2.5j))
+
+
+@pytest.mark.parametrize(
+    "conversion",
+    ["assignment", "numpy", "builtin-1arg", "builtin-2arg"],
+)
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        (np.uint64(2**63), np.complex128(2**63)),
+        (np.int64(-1024), np.complex128(-1024)),
+    ],
+    ids=["unsigned", "signed"],
+)
+def test_integer_to_complex_preserves_signedness(conversion, source, expected):
+    @cuda.jit
+    def kernel(inp, out):
+        if conversion == "numpy":
+            out[0] = np.complex128(inp[0])
+        elif conversion == "builtin-1arg":
+            out[0] = complex(inp[0])
+        elif conversion == "builtin-2arg":
+            out[0] = complex(inp[0], 0)
+        else:
+            out[0] = inp[0]
+
+    inp = np.array([source])
+    out = np.zeros(1, dtype=np.complex128)
+    kernel[1, 1](inp, out)
+
+    np.testing.assert_equal(out[0], expected)

--- a/tests/test_half_precision.py
+++ b/tests/test_half_precision.py
@@ -57,9 +57,15 @@ BF16_INTEGER_CAST_CASES = [
     pytest.param(np.int32, types.int32, -3, np.int32(-3), "arith.fptosi", id="bf16-to-int32"),
     pytest.param(np.int64, types.int64, -3, np.int64(-3), "arith.fptosi", id="bf16-to-int64"),
     pytest.param(np.uint8, types.uint8, 2**7, np.uint8(2**7), "arith.fptoui", id="bf16-to-uint8"),
-    pytest.param(np.uint16, types.uint16, 2**15, np.uint16(2**15), "arith.fptoui", id="bf16-to-uint16"),
-    pytest.param(np.uint32, types.uint32, 2**31, np.uint32(2**31), "arith.fptoui", id="bf16-to-uint32"),
-    pytest.param(np.uint64, types.uint64, 2**63, np.uint64(2**63), "arith.fptoui", id="bf16-to-uint64"),
+    pytest.param(
+        np.uint16, types.uint16, 2**15, np.uint16(2**15), "arith.fptoui", id="bf16-to-uint16"
+    ),
+    pytest.param(
+        np.uint32, types.uint32, 2**31, np.uint32(2**31), "arith.fptoui", id="bf16-to-uint32"
+    ),
+    pytest.param(
+        np.uint64, types.uint64, 2**63, np.uint64(2**63), "arith.fptoui", id="bf16-to-uint64"
+    ),
 ]
 
 

--- a/tests/test_half_precision.py
+++ b/tests/test_half_precision.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 import sys
-from numba_cuda_mlir import cuda
+from numba_cuda_mlir import cuda, compiler, types
 from numba_cuda_mlir.numba_cuda import bf16
 
 pytestmark = [
@@ -51,6 +51,18 @@ BF16_COMPARISON_OPS = [
 ]
 
 
+BF16_INTEGER_CAST_CASES = [
+    pytest.param(np.int8, types.int8, -3, np.int8(-3), "arith.fptosi", id="bf16-to-int8"),
+    pytest.param(np.int16, types.int16, -3, np.int16(-3), "arith.fptosi", id="bf16-to-int16"),
+    pytest.param(np.int32, types.int32, -3, np.int32(-3), "arith.fptosi", id="bf16-to-int32"),
+    pytest.param(np.int64, types.int64, -3, np.int64(-3), "arith.fptosi", id="bf16-to-int64"),
+    pytest.param(np.uint8, types.uint8, 2**7, np.uint8(2**7), "arith.fptoui", id="bf16-to-uint8"),
+    pytest.param(np.uint16, types.uint16, 2**15, np.uint16(2**15), "arith.fptoui", id="bf16-to-uint16"),
+    pytest.param(np.uint32, types.uint32, 2**31, np.uint32(2**31), "arith.fptoui", id="bf16-to-uint32"),
+    pytest.param(np.uint64, types.uint64, 2**63, np.uint64(2**63), "arith.fptoui", id="bf16-to-uint64"),
+]
+
+
 @pytest.mark.parametrize("op,input_val,expected", BF16_UNARY_OPS)
 def test_bf16_unary_intrinsics(op, input_val, expected):
     @cuda.jit
@@ -93,6 +105,25 @@ def test_bf16_constructor(value):
     out = np.zeros(1, dtype=np.float32)
     kernel[1, 1](out, value)
     np.testing.assert_allclose(out[0], float(value), rtol=0.1)
+
+
+@pytest.mark.parametrize(
+    "destination_dtype,destination_type,value,expected,conversion_op",
+    BF16_INTEGER_CAST_CASES,
+)
+def test_bf16_integer_cast_preserves_signedness(
+    destination_dtype, destination_type, value, expected, conversion_op
+):
+    @cuda.jit
+    def kernel(out, x):
+        out[0] = destination_dtype(bf16.bfloat16(x))
+
+    out = np.zeros(1, dtype=destination_dtype)
+    kernel[1, 1](out, np.float64(value))
+    np.testing.assert_equal(out[0], expected)
+
+    mlir = compiler.compile_mlir(kernel, types.void(destination_type[:], types.float64))
+    assert conversion_op in mlir
 
 
 def test_bf16_fma():

--- a/tests/test_half_precision.py
+++ b/tests/test_half_precision.py
@@ -132,6 +132,28 @@ def test_bf16_integer_cast_preserves_signedness(
     assert conversion_op in mlir
 
 
+@pytest.mark.parametrize(
+    "destination_dtype,destination_type,value,expected,conversion_op",
+    [
+        (np.int16, types.int16, -3, np.int16(-3), "arith.fptosi"),
+        (np.uint16, types.uint16, 3, np.uint16(3), "arith.fptoui"),
+    ],
+)
+def test_bf16_integer_assignment_is_numeric(
+    destination_dtype, destination_type, value, expected, conversion_op
+):
+    @cuda.jit
+    def kernel(out, x):
+        out[0] = bf16.bfloat16(x)
+
+    out = np.zeros(1, dtype=destination_dtype)
+    kernel[1, 1](out, np.float64(value))
+    np.testing.assert_equal(out[0], expected)
+
+    mlir = compiler.compile_mlir(kernel, types.void(destination_type[:], types.float64))
+    assert conversion_op in mlir
+
+
 def test_bf16_fma():
     @cuda.jit
     def kernel(out, a, b, c):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -131,6 +131,33 @@ def test_math_operand_conversion_preserves_signedness(fn, value, expected):
     np.testing.assert_allclose(out.copy_to_host()[0], expected, rtol=1e-6)
 
 
+NARROW_INTEGER_CASES = [
+    pytest.param(math.sqrt, np.uint8(200), math.sqrt(200), id="sqrt-uint8"),
+    pytest.param(math.sqrt, np.int8(100), math.sqrt(100), id="sqrt-int8"),
+    pytest.param(math.sqrt, np.uint16(60000), math.sqrt(60000), id="sqrt-uint16"),
+    pytest.param(math.sqrt, np.int16(300), math.sqrt(300), id="sqrt-int16"),
+    pytest.param(math.floor, np.uint8(200), 200.0, id="floor-uint8"),
+    pytest.param(math.floor, np.int8(-56), -56.0, id="floor-int8"),
+    pytest.param(math.floor, np.uint16(60000), 60000.0, id="floor-uint16"),
+    pytest.param(math.floor, np.int16(-300), -300.0, id="floor-int16"),
+    pytest.param(math.fabs, np.int8(-56), 56.0, id="fabs-int8"),
+]
+
+
+@pytest.mark.parametrize("fn,value,expected", NARROW_INTEGER_CASES)
+def test_math_accepts_narrow_integer_widths(fn, value, expected):
+    """8- and 16-bit sources used to raise ValueError instead of lowering."""
+
+    @cuda.jit
+    def kernel(src, out):
+        out[0] = fn(src[0])
+
+    src = cuda.to_device(np.array([value]))
+    out = cuda.device_array(1, dtype=np.float64)
+    kernel[1, 1](src, out)
+    np.testing.assert_allclose(out.copy_to_host()[0], expected, rtol=1e-6)
+
+
 def test_math_binary_operand_conversion_preserves_signedness():
     @cuda.jit
     def kernel(x, y, out):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -93,6 +93,56 @@ def test_arithmetic_operand_conversion_preserves_signedness(op, lhs, rhs, expect
     np.testing.assert_equal(out.copy_to_host()[0], expected)
 
 
+# Every value below has its high bit set, so reading it as signed yields a
+# negative number and the wrong answer is obvious rather than a rounding
+# difference. math.ceil/floor/trunc of an integer are pure conversions, which
+# makes them the most direct probe of the integer-to-float widening itself.
+BIG_UINT64 = np.uint64(2**64 - 1024)
+BIG_UINT64_AS_FLOAT = 1.8446744073709552e19
+BIG_UINT32 = np.uint32(4000000000)
+
+MATH_SIGNEDNESS_CASES = [
+    pytest.param(math.floor, BIG_UINT64, BIG_UINT64_AS_FLOAT, id="floor-uint64"),
+    pytest.param(math.ceil, BIG_UINT64, BIG_UINT64_AS_FLOAT, id="ceil-uint64"),
+    pytest.param(math.trunc, BIG_UINT64, BIG_UINT64_AS_FLOAT, id="trunc-uint64"),
+    pytest.param(math.fabs, BIG_UINT64, BIG_UINT64_AS_FLOAT, id="fabs-uint64"),
+    pytest.param(math.sqrt, BIG_UINT64, 4294967296.0, id="sqrt-uint64"),
+    pytest.param(math.log, BIG_UINT64, math.log(BIG_UINT64_AS_FLOAT), id="log-uint64"),
+    pytest.param(math.floor, BIG_UINT32, 4000000000.0, id="floor-uint32"),
+    pytest.param(math.sqrt, BIG_UINT32, math.sqrt(4000000000.0), id="sqrt-uint32"),
+    pytest.param(math.floor, np.int64(-1024), -1024.0, id="floor-int64-control"),
+    pytest.param(math.fabs, np.int64(-1024), 1024.0, id="fabs-int64-control"),
+    pytest.param(math.sqrt, np.int64(1024), 32.0, id="sqrt-int64-control"),
+    pytest.param(math.floor, np.int32(-4), -4.0, id="floor-int32-control"),
+]
+
+
+@pytest.mark.parametrize("fn,value,expected", MATH_SIGNEDNESS_CASES)
+def test_math_operand_conversion_preserves_signedness(fn, value, expected):
+    @cuda.jit
+    def kernel(src, out):
+        out[0] = fn(src[0])
+
+    src = cuda.to_device(np.array([value]))
+    out = cuda.device_array(1, dtype=np.float64)
+    kernel[1, 1](src, out)
+    # The f32 conversion path for 32-bit sources costs a few digits, so compare
+    # with a tolerance rather than exactly.
+    np.testing.assert_allclose(out.copy_to_host()[0], expected, rtol=1e-6)
+
+
+def test_math_binary_operand_conversion_preserves_signedness():
+    @cuda.jit
+    def kernel(x, y, out):
+        out[0] = math.hypot(x[0], y[0])
+
+    x = cuda.to_device(np.array([BIG_UINT64]))
+    y = cuda.to_device(np.array([np.uint64(0)]))
+    out = cuda.device_array(1, dtype=np.float64)
+    kernel[1, 1](x, y, out)
+    np.testing.assert_allclose(out.copy_to_host()[0], BIG_UINT64_AS_FLOAT, rtol=1e-6)
+
+
 def test_math_ceil():
     @cuda.jit()
     def math_ceil_kernel(x):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,9 +4,93 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 import math
+import operator
 from numba_cuda_mlir import cuda
 import numpy as np
 import pytest
+
+
+ARITHMETIC_SIGNEDNESS_CASES = [
+    pytest.param(operator.add, np.int8(-56), np.int64(0), np.int64(-56), id="add"),
+    pytest.param(operator.sub, np.int8(-56), np.int64(0), np.int64(-56), id="sub"),
+    pytest.param(operator.mul, np.int8(-7), np.int64(2), np.int64(-14), id="mul"),
+    pytest.param(
+        operator.truediv,
+        np.int8(-7),
+        np.int64(2),
+        np.float64(-3.5),
+        id="truediv",
+    ),
+    pytest.param(
+        operator.add,
+        np.uint8(200),
+        np.int64(0),
+        np.int64(200),
+        id="unsigned-control",
+    ),
+    pytest.param(
+        operator.mod,
+        np.uint8(200),
+        np.int64(256),
+        np.int64(200),
+        id="mod-unsigned-source",
+    ),
+    pytest.param(
+        operator.floordiv,
+        np.uint8(200),
+        np.int64(2),
+        np.int64(100),
+        id="floordiv-unsigned-source",
+    ),
+    pytest.param(
+        operator.lshift,
+        np.int8(-56),
+        np.int64(1),
+        np.int64(-112),
+        id="lshift-signed-source",
+    ),
+    pytest.param(
+        operator.rshift,
+        np.int8(-56),
+        np.int64(1),
+        np.int64(-28),
+        id="rshift-signed-source",
+    ),
+    pytest.param(
+        operator.and_,
+        np.int8(-56),
+        np.int64(-1),
+        np.int64(-56),
+        id="and-signed-source",
+    ),
+    pytest.param(
+        operator.or_,
+        np.int8(-56),
+        np.int64(0),
+        np.int64(-56),
+        id="or-signed-source",
+    ),
+    pytest.param(
+        operator.xor,
+        np.int8(-56),
+        np.int64(0),
+        np.int64(-56),
+        id="xor-signed-source",
+    ),
+]
+
+
+@pytest.mark.parametrize("op,lhs,rhs,expected", ARITHMETIC_SIGNEDNESS_CASES)
+def test_arithmetic_operand_conversion_preserves_signedness(op, lhs, rhs, expected):
+    @cuda.jit
+    def kernel(lhs, rhs, out):
+        out[0] = op(lhs[0], rhs[0])
+
+    lhs = cuda.to_device(np.array([lhs]))
+    rhs = cuda.to_device(np.array([rhs]))
+    out = cuda.device_array(1, dtype=type(expected))
+    kernel[1, 1](lhs, rhs, out)
+    np.testing.assert_equal(out.copy_to_host()[0], expected)
 
 
 def test_math_ceil():

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -11,6 +11,8 @@ import pytest
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir.lowering_utilities.type_conversions import to_numba_type
+from numba_cuda_mlir.mlir_lowering import MLIRLower
+from numba_cuda_mlir.type_defs.vector_types import VectorType
 
 
 @pytest.mark.parametrize(
@@ -99,6 +101,12 @@ INTEGER_FLOAT_CAST_CASES = [
     pytest.param(np.uint16(60000), np.float64, 60000.0, id="uint16-to-float64"),
     pytest.param(
         np.uint32(3_000_000_000),
+        np.float64,
+        3_000_000_000.0,
+        id="uint32-to-float64",
+    ),
+    pytest.param(
+        np.uint32(3_000_000_000),
         np.float32,
         np.float32(3_000_000_000),
         id="uint32-to-float32",
@@ -135,3 +143,37 @@ def test_explicit_integer_float_cast_preserves_signedness(source, destination_dt
     destination = cuda.device_array(1, dtype=destination_dtype)
     cast[1, 1](source, destination)
     np.testing.assert_equal(destination.copy_to_host()[0], expected)
+
+
+@pytest.mark.parametrize(
+    "source_type,target_type,expected_signed",
+    [
+        (VectorType(types.int8, 2), VectorType(types.float64, 2), True),
+        (VectorType(types.uint8, 2), VectorType(types.float64, 2), False),
+        (VectorType(types.float64, 2), VectorType(types.int32, 2), True),
+        (VectorType(types.float64, 2), VectorType(types.uint32, 2), False),
+    ],
+    ids=["int-to-float", "uint-to-float", "float-to-int", "float-to-uint"],
+)
+def test_lower_cast_uses_vector_integer_signedness(
+    monkeypatch, source_type, target_type, expected_signed
+):
+    class CastRegistry:
+        def find(self, _):
+            return None
+
+    captured = {}
+
+    def fake_convert(value, target, *, signed):
+        captured["target"] = target
+        captured["signed"] = signed
+        return value
+
+    lower = object.__new__(MLIRLower)
+    lower.context = type("Context", (), {"_casts": CastRegistry()})()
+    monkeypatch.setattr(MLIRLower, "get_mlir_type", lambda _, ty: ty)
+    monkeypatch.setattr("numba_cuda_mlir.mlir_lowering.convert", fake_convert)
+
+    value = object()
+    assert lower.lower_cast(source_type, target_type, value) is value
+    assert captured == {"target": target_type, "signed": expected_signed}

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -135,6 +135,38 @@ NUMERIC_CAST_CASES = [
     ),
     pytest.param(np.int8(-56), np.int64, np.int64(-56), id="int8-to-int64"),
     pytest.param(np.int32(-5), np.int64, np.int64(-5), id="int32-to-int64"),
+    # Below 2**63 a uint64 has the same bit pattern read either way, so only
+    # these values distinguish uitofp from sitofp at the widest integer type.
+    pytest.param(
+        np.uint64(2**64 - 1024),
+        np.float64,
+        1.8446744073709552e19,
+        id="uint64-to-float64",
+    ),
+    pytest.param(
+        np.uint64(2**63),
+        np.float64,
+        9.223372036854776e18,
+        id="uint64-msb-to-float64",
+    ),
+    pytest.param(
+        np.uint64(2**63),
+        np.float32,
+        np.float32(2**63),
+        id="uint64-msb-to-float32",
+    ),
+    pytest.param(
+        np.float64(2**63),
+        np.uint64,
+        np.uint64(9223372036854775808),
+        id="float64-to-uint64",
+    ),
+    pytest.param(
+        np.int64(-1024),
+        np.uint64,
+        np.uint64(18446744073709550592),
+        id="int64-to-uint64",
+    ),
 ]
 
 

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -10,6 +10,7 @@ import pytest
 
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.numba_cuda import types
+from numba_cuda_mlir.lowering_utilities import get_conversion_signedness
 from numba_cuda_mlir.lowering_utilities.type_conversions import to_numba_type
 from numba_cuda_mlir.mlir_lowering import MLIRLower
 from numba_cuda_mlir.type_defs.vector_types import VectorType
@@ -96,7 +97,8 @@ def test_custom_type_conversion():
     assert to_numba_type(frontend_val) == custom_numba_type_instance
 
 
-INTEGER_FLOAT_CAST_CASES = [
+NUMERIC_CAST_CASES = [
+    pytest.param(np.bool_(True), np.int64, np.int64(1), id="bool-to-int64"),
     pytest.param(np.uint8(200), np.float64, 200.0, id="uint8-to-float64"),
     pytest.param(np.uint16(60000), np.float64, 60000.0, id="uint16-to-float64"),
     pytest.param(
@@ -118,11 +120,26 @@ INTEGER_FLOAT_CAST_CASES = [
         id="float64-to-uint32",
     ),
     pytest.param(np.int8(-56), np.float64, -56.0, id="int8-to-float64"),
+    pytest.param(np.uint8(200), np.int64, np.int64(200), id="uint8-to-int64"),
+    pytest.param(
+        np.int8(-56),
+        np.uint32,
+        np.uint32(4_294_967_240),
+        id="int8-to-uint32",
+    ),
+    pytest.param(
+        np.uint32(3_000_000_000),
+        np.int64,
+        np.int64(3_000_000_000),
+        id="uint32-to-int64",
+    ),
+    pytest.param(np.int8(-56), np.int64, np.int64(-56), id="int8-to-int64"),
+    pytest.param(np.int32(-5), np.int64, np.int64(-5), id="int32-to-int64"),
 ]
 
 
-@pytest.mark.parametrize("source, destination_dtype, expected", INTEGER_FLOAT_CAST_CASES)
-def test_integer_float_cast_preserves_signedness(source, destination_dtype, expected):
+@pytest.mark.parametrize("source, destination_dtype, expected", NUMERIC_CAST_CASES)
+def test_numeric_assignment_preserves_signedness(source, destination_dtype, expected):
     @cuda.jit
     def cast(source, destination):
         destination[0] = source[0]
@@ -133,8 +150,8 @@ def test_integer_float_cast_preserves_signedness(source, destination_dtype, expe
     np.testing.assert_equal(destination.copy_to_host()[0], expected)
 
 
-@pytest.mark.parametrize("source, destination_dtype, expected", INTEGER_FLOAT_CAST_CASES)
-def test_explicit_integer_float_cast_preserves_signedness(source, destination_dtype, expected):
+@pytest.mark.parametrize("source, destination_dtype, expected", NUMERIC_CAST_CASES)
+def test_explicit_numeric_cast_preserves_signedness(source, destination_dtype, expected):
     @cuda.jit
     def cast(source, destination):
         destination[0] = destination_dtype(source[0])
@@ -143,6 +160,41 @@ def test_explicit_integer_float_cast_preserves_signedness(source, destination_dt
     destination = cuda.device_array(1, dtype=destination_dtype)
     cast[1, 1](source, destination)
     np.testing.assert_equal(destination.copy_to_host()[0], expected)
+
+
+@pytest.mark.parametrize(
+    "source_type,target_type,expected",
+    [
+        (types.int8, types.int64, True),
+        (types.uint8, types.int64, False),
+        (types.int8, types.uint32, True),
+        (types.float64, types.int32, True),
+        (types.float64, types.uint32, False),
+        (types.boolean, types.int64, False),
+        (types.float64, types.boolean, False),
+        (VectorType(types.int8, 2), VectorType(types.float64, 2), True),
+        (VectorType(types.uint8, 2), VectorType(types.float64, 2), False),
+        (VectorType(types.float64, 2), VectorType(types.int32, 2), True),
+        (VectorType(types.float64, 2), VectorType(types.uint32, 2), False),
+        (types.float32, types.float64, None),
+    ],
+    ids=[
+        "signed-source",
+        "unsigned-source",
+        "source-precedes-target",
+        "signed-target",
+        "unsigned-target",
+        "boolean-source",
+        "boolean-target",
+        "signed-vector-source",
+        "unsigned-vector-source",
+        "signed-vector-target",
+        "unsigned-vector-target",
+        "no-integer-type",
+    ],
+)
+def test_get_conversion_signedness(source_type, target_type, expected):
+    assert get_conversion_signedness(source_type, target_type) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -123,3 +123,15 @@ def test_integer_float_cast_preserves_signedness(source, destination_dtype, expe
     destination = cuda.device_array(1, dtype=destination_dtype)
     cast[1, 1](source, destination)
     np.testing.assert_equal(destination.copy_to_host()[0], expected)
+
+
+@pytest.mark.parametrize("source, destination_dtype, expected", INTEGER_FLOAT_CAST_CASES)
+def test_explicit_integer_float_cast_preserves_signedness(source, destination_dtype, expected):
+    @cuda.jit
+    def cast(source, destination):
+        destination[0] = destination_dtype(source[0])
+
+    source = cuda.to_device(np.array([source]))
+    destination = cuda.device_array(1, dtype=destination_dtype)
+    cast[1, 1](source, destination)
+    np.testing.assert_equal(destination.copy_to_host()[0], expected)

--- a/tests/test_type_conversions.py
+++ b/tests/test_type_conversions.py
@@ -8,6 +8,7 @@ import ctypes
 import numpy as np
 import pytest
 
+from numba_cuda_mlir import cuda
 from numba_cuda_mlir.numba_cuda import types
 from numba_cuda_mlir.lowering_utilities.type_conversions import to_numba_type
 
@@ -91,3 +92,34 @@ def test_custom_type_conversion():
 
     frontend_val = CustomFrontendType()
     assert to_numba_type(frontend_val) == custom_numba_type_instance
+
+
+INTEGER_FLOAT_CAST_CASES = [
+    pytest.param(np.uint8(200), np.float64, 200.0, id="uint8-to-float64"),
+    pytest.param(np.uint16(60000), np.float64, 60000.0, id="uint16-to-float64"),
+    pytest.param(
+        np.uint32(3_000_000_000),
+        np.float32,
+        np.float32(3_000_000_000),
+        id="uint32-to-float32",
+    ),
+    pytest.param(
+        np.float64(3_000_000_000),
+        np.uint32,
+        np.uint32(3_000_000_000),
+        id="float64-to-uint32",
+    ),
+    pytest.param(np.int8(-56), np.float64, -56.0, id="int8-to-float64"),
+]
+
+
+@pytest.mark.parametrize("source, destination_dtype, expected", INTEGER_FLOAT_CAST_CASES)
+def test_integer_float_cast_preserves_signedness(source, destination_dtype, expected):
+    @cuda.jit
+    def cast(source, destination):
+        destination[0] = source[0]
+
+    source = cuda.to_device(np.array([source]))
+    destination = cuda.device_array(1, dtype=destination_dtype)
+    cast[1, 1](source, destination)
+    np.testing.assert_equal(destination.copy_to_host()[0], expected)

--- a/tests/test_vector_type_complex_cast.py
+++ b/tests/test_vector_type_complex_cast.py
@@ -33,6 +33,16 @@ class TestVectorTypeComplexCast(NumbaCUDATestCase):
         self.assertEqual(res64[0], complex(1.5, 2.5))
         self.assertEqual(res128[0], complex(3.5, 4.5))
 
+    def test_unsigned_integer_vector_to_complex(self):
+        @cuda.jit("void(complex64[:])")
+        def kernel(out):
+            out[0] = complex(cuda.uint8x2(200, 255))
+
+        out = np.zeros(1, dtype=np.complex64)
+        kernel[1, 1](out)
+
+        self.assertEqual(out[0], np.complex64(200 + 255j))
+
     def test_int_vector_to_complex(self):
         @cuda.jit("void(complex128[:])")
         def kernel(arr):

--- a/tests/test_vector_types.py
+++ b/tests/test_vector_types.py
@@ -234,6 +234,19 @@ def test_cuda_vector_float32x4_basic():
     np.testing.assert_allclose(arr, [2.0, 4.0, 6.0, 8.0])
 
 
+def test_signed_integer_vector_to_float_vector_cast():
+    @cuda.jit
+    def kernel(out):
+        integers = cuda.int8x2(-56, -1)
+        floats = cuda.float64x2(integers)
+        out[0] = floats.x
+        out[1] = floats.y
+
+    out = np.zeros(2, dtype=np.float64)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, [-56.0, -1.0])
+
+
 def test_cuda_vector_constructor_from_multidimensional_vector():
     @cuda.jit
     def kernel(arr_in, arr_out):

--- a/tests/test_vector_types.py
+++ b/tests/test_vector_types.py
@@ -305,6 +305,31 @@ def test_vector_cast_preserves_signedness(source_type, target_type, values, dtyp
     np.testing.assert_array_equal(out, expected)
 
 
+@pytest.mark.parametrize(
+    "narrow_type,wide_type,values,dtype,expected",
+    [
+        (cuda.uint8x2, cuda.uint16x2, (200, 255), np.uint16, (201, 257)),
+        (cuda.int8x2, cuda.int16x2, (-56, -1), np.int16, (-55, 1)),
+    ],
+)
+def test_mixed_width_integer_vector_addition(
+    narrow_type, wide_type, values, dtype, expected
+):
+    first, second = values
+
+    @cuda.jit
+    def kernel(out):
+        narrow = narrow_type(first, second)
+        wide = wide_type(1, 2)
+        result = narrow + wide
+        out[0] = result.x
+        out[1] = result.y
+
+    out = np.zeros(2, dtype=dtype)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, expected)
+
+
 def test_cuda_vector_constructor_from_multidimensional_vector():
     @cuda.jit
     def kernel(arr_in, arr_out):

--- a/tests/test_vector_types.py
+++ b/tests/test_vector_types.py
@@ -247,6 +247,64 @@ def test_signed_integer_vector_to_float_vector_cast():
     np.testing.assert_array_equal(out, [-56.0, -1.0])
 
 
+VECTOR_CAST_CASES = [
+    pytest.param(
+        cuda.uint8x2, cuda.float64x2, (200, 255), np.float64, (200.0, 255.0), id="uint8-to-float64"
+    ),
+    pytest.param(
+        cuda.uint16x2,
+        cuda.float64x2,
+        (60000, 65535),
+        np.float64,
+        (60000.0, 65535.0),
+        id="uint16-to-float64",
+    ),
+    pytest.param(
+        cuda.uint32x2,
+        cuda.float64x2,
+        (3_000_000_000, 4_000_000_000),
+        np.float64,
+        (3_000_000_000.0, 4_000_000_000.0),
+        id="uint32-to-float64",
+    ),
+    pytest.param(
+        cuda.uint32x2,
+        cuda.float32x2,
+        (3_000_000_000, 4_000_000_000),
+        np.float32,
+        (np.float32(3_000_000_000), np.float32(4_000_000_000)),
+        id="uint32-to-float32",
+    ),
+    pytest.param(
+        cuda.float64x2,
+        cuda.uint32x2,
+        (3_000_000_000.0, 4_000_000_000.0),
+        np.uint32,
+        (np.uint32(3_000_000_000), np.uint32(4_000_000_000)),
+        id="float64-to-uint32",
+    ),
+    pytest.param(
+        cuda.int8x2, cuda.float64x2, (-56, -1), np.float64, (-56.0, -1.0), id="int8-to-float64"
+    ),
+]
+
+
+@pytest.mark.parametrize("source_type,target_type,values,dtype,expected", VECTOR_CAST_CASES)
+def test_vector_cast_preserves_signedness(source_type, target_type, values, dtype, expected):
+    first, second = values
+
+    @cuda.jit
+    def kernel(out):
+        source = source_type(first, second)
+        target = target_type(source)
+        out[0] = target.x
+        out[1] = target.y
+
+    out = np.zeros(2, dtype=dtype)
+    kernel[1, 1](out)
+    np.testing.assert_array_equal(out, expected)
+
+
 def test_cuda_vector_constructor_from_multidimensional_vector():
     @cuda.jit
     def kernel(arr_in, arr_out):

--- a/tests/test_vector_types.py
+++ b/tests/test_vector_types.py
@@ -312,9 +312,7 @@ def test_vector_cast_preserves_signedness(source_type, target_type, values, dtyp
         (cuda.int8x2, cuda.int16x2, (-56, -1), np.int16, (-55, 1)),
     ],
 )
-def test_mixed_width_integer_vector_addition(
-    narrow_type, wide_type, values, dtype, expected
-):
+def test_mixed_width_integer_vector_addition(narrow_type, wide_type, values, dtype, expected):
     first, second = values
 
     @cuda.jit


### PR DESCRIPTION
Closes #290.

Select signed or unsigned floating-point conversion operations from frontend types during casts and array stores, while preserving the legacy fallback for conversions without frontend signedness metadata. Boolean-to-integer stores remain zero-extended.\n\nAdds a table-driven regression matrix for unsigned-to-float, float-to-unsigned, and signed control conversions.