### PR TITLE
Compute CFG dominators from immediate dominators

### DIFF
--- a/src/numba_cuda_mlir/numba_cuda/core/controlflow.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/controlflow.py
@@ -241,6 +241,10 @@ class CFGraph:
         return self._find_immediate_dominators()
 
     @functools.cached_property
+    def _ipdom(self):
+        return self._find_immediate_post_dominators()
+
+    @functools.cached_property
     def _df(self):
         return self._find_dominance_frontier()
 
@@ -275,7 +279,16 @@ class CFGraph:
          must go through).  By construction, it is non-empty: it contains
          at least the entry point.
         """
-        return self._post_doms[self._entry_point]
+        ipdom = self._ipdom
+        node = self._entry_point
+        if node not in ipdom:
+            return set(self._nodes)
+        backbone = set()
+        while node is not None:
+            backbone.add(node)
+            parent = ipdom[node]
+            node = None if parent == node else parent
+        return backbone
 
     def loops(self):
         """
@@ -425,33 +438,25 @@ class CFGraph:
                 exit_points.add(n)
         return exit_points
 
-    def _find_postorder(self):
-        succs = self._succs
-        back_edges = self._back_edges
-        post_order = []
-        seen = set()
-
-        post_order = []
-
-        # DFS
-        def dfs_rec(node):
-            if node not in seen:
-                seen.add(node)
-                stack.append((post_order.append, node))
-                stack.extend(
-                    (dfs_rec, dest) for dest in succs[node] if (node, dest) not in back_edges
-                )
-
-        stack = [(dfs_rec, self._entry_point)]
-        while stack:
-            cb, data = stack.pop()
-            cb(data)
-
-        return post_order
-
     def _find_immediate_dominators(self):
-        # The algorithm implemented computes the immediate dominator
-        # for each node in the CFG which is equivalent to build a dominator tree
+        return self._immediate_dominators({self._entry_point}, self._preds, self._succs)
+
+    def _find_immediate_post_dominators(self):
+        # Roots: exit points plus the bodies of loops that never exit.
+        roots = set(self._exit_points)
+        for loop in self._loops.values():
+            if not loop.exits:
+                roots.update(loop.body)
+        if not roots:
+            return {}
+        return self._immediate_dominators(roots, self._succs, self._preds)
+
+    def _immediate_dominators(self, roots, preds_table, succs_table):
+        """
+        Cooper-Harvey-Kennedy immediate dominators of the nodes reachable
+        from *roots*, which hang under a shared virtual root.  A root maps
+        to itself; a node dominated only by the virtual root maps to None.
+        """
         # Based on the implementation from NetworkX
         # library - nx.immediate_dominators
         # https://github.com/networkx/networkx/blob/858e7cb183541a78969fed0cbcd02346f5866c02/networkx/algorithms/dominance.py    # noqa: E501
@@ -459,6 +464,25 @@ class CFGraph:
         #   Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy
         #   A Simple, Fast Dominance Algorithm
         #   https://www.cs.rice.edu/~keith/EMBED/dom.pdf
+        order = []
+        seen = set()
+
+        def visit(node):
+            if node not in seen:
+                seen.add(node)
+                stack.append((order.append, node))
+                stack.extend((visit, dest) for dest in succs_table[node])
+
+        stack = [(visit, root) for root in roots]
+        while stack:
+            cb, node = stack.pop()
+            cb(node)
+
+        virtual_root = object()
+        idx = {node: i for i, node in enumerate(order)}
+        idx[virtual_root] = len(order)
+        idom = {virtual_root: virtual_root}
+
         def intersect(u, v):
             while u != v:
                 while idx[u] < idx[v]:
@@ -467,25 +491,42 @@ class CFGraph:
                     v = idom[v]
             return u
 
-        entry = self._entry_point
-        preds_table = self._preds
-
-        order = self._find_postorder()
-        idx = {e: i for i, e in enumerate(order)}  # index of each node
-        idom = {entry: entry}
-        order.pop()
-        order.reverse()
-
+        reverse_postorder = order[::-1]
         changed = True
         while changed:
             changed = False
