### PR TITLE
Avoid per-block set copies in liveness and scope repair

### DIFF
--- a/src/numba_cuda_mlir/numba_cuda/core/analysis.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/analysis.py
@@ -195,10 +195,10 @@ def compute_dead_maps(cfg, blocks, live_map, var_def_map):
             exit_dead_map[offset] = terminator_liveset
 
     # Verify that the dead maps cover all live variables
-    all_vars = reduce(operator.or_, live_map.values(), set())
-    internal_dead_vars = reduce(operator.or_, internal_dead_map.values(), set())
-    escaping_dead_vars = reduce(operator.or_, escaping_dead_map.values(), set())
-    exit_dead_vars = reduce(operator.or_, exit_dead_map.values(), set())
+    all_vars = set().union(*live_map.values())
+    internal_dead_vars = set().union(*internal_dead_map.values())
+    escaping_dead_vars = set().union(*escaping_dead_map.values())
+    exit_dead_vars = set().union(*exit_dead_map.values())
     dead_vars = internal_dead_vars | escaping_dead_vars | exit_dead_vars
     missing_vars = all_vars - dead_vars
     if missing_vars:

--- a/src/numba_cuda_mlir/numba_cuda/core/ir_utils.py
+++ b/src/numba_cuda_mlir/numba_cuda/core/ir_utils.py
@@ -2465,14 +2465,12 @@ def fixup_var_define_in_scope(blocks):
     # Scan for all used variables
     used_var = {}
     for blk in blocks.values():
-        scope = blk.scope
         for inst in blk.body:
             for var in inst.list_vars():
                 used_var[var] = inst
-    # Note: not all blocks share a single scope even though they should.
-    # Ensure the scope of each block defines all used variables.
-    for blk in blocks.values():
-        scope = blk.scope
+    # Define every used variable in each distinct block scope.
+    scopes = {id(blk.scope): blk.scope for blk in blocks.values()}
+    for scope in scopes.values():
         for var in used_var.keys():
             # add this variable if it's not in scope
             if var.name not in scope.localvars:


### PR DESCRIPTION
# Avoid per-block set copies in liveness and scope repair

## Summary

Two front-end helpers did work proportional to blocks times variables. On the IR of a 1500-step kernel (4501 blocks, 3001 variables), `compute_dead_maps` takes 0.026 s instead of 0.592 s and `fixup_var_define_in_scope` 0.029 s instead of 5.333 s.

## The problem

`compute_dead_maps` checks that the dead maps cover every live variable by joining the per-block sets with `reduce(operator.or_, ...)`, which copies the accumulated set at every step. `fixup_var_define_in_scope` walked every block and defined every used variable in that block's scope, so each variable was looked up once per block even though the blocks of a function share a scope.

## The fix

The four joins are single `set().union(*values)` calls. The scope repair collects the distinct scopes first and defines the used variables once in each, so blocks with separate scopes are still covered.

## Tests

The dead maps computed on the benchmark IR are equal before and after.

Full suite: 4514 passed, 177 skipped, 300 xfailed, 0 failed.