-            for u in order:
-                new_idom = functools.reduce(intersect, (v for v in preds_table[u] if v in idom))
-                if u not in idom or idom[u] != new_idom:
+            for u in reverse_postorder:
+                preds = [v for v in preds_table[u] if v in idom]
+                if u in roots:
+                    preds.append(virtual_root)
+                new_idom = functools.reduce(intersect, preds)
+                if idom.get(u) != new_idom:
                     idom[u] = new_idom
                     changed = True
 
-        return idom
+        result = {}
+        for u in order:
+            v = idom[u]
+            result[u] = u if u in roots else (None if v is virtual_root else v)
+        return result
+
+    def _dominator_sets(self, idom):
+        # Each node's set is its chain of immediate dominators; unreachable nodes get every node.
+        doms = {}
+        for node in idom:
+            chain = []
+            cur = node
+            while cur is not None and cur not in doms:
+                chain.append(cur)
+                parent = idom[cur]
+                cur = None if parent == cur else parent
+            base = set() if cur is None else doms[cur]
+            for cur in reversed(chain):
+                base = base | {cur}
+                doms[cur] = base
+        for node in self._nodes:
+            doms.setdefault(node, set(self._nodes))
+        return doms
 
     def _find_dominator_tree(self):
         idom = self._idom
@@ -515,67 +556,11 @@ class CFGraph:
 
         return df
 
-    def _find_dominators_internal(self, post=False):
-        # See theoretical description in
-        # http://en.wikipedia.org/wiki/Dominator_%28graph_theory%29
-        # The algorithm implemented here uses a todo-list as described
-        # in http://pages.cs.wisc.edu/~fischer/cs701.f08/finding.loops.html
-        if post:
-            entries = set(self._exit_points)
-            preds_table = self._succs
-            succs_table = self._preds
-        else:
-            entries = set([self._entry_point])
-            preds_table = self._preds
-            succs_table = self._succs
-
-        if not entries:
-            raise RuntimeError("no entry points: dominator algorithm cannot be seeded")
-
-        doms = {}
-        for e in entries:
-            doms[e] = set([e])
-
-        todo = []
-        for n in self._nodes:
-            if n not in entries:
-                doms[n] = set(self._nodes)
-                todo.append(n)
-
-        while todo:
-            n = todo.pop()
-            if n in entries:
-                continue
-            new_doms = set([n])
-            preds = preds_table[n]
-            if preds:
-                new_doms |= functools.reduce(set.intersection, [doms[p] for p in preds])
-            if new_doms != doms[n]:
-                assert len(new_doms) < len(doms[n])
-                doms[n] = new_doms
-                todo.extend(succs_table[n])
-        return doms
-
     def _find_dominators(self):
-        return self._find_dominators_internal(post=False)
+        return self._dominator_sets(self._idom)
 
     def _find_post_dominators(self):
-        # To handle infinite loops correctly, we need to add a dummy
-        # exit point, and link members of infinite loops to it.
-        dummy_exit = object()
-        self._exit_points.add(dummy_exit)
-        for loop in self._loops.values():
-            if not loop.exits:
-                for b in loop.body:
-                    self._add_edge(b, dummy_exit)
-        pdoms = self._find_dominators_internal(post=True)
-        # Fix the _post_doms table to make no reference to the dummy exit
-        del pdoms[dummy_exit]
-        for doms in pdoms.values():
-            doms.discard(dummy_exit)
-        self._remove_node_edges(dummy_exit)
-        self._exit_points.remove(dummy_exit)
-        return pdoms
+        return self._dominator_sets(self._ipdom)
 
     # Finding loops and back edges: see
     # http://pages.cs.wisc.edu/~fischer/cs701.f08/finding.loops.html
@@ -597,6 +582,7 @@ class CFGraph:
         back_edges = set()
         # stack: keeps track of the traversal path
         stack = []
+        on_stack = set()
         # succs_state: keep track of unvisited successors of a node
         succs_state = {}
         entry_point = self.entry_point()
@@ -605,6 +591,7 @@ class CFGraph:
 
         def push_state(node):
             stack.append(node)
+            on_stack.add(node)
             succs_state[node] = [dest for dest in self._succs[node]]
 
         push_state(entry_point)
@@ -620,7 +607,7 @@ class CFGraph:
                 # Check the next successor
                 cur_node = tos_succs.pop()
                 # Is it in our traversal path?
-                if cur_node in stack:
+                if cur_node in on_stack:
                     # Yes, it's a backedge
                     back_edges.add((tos, cur_node))
                 elif cur_node not in checked:
@@ -629,6 +616,7 @@ class CFGraph:
             else:
                 # Checked all successors. Pop
                 stack.pop()
+                on_stack.remove(tos)
                 checked.add(tos)
 
         if stats is not None:

--- a/src/numba_cuda_mlir/numba_cuda/core/ssa.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/ssa.py
@@ -161,17 +161,36 @@ def _find_defs_violators(blocks, cfg):
     # scan from the first to the last basic-block as they occur in bytecode.
     violators = {k: None for k, vs in defs.items() if len(vs) > 1}
     # Gather violators by uses not dominated by the one def
-    doms = cfg.dominators()
+    enter, leave = _dominator_tree_intervals(cfg)
     for k, use_blocks in uses.items():
         if k not in violators:
+            def_labels = [label for _assign, label in defs[k] if label in enter]
             for label in use_blocks:
-                dom = doms[label]
-                def_labels = {label for _assign, label in defs[k]}
-                if not def_labels.intersection(dom):
+                use_enter = enter[label]
+                if not any(enter[d] <= use_enter < leave[d] for d in def_labels):
                     violators[k] = None
                     break
     _logger.debug("SSA violators %s", _lazy_pformat(list(violators)))
     return violators
+
+
+def _dominator_tree_intervals(cfg):
+    """Return ``(enter, leave)``: ``a`` dominates ``b`` iff ``enter[a] <= enter[b] < leave[a]``."""
+    domtree = cfg.dominator_tree()
+    enter = {}
+    leave = {}
+    counter = 0
+    stack = [(cfg.entry_point(), False)]
+    while stack:
+        node, done = stack.pop()
+        if done:
+            leave[node] = counter
+            continue
+        enter[node] = counter
+        counter += 1
+        stack.append((node, True))
+        stack.extend((child, False) for child in domtree[node])
+    return enter, leave
 
 
 def _run_block_analysis(blocks, states, handler):

--- a/tests/numba_cuda_tests/cudapy/test_flow_control.py
+++ b/tests/numba_cuda_tests/cudapy/test_flow_control.py
@@ -730,6 +730,34 @@ class TestCFGraph(NumbaCUDATestCase):
             },
         )
 
+    def test_dominators_deep_graph(self):
+        # Diamond chain: head 2i -> body 2i+1 -> join 2i+2, head 2i -> join 2i+2.
+        n_diamonds = 2000
+        adj = {}
+        for i in range(n_diamonds):
+            head, body, join = 2 * i, 2 * i + 1, 2 * i + 2
+            adj[head] = [body, join]
+            adj[body] = [join]
+        last = 2 * n_diamonds
+        adj[last] = []
+        g = self.from_adj_list(adj)
+        g.set_entry_point(0)
+        g.process()
+
+        spine = set(range(0, last + 1, 2))
+        self.assertEqual(g.backbone(), spine)
+        idoms = g.immediate_dominators()
+        self.assertEqual(idoms[0], 0)
+        for i in range(n_diamonds):
+            self.assertEqual(idoms[2 * i + 1], 2 * i)
+            self.assertEqual(idoms[2 * i + 2], 2 * i)
+        doms = g.dominators()
+        self.assertEqual(doms[last], spine)
+        self.assertEqual(doms[last - 1], (spine - {last}) | {last - 1})
+        pdoms = g.post_dominators()
+        self.assertEqual(pdoms[0], spine)
+        self.assertEqual(pdoms[1], (spine - {0}) | {1})
+
     def test_post_dominators_loopless(self):
         def eq_(d, l):
             self.assertEqual(sorted(doms[d]), l)

--- a/tests/numba_cuda_tests/cudapy/test_ssa.py
+++ b/tests/numba_cuda_tests/cudapy/test_ssa.py
@@ -14,6 +14,9 @@ from numba_cuda_mlir.numba_cuda import types
 import numba_cuda_mlir
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.numba_cuda.core import errors
+from numba_cuda_mlir.numba_cuda.compiler import run_frontend
+from numba_cuda_mlir.numba_cuda.core.analysis import compute_cfg_from_blocks
+from numba_cuda_mlir.numba_cuda.core.ssa import _find_defs_violators
 
 from numba_cuda_mlir.extending import overload, typing_registry
 from numba_cuda_mlir.testing import NumbaCUDATestCase
@@ -441,3 +444,31 @@ class TestReportedSSAIssues(SSABaseTest):
 
         np.testing.assert_array_equal(python, expect)
         np.testing.assert_array_equal(nb, expect)
+
+
+class TestSSAViolators(NumbaCUDATestCase):
+    def _violators(self, pyfunc):
+        func_ir = run_frontend(pyfunc)
+        cfg = compute_cfg_from_blocks(func_ir.blocks)
+        return set(_find_defs_violators(func_ir.blocks, cfg))
+
+    def test_single_def_dominating_uses(self):
+        def foo(c):
+            a = 1
+            if c:
+                b = a
+            else:
+                b = a + 1
+            return a + b
+
+        violators = self._violators(foo)
+        self.assertNotIn("a", violators)
+        self.assertIn("b", violators)
+
+    def test_single_def_not_dominating_use(self):
+        def foo(c):
+            if c:
+                a = 1
+            return a
+
+        self.assertIn("a", self._violators(foo))


### PR DESCRIPTION
# Compute CFG dominators from immediate dominators

## Summary

Dominator and post-dominator sets were built by a fixed point whose cost grew with the square of the block count, and the compiler asked for the full sets twice per kernel. They are now built from the immediate dominators the graph already computes, and the two callers that only needed one chain no longer build the sets at all. A kernel of 400 sequential conditionals compiles in 5.2 s instead of 12.4 s.

numba/numba#10494 (the compile-time half of numba/numba#5611) builds dominator sets from immediate dominators in the same way. This change also finds post-dominators without editing the graph, walks the immediate post-dominator chain in `backbone()`, and tests dominance in SSA from the dominator tree.

## The problem

Every block started with the full node set and the sets shrank until nothing changed. Each step took the common elements of the predecessors' sets and copied the result, so a block deep in a long chain was revisited once per block above it, copying a chain-length set each time. Kernels with many sequential conditionals have that shape:

```python
@cuda.jit
def kernel(out, x):
    a = x
    a = a + 1 if a > 0 else a - 1
    a = a + 2 if a > 1 else a - 2
    ...                                 # N steps, one diamond of blocks each
    out[0] = a
```

`backbone()` and `ssa._find_defs_violators` then requested the full sets, each for a question that needs one chain. Post-dominators also required adding a placeholder exit block, linking every block of an infinite loop to it, and removing both afterwards.

## The fix

`_immediate_dominators(roots, preds, succs)` runs Cooper-Harvey-Kennedy from a set of starting blocks under a shared placeholder root, so one routine serves the forward graph from the entry and the reversed graph from the exits. A starting block maps to itself; a block dominated only by the placeholder maps to `None`.

`_find_immediate_post_dominators` starts from the exit blocks and the blocks of loops that never exit, so the graph is never edited. With no exit and no such loop there is nothing to start from, and every block keeps the all-blocks set it had before.

`_dominator_sets(idom)` follows each block's chain of immediate dominators, reusing chains already built. Only `dominators()` and `post_dominators()` call it.

`backbone()` follows the immediate post-dominator chain from the entry. `ssa._find_defs_violators` numbers the dominator tree in visiting order and compares two numbers per use. `_find_back_edges` keeps the current path in a set beside the stack.

## Tests

`test_dominators_deep_graph` checks `backbone`, immediate dominators, dominators and post-dominators on a chain of 2000 diamonds. `TestSSAViolators` flags a single-definition variable exactly when a use is not dominated by the definition.

Every analysis was compared with the previous implementation on all 66,066 directed graphs of one to four blocks and on 3,000 random graphs of two to twelve blocks; all results are identical.

| | before | after |
|---|---|---|
| 400-step kernel, first compile | 12.4 s | 5.2 s |
| `backbone()`, 4001-block diamond chain | 0.608 s | 0.009 s |
| `dominators()`, 4001-block diamond chain | 0.792 s | 0.133 s |
| back edges, 9001 blocks | 0.068 s | 0.004 s |

Full suite: 4518 passed, 177 skipped, 300 xfailed, 0 failed.

## Notes for reviewers

Starting blocks map to themselves, as `_find_dominator_tree` and `_find_dominance_frontier` already expect of the entry, so `_dominator_sets` and `backbone()` stop on the same test in both directions. Each block's dominator set is still its own `set`; only the two loop-exit fix-ups request the post-dominator sets.