### PR TITLE
Add cuda.unroll and cuda.nounroll loop unroll hints

### DIFF
--- a/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
@@ -211,6 +211,11 @@ public:
   LLVMValueRef mdString(const char *str, unsigned len);
   LLVMValueRef mdNode(LLVMValueRef *vals, unsigned count);
   void addNamedMetadataOperand(const char *name, LLVMValueRef val);
+  /// Build a loop-ID node: `!N = distinct !{!N, vals...}`.
+  LLVMValueRef selfReferentialMDNode(LLVMValueRef *vals, unsigned count);
+  /// Attach `node` to `inst` under metadata kind `kindName`.
+  void setInstructionMetadata(LLVMValueRef inst, const char *kindName,
+                              LLVMValueRef node);
 
   // --- Debug info ---
   void initDebugInfo();
@@ -478,6 +483,12 @@ private:
   LLVM_FN(LLVMValueRef, fnMDNode, LLVMContextRef, LLVMValueRef *, unsigned)
   LLVM_FN(void, fnAddNamedMetadataOperand, LLVMModuleRef, const char *,
            LLVMValueRef)
+  LLVM_FN(unsigned, fnGetMDKindIDInContext, LLVMContextRef, const char *,
+           unsigned)
+  LLVM_FN(void, fnSetMetadata, LLVMValueRef, unsigned, LLVMValueRef)
+  LLVM_FN(LLVMMetadataRef, fnValueAsMetadata, LLVMValueRef)
+  LLVM_FN(LLVMMetadataRef, fnTemporaryMDNode, LLVMContextRef,
+           LLVMMetadataRef *, size_t)
 
   // Debug info
   LLVMDIBuilderRef diBuilder = nullptr;

--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -90,6 +90,10 @@ private:
 
   llvm::StringMap<LLVMTypeRef> namedStructCache;
 
+  // `!llvm.loop` ID node by loop annotation.
+  llvm::DenseMap<mlir::Attribute, LLVMValueRef> loopMetadata;
+  LLVMValueRef loopMetadataFor(mlir::LLVM::LoopAnnotationAttr attr);
+
   // Debug info state
   LLVMMetadataRef diCompileUnit = nullptr;
   LLVMMetadataRef diSubroutineType = nullptr;

--- a/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm70/LLVM70IRBuilder.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstring>
 
 using namespace llvm70;
 
@@ -203,6 +206,10 @@ llvm::Error LLVM70IRBuilder::resolveSymbols() {
   RESOLVE(fnMDString, "LLVMMDStringInContext");
   RESOLVE(fnMDNode, "LLVMMDNodeInContext");
   RESOLVE(fnAddNamedMetadataOperand, "LLVMAddNamedMetadataOperand");
+  RESOLVE(fnGetMDKindIDInContext, "LLVMGetMDKindIDInContext");
+  RESOLVE(fnSetMetadata, "LLVMSetMetadata");
+  RESOLVE(fnValueAsMetadata, "LLVMValueAsMetadata");
+  RESOLVE(fnTemporaryMDNode, "LLVMTemporaryMDNode");
 
   // Debug info
   RESOLVE(fnCreateDIBuilder, "LLVMCreateDIBuilder");
@@ -664,6 +671,24 @@ LLVMValueRef LLVM70IRBuilder::mdNode(LLVMValueRef *vals, unsigned count) {
 void LLVM70IRBuilder::addNamedMetadataOperand(const char *name,
                                              LLVMValueRef val) {
   fnAddNamedMetadataOperand(module, name, val);
+}
+LLVMValueRef LLVM70IRBuilder::selfReferentialMDNode(LLVMValueRef *vals,
+                                                   unsigned count) {
+  // Placeholder operand 0, replaced by the node itself; RAUW frees the placeholder.
+  LLVMMetadataRef placeholder = fnTemporaryMDNode(ctx, nullptr, 0);
+  llvm::SmallVector<LLVMValueRef> operands;
+  operands.push_back(fnMetadataAsValue(ctx, placeholder));
+  operands.append(vals, vals + count);
+  LLVMValueRef node = fnMDNode(ctx, operands.data(), operands.size());
+  fnMetadataReplaceAllUsesWith(placeholder, fnValueAsMetadata(node));
+  return node;
+}
+void LLVM70IRBuilder::setInstructionMetadata(LLVMValueRef inst,
+                                            const char *kindName,
+                                            LLVMValueRef node) {
+  unsigned kind = fnGetMDKindIDInContext(
+      ctx, kindName, static_cast<unsigned>(std::strlen(kindName)));
+  fnSetMetadata(inst, kind, node);
 }
 
 // Debug info

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -749,9 +749,41 @@ llvm::Error MLIRToLLVM70::translateReturnOp(Operation *op) {
   return llvm::Error::success();
 }
 
+LLVMValueRef MLIRToLLVM70::loopMetadataFor(LLVM::LoopAnnotationAttr attr) {
+  LLVMValueRef &node = loopMetadata[attr];
+  if (node)
+    return node;
+
+  llvm::SmallVector<LLVMValueRef> properties;
+  auto mdString = [&](llvm::StringRef name) {
+    return b.mdString(name.data(), name.size());
+  };
+  auto addFlag = [&](llvm::StringRef name) {
+    LLVMValueRef str = mdString(name);
+    properties.push_back(b.mdNode(&str, 1));
+  };
+  auto isTrue = [](BoolAttr flag) { return flag && flag.getValue(); };
+  if (LLVM::LoopUnrollAttr unroll = attr.getUnroll()) {
+    if (isTrue(unroll.getDisable()))
+      addFlag("llvm.loop.unroll.disable");
+    if (IntegerAttr count = unroll.getCount()) {
+      LLVMValueRef ops[2] = {
+          mdString("llvm.loop.unroll.count"),
+          b.constInt(b.i32Ty(), count.getValue().getZExtValue(), false)};
+      properties.push_back(b.mdNode(ops, 2));
+    }
+    if (isTrue(unroll.getFull()))
+      addFlag("llvm.loop.unroll.full");
+  }
+  node = b.selfReferentialMDNode(properties.data(), properties.size());
+  return node;
+}
+
 llvm::Error MLIRToLLVM70::translateBrOp(Operation *op) {
   auto brOp = cast<LLVM::BrOp>(op);
-  b.buildBr(blockMap[brOp.getDest()]);
+  LLVMValueRef br = b.buildBr(blockMap[brOp.getDest()]);
+  if (LLVM::LoopAnnotationAttr attr = brOp.getLoopAnnotationAttr())
+    b.setInstructionMetadata(br, "llvm.loop", loopMetadataFor(attr));
   return llvm::Error::success();
 }
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -10,6 +10,7 @@ Reference documentation
    compilation.rst
    kernel.rst
    cache_hints.rst
+   loop_unroll.rst
    types.rst
    libdevice.rst
    envvars.rst

--- a/docs/source/reference/loop_unroll.rst
+++ b/docs/source/reference/loop_unroll.rst
@@ -1,0 +1,56 @@
+..
+   SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+   SPDX-License-Identifier: BSD-2-Clause
+
+.. _loop-unroll:
+
+Loop Unrolling
+==============
+
+If the number of iterations ``n`` of a ``for`` loop is known at compile time, it can be unrolled fully with ``consteval``, which replicates the loop instructions ``n`` times in numba-cuda-mlir's IR before it gets to the NVIDIA compiler.
+Finer control can be gained using ``cuda.unroll(iterator, count)``, which leaves the loop intact on the numba-cuda-mlir side but tells the backend how to unroll it.
+Using ``cuda.unroll`` lets you specify how many iterations should be unrolled, so a loop of (say) 8 iterations could be unrolled to a 2-iteration loop which has 4 copies of the loop body in the final instruction stream.
+The ``libnvvm`` backend has the final say on what loops are unrolled using ``cuda.unroll``. Sometimes, it can unroll loops that you'd prefer to keep rolled, in which case you can use ``cuda.nounroll`` to tell the backend *not* to unroll a loop.
+
+Compile-time unrolling
+----------------------
+
+.. function:: numba_cuda_mlir.cuda.experimental.consteval(iterable)
+
+   Evaluate ``iterable`` at compile time and repeat the loop body once per item, with the loop variable replaced by that item. The loop variable may be a name, a tuple or a list. ``break``, ``continue`` and an ``else`` clause are not supported. Enable it with ``from numba_cuda_mlir.cuda.experimental import consteval`` in the module that defines the kernel.
+
+Example::
+
+    from numba_cuda_mlir.cuda.experimental import consteval
+
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in consteval(range(16)):
+            acc += x[k]
+        out[0] = acc
+
+
+Unroll hints
+------------
+
+These functions attach an unroll hint for the backend to a ``for`` loop over a ``range``, a 1-D array, a tuple or ``np.nditer``. These perform the same way as ``#pragma unroll`` does in CUDA C++.
+
+.. seealso:: `Loop unrolling metadata <https://llvm.org/docs/LangRef.html#llvm-loop-unroll>`_ in the LLVM Language Reference.
+
+.. function:: numba_cuda_mlir.cuda.unroll(iterable, count=None)
+
+   Iterate ``iterable`` with a full-unroll hint (``#pragma unroll``), or an unroll-by-``count`` hint (``#pragma unroll count``) when ``count`` is given positionally or by keyword. ``count`` must be a positive compile-time integer, or ``None`` for the full-unroll hint.
+
+.. function:: numba_cuda_mlir.cuda.nounroll(iterable)
+
+   Iterate ``iterable`` with an unroll-disable hint (``#pragma unroll 1``).
+
+Example::
+
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.unroll(range(16), count=4):
+            acc += x[k]
+        out[0] = acc

--- a/src/numba_cuda_mlir/cuda/__init__.py
+++ b/src/numba_cuda_mlir/cuda/__init__.py
@@ -149,3 +149,14 @@ def stwb(array, i, value):
 def stwt(array, i, value):
     """Generate a `st.global.wt` instruction for element `i` of an array."""
     pass
+
+
+# Loop unroll hints
+def unroll(iterable, count=None):
+    """Iterate `iterable` with an `llvm.loop.unroll.full` hint, or `.count` when given."""
+    return iterable
+
+
+def nounroll(iterable):
+    """Iterate `iterable` with an `llvm.loop.unroll.disable` hint."""
+    return iterable

--- a/src/numba_cuda_mlir/cuda/__init__.pyi
+++ b/src/numba_cuda_mlir/cuda/__init__.pyi
@@ -22,3 +22,9 @@ def literal_unroll(value: Any) -> Any:
         >>> for i in consteval(range(10)):
         ...     array[i] = i
     """
+
+def unroll(iterable: Any, count: int | None = None) -> Any:
+    """Iterate ``iterable`` with an ``llvm.loop.unroll.full`` hint, or ``.count`` when given."""
+
+def nounroll(iterable: Any) -> Any:
+    """Iterate ``iterable`` with an ``llvm.loop.unroll.disable`` hint."""

--- a/src/numba_cuda_mlir/lowering/cuda.py
+++ b/src/numba_cuda_mlir/lowering/cuda.py
@@ -1582,3 +1582,32 @@ def register_cache_hint_lowerings():
 
 
 register_cache_hint_lowerings()
+
+
+def _hint_iterable(builder, target, iterable, unroll):
+    builder.store_var(target, builder.load_var(iterable))
+    builder._unroll_hints[target.name] = ir.Attribute.parse(
+        f"#llvm.loop_annotation<unroll = <{unroll}>>"
+    )
+
+
+def register_loop_unroll_lowerings():
+    """Register lowerings for the loop unroll hints."""
+
+    @lower(cuda.unroll, types.Any)
+    @lower(cuda.unroll, types.Any, types.Any)
+    def unroll(builder, target, args, kwargs):
+        count = args[1] if len(args) == 2 else dict(kwargs).get("count")
+        count_type = types.none if count is None else builder.get_numba_type(count.name)
+        if isinstance(count_type, types.NoneType):
+            unroll = "full = true"
+        else:
+            unroll = f"count = {count_type.literal_value}"
+        _hint_iterable(builder, target, args[0], unroll)
+
+    @lower(cuda.nounroll, types.Any)
+    def nounroll(builder, target, args, kwargs):
+        _hint_iterable(builder, target, args[0], "disable = true")
+
+
+register_loop_unroll_lowerings()

--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -236,6 +236,10 @@ class MLIRLower(object):
         self._deferred_dbg_declare_vars: set[str] = set()
         self._debug_forced_alloca: set[str] = set()
         self._poly_dbg_alloca: dict[str, ir.Value] = {}
+        # Variable name -> loop_annotation set by cuda.unroll / cuda.nounroll.
+        self._unroll_hints: dict[str, ir.Attribute] = {}
+        # Loop header block offset -> loop_annotation for its back edges.
+        self._loop_unroll_headers: dict[int, ir.Attribute] = {}
 
         self.nrt = MLIRNRTContext(context.data_model_manager)
 
@@ -1221,6 +1225,8 @@ extern "C" __global__ void
         trace()
         assert self.var_lowered(var), f"Var {var.name} not found in varmap."
         var_value = self.load_var(var)
+        if var.name in self._unroll_hints:
+            self._unroll_hints[target.name] = self._unroll_hints[var.name]
 
         match var_value:
             case (
@@ -1478,6 +1484,8 @@ extern "C" __global__ void
     def lower_iternext_expr_assign(self, target, value):
         trace()
         iter_obj = self.load_var(value)
+        if value.name in self._unroll_hints:
+            self._loop_unroll_headers[self.current_offset] = self._unroll_hints[value.name]
         if isinstance(iter_obj, RangeObject):
             iternext = iter_obj.next()
             self.store_var(target, iternext)
@@ -1492,6 +1500,8 @@ extern "C" __global__ void
     def lower_getiter_expr_assign(self, target, value):
         trace()
         value_type = self.get_numba_type(value.name)
+        if value.name in self._unroll_hints:
+            self._unroll_hints[target.name] = self._unroll_hints[value.name]
 
         if isinstance(value_type, types.RangeType):
             ro = self.load_var(value)
@@ -3014,7 +3024,12 @@ extern "C" __global__ void
 
         assert target in self.blkmap, f"target {target} not found in self.blkmap"
 
-        cf.br(dest_operands=[], dest=self.blkmap[target])
+        # A jump to a header already lowered is a back edge; llvm.br keeps the annotation through canonicalization.
+        hint = self._loop_unroll_headers.get(target)
+        if hint is None:
+            cf.br(dest_operands=[], dest=self.blkmap[target])
+        else:
+            llvm.br([], self.blkmap[target], loop_annotation=hint)
 
     def _decref_if_assigned_multi(self, name, var_type):
         """Decref a multi-assign variable by loading from its stack slot,

--- a/src/numba_cuda_mlir/typing/cuda.py
+++ b/src/numba_cuda_mlir/typing/cuda.py
@@ -1058,6 +1058,57 @@ def register_cache_hint_intrinsics():
 register_cache_hint_intrinsics()
 
 
+# `llvm.loop.unroll.count` is an i32 metadata operand that must stay positive.
+UNROLL_COUNT_MAX = 2**31 - 1
+
+
+class UnrollTemplate(AbstractTemplate):
+    from numba_cuda_mlir import cuda
+
+    key = cuda.unroll
+
+    def generic(self, args, kws):
+        from numba_cuda_mlir.numba_cuda.core.errors import TypingError
+
+        if kws:
+            if set(kws) != {"count"}:
+                return None
+            args = (*args, kws["count"])
+        if len(args) not in (1, 2):
+            return None
+        count = args[1] if len(args) == 2 else types.none
+        if not isinstance(count, types.NoneType):
+            if not isinstance(count, types.IntegerLiteral):
+                return None
+            value = count.literal_value
+            if not 1 <= value <= UNROLL_COUNT_MAX:
+                raise TypingError(
+                    f"unroll count must be between 1 and {UNROLL_COUNT_MAX}, got {value}"
+                )
+        return signature(args[0], *args)
+
+
+class NounrollTemplate(AbstractTemplate):
+    from numba_cuda_mlir import cuda
+
+    key = cuda.nounroll
+
+    def generic(self, args, kws):
+        if kws or len(args) != 1:
+            return None
+        return signature(args[0], *args)
+
+
+def register_loop_unroll_intrinsics():
+    from numba_cuda_mlir import cuda
+
+    registry.register_global(cuda.unroll)(UnrollTemplate)
+    registry.register_global(cuda.nounroll)(NounrollTemplate)
+
+
+register_loop_unroll_intrinsics()
+
+
 # Register cuda.bindings.driver.CUtensorMap if available
 try:
     from cuda.bindings import driver

--- a/tests/test_loop_unroll.py
+++ b/tests/test_loop_unroll.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+import numpy as np
+import pytest
+
+from numba_cuda_mlir import cuda, testing
+from numba_cuda_mlir.numba_cuda.core.errors import TypingError
+
+N = 16
+LATCH = "llvm.br ^bb{{[0-9]+}} {loop_annotation = #loop_annotation}"
+
+
+def _optimized_mlir(kernel):
+    (mlir_text,) = kernel.inspect_mlir_optimized().values()
+    return mlir_text
+
+
+def _llvm_ir(kernel):
+    (llvm_ir,) = kernel.inspect_llvm().values()
+    return llvm_ir
+
+
+def _run_sum(kernel):
+    x = cuda.to_device(np.arange(N, dtype=np.float32))
+    out = cuda.to_device(np.zeros(1, dtype=np.float32))
+    kernel[1, 1](x, out)
+    return out.copy_to_host()[0]
+
+
+def _expect_typing_error(kernel, match=None):
+    x = cuda.to_device(np.arange(N, dtype=np.float32))
+    out = cuda.to_device(np.zeros(1, dtype=np.float32))
+    with pytest.raises(TypingError, match=match):
+        kernel[1, 1](x, out)
+
+
+def test_unroll_full_annotates_latch():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.unroll(range(N)):
+            acc += x[k]
+        out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    testing.filecheck(
+        f"""
+        CHECK: #llvm.loop_unroll<full = true>
+        CHECK: {LATCH}
+        """,
+        _optimized_mlir(kernel),
+    )
+
+
+@pytest.mark.parametrize("keyword", [False, True], ids=["positional", "keyword"])
+def test_unroll_count_annotates_latch(keyword):
+    if keyword:
+
+        @cuda.jit
+        def kernel(x, out):
+            acc = np.float32(0.0)
+            for k in cuda.unroll(range(N), count=4):
+                acc += x[k]
+            out[0] = acc
+
+    else:
+
+        @cuda.jit
+        def kernel(x, out):
+            acc = np.float32(0.0)
+            for k in cuda.unroll(range(N), 4):
+                acc += x[k]
+            out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    testing.filecheck(
+        f"""
+        CHECK: #llvm.loop_unroll<count = 4 : i64>
+        CHECK: {LATCH}
+        """,
+        _optimized_mlir(kernel),
+    )
+
+
+def test_nounroll_annotates_latch():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.nounroll(range(N)):
+            acc += x[k]
+        out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    testing.filecheck(
+        f"""
+        CHECK: #llvm.loop_unroll<disable = true>
+        CHECK: {LATCH}
+        """,
+        _optimized_mlir(kernel),
+    )
+
+
+def test_debug_build_annotates_latch():
+    @cuda.jit(debug=True, opt=False)
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.unroll(range(N), 4):
+            acc += x[k]
+        out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    mlir_text = _optimized_mlir(kernel)
+    assert "loop_unroll:" not in mlir_text
+    testing.filecheck(
+        f"""
+        CHECK: #llvm.loop_unroll<count = 4 : i64>
+        CHECK: {LATCH}
+        """,
+        mlir_text,
+    )
+    assert '!{!"llvm.loop.unroll.count", i32 4}' in _llvm_ir(kernel)
+
+
+def test_nounroll_keeps_loop_in_ptx():
+    @cuda.jit
+    def unrolled(x, out):
+        acc = np.float32(0.0)
+        for k in range(N):
+            acc += x[k]
+        out[0] = acc
+
+    @cuda.jit
+    def rolled(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.nounroll(range(N)):
+            acc += x[k]
+        out[0] = acc
+
+    assert _run_sum(unrolled) == _run_sum(rolled)
+    (ptx_unrolled,) = unrolled.inspect_asm().values()
+    (ptx_rolled,) = rolled.inspect_asm().values()
+    assert ptx_rolled.count("ld.global") == 1
+    assert ptx_unrolled.count("ld.global") > 1
+
+
+def test_unroll_count_shapes_ptx():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.unroll(range(N), 4):
+            acc += x[k]
+        out[0] = acc
+
+    _run_sum(kernel)
+    (ptx,) = kernel.inspect_asm().values()
+    assert ptx.count("ld.global") == 4
+
+
+def test_nounroll_survives_lto():
+    @cuda.jit(lto=True)
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.nounroll(range(N)):
+            acc += x[k]
+        out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    (ptx,) = kernel.inspect_lto_ptx().values()
+    assert ptx.count("ld.global") == 1
+
+
+def test_break_and_continue_loop_is_annotated():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.unroll(range(N), 2):
+            if k % 3 == 0:
+                continue
+            if k > 10:
+                break
+            acc += x[k]
+        out[0] = acc
+
+    assert _run_sum(kernel) == sum(k for k in range(11) if k % 3 != 0)
+    testing.filecheck(
+        f"""
+        CHECK: #llvm.loop_unroll<count = 2 : i64>
+        CHECK: {LATCH}
+        """,
+        _optimized_mlir(kernel),
+    )
+
+
+def test_break_as_last_statement_keeps_hint():
+    @cuda.jit
+    def kernel(x, out):
+        for k in cuda.unroll(range(N), 4):
+            v = x[k]
+            out[k] = v
+            if v > 100.0:
+                break
+
+    x = cuda.to_device(np.arange(N, dtype=np.float32))
+    out = cuda.to_device(np.zeros(N, dtype=np.float32))
+    kernel[1, 1](x, out)
+    np.testing.assert_array_equal(out.copy_to_host(), x.copy_to_host())
+    assert "#llvm.loop_unroll<count = 4 : i64>" in _optimized_mlir(kernel)
+    (ptx,) = kernel.inspect_asm().values()
+    assert ptx.count("ld.global") == 4
+
+
+def test_return_as_last_statement_keeps_hint():
+    @cuda.jit
+    def kernel(x, out):
+        for k in cuda.unroll(range(N)):
+            v = x[k]
+            out[k] = v
+            if v > 100.0:
+                return
+
+    x = cuda.to_device(np.arange(N, dtype=np.float32))
+    out = cuda.to_device(np.zeros(N, dtype=np.float32))
+    kernel[1, 1](x, out)
+    np.testing.assert_array_equal(out.copy_to_host(), x.copy_to_host())
+    assert "#llvm.loop_unroll<full = true>" in _optimized_mlir(kernel)
+    (ptx,) = kernel.inspect_asm().values()
+    assert ptx.count("ld.global") == N
+
+
+def test_nested_loops_carry_their_own_hints():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for i in cuda.nounroll(range(4)):
+            for k in cuda.unroll(range(4)):
+                acc += x[i * 4 + k]
+        out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    testing.filecheck(
+        """
+        CHECK-DAG: #llvm.loop_unroll<disable = true>
+        CHECK-DAG: #llvm.loop_unroll<full = true>
+        CHECK: llvm.br ^bb{{[0-9]+}} {loop_annotation = #loop_annotation}
+        CHECK: llvm.br ^bb{{[0-9]+}} {loop_annotation = #loop_annotation1}
+        """,
+        _optimized_mlir(kernel),
+    )
+
+
+def test_latches_of_one_loop_share_its_llvm_loop_id():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.unroll(range(N), 2):
+            if k % 3 == 0:
+                continue
+            acc += x[k]
+        out[0] = acc
+
+    assert _run_sum(kernel) == sum(k for k in range(N) if k % 3 != 0)
+    llvm_ir = _llvm_ir(kernel)
+    ids = set(re.findall(r"!llvm\.loop !(\d+)", llvm_ir))
+    assert len(ids) == 1
+    (loop_id,) = ids
+    assert f"!{loop_id} = distinct !{{!{loop_id}, " in llvm_ir
+
+
+def test_array_loop_is_annotated():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for v in cuda.unroll(x, 4):
+            acc += v
+        out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    mlir_text = _optimized_mlir(kernel)
+    assert "#llvm.loop_unroll<count = 4 : i64>" in mlir_text
+    assert "{loop_annotation = #loop_annotation}" in mlir_text
+
+
+def test_tuple_loop_is_annotated():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.nounroll((0, 1, 2, 3)):
+            acc += x[k]
+        out[0] = acc
+
+    assert _run_sum(kernel) == 6.0
+    mlir_text = _optimized_mlir(kernel)
+    assert "#llvm.loop_unroll<disable = true>" in mlir_text
+    assert "{loop_annotation = #loop_annotation}" in mlir_text
+
+
+def test_nditer_loop_is_annotated():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for v in cuda.unroll(np.nditer(x)):
+            acc += v[()]
+        out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    mlir_text = _optimized_mlir(kernel)
+    assert "#llvm.loop_unroll<full = true>" in mlir_text
+    assert "{loop_annotation = #loop_annotation}" in mlir_text
+
+
+def test_hinted_iterable_held_in_a_variable():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        it = cuda.nounroll(x)
+        for v in it:
+            acc += v
+        out[0] = acc
+
+    assert _run_sum(kernel) == np.arange(N, dtype=np.float32).sum()
+    assert "#llvm.loop_unroll<disable = true>" in _optimized_mlir(kernel)
+
+
+def test_runtime_count_is_rejected():
+    @cuda.jit
+    def kernel(x, out, n):
+        acc = np.float32(0.0)
+        for k in cuda.unroll(range(N), n):
+            acc += x[k]
+        out[0] = acc
+
+    x = cuda.to_device(np.arange(N, dtype=np.float32))
+    out = cuda.to_device(np.zeros(1, dtype=np.float32))
+    with pytest.raises(TypingError):
+        kernel[1, 1](x, out, 4)
+
+
+@pytest.mark.parametrize("count", [0, 2**31], ids=["zero", "above_i32"])
+def test_out_of_range_count_is_rejected(count):
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for k in cuda.unroll(range(N), count):
+            acc += x[k]
+        out[0] = acc
+
+    _expect_typing_error(kernel, match="unroll count")
+
+
+def test_non_iterable_is_rejected():
+    @cuda.jit
+    def kernel(x, out):
+        acc = np.float32(0.0)
+        for v in cuda.unroll(x[0]):
+            acc += v
+        out[0] = acc
+
+    _expect_typing_error(kernel)
+
+
+def test_markers_return_the_iterable_outside_compiled_code():
+    r = range(N)
+    assert cuda.unroll(r) is r
+    assert cuda.unroll(r, 4) is r
+    assert cuda.unroll(r, count=4) is r
+    assert cuda.unroll(r, None) is r
+    assert cuda.nounroll(r) is r


### PR DESCRIPTION
# Add `cuda.unroll` and `cuda.nounroll` loop unroll hints

## Summary

`cuda.unroll(it)`, `cuda.unroll(it, n)` and `cuda.nounroll(it)` wrap the iterable of a `for` loop and ask libnvvm to unroll that loop fully, `n` times, or not at all. They do the same job as `#pragma unroll`, `#pragma unroll n` and `#pragma unroll 1` in CUDA C++. Any iterable a `for` loop lowers takes the hint.

## The problem

The only way to unroll a loop today is `consteval`, which expands it in the AST. The kernel grows by the body times the trip count before the front end sees it, so compile time grows with it (linearly once #296 and #297 land, faster before). Besides compile cost, `consteval` does not support partial unrolling or preventing libnvvm unrolling a rolled loop.

## The fix

`cuda.unroll` and `cuda.nounroll` pass their iterable through directly, typed as identity. `count` (positional or keyword) is how many copies of the body to unroll, and must be a compile-time integer. The lowering step attaches the hint to the iterable, which travels with it through assignments and into the loop's iterator. The hint is stored in a table by the loop's header, and every jump back to that header gets emitted as an `llvm.br` with the hint as its `loop_annotation`. The LLVM70 bridge turns the annotation into `!llvm.loop` metadata on the branch, which the modern bridge does already.

`docs/source/reference/loop_unroll.rst` documents `consteval` unrolling and the two hints.

## Tests

Nineteen tests in `tests/test_loop_unroll.py`, 22 cases:

- `test_unroll_full_annotates_latch`, `test_unroll_count_annotates_latch` (positional and keyword), `test_nounroll_annotates_latch`: each hint form lands as a `loop_annotation` on the loop's back edge
- `test_array_loop_is_annotated`, `test_tuple_loop_is_annotated`, `test_nditer_loop_is_annotated`: the same for the other iterables
- `test_hinted_iterable_held_in_a_variable`: `it = cuda.nounroll(x)` followed by `for v in it` keeps the hint
- `test_nounroll_keeps_loop_in_ptx`, `test_unroll_count_shapes_ptx`, `test_nounroll_survives_lto`: libnvvm honours the hint: one load in the PTX for `nounroll`, four for `count=4`, one after an LTO link
- `test_break_as_last_statement_keeps_hint`, `test_return_as_last_statement_keeps_hint`: a body whose last statement leaves the loop is unrolled four times and fully
- `test_debug_build_annotates_latch`: a `debug=True` build keeps the annotation and its LLVM IR carries the count node
- `test_break_and_continue_loop_is_annotated`, `test_nested_loops_carry_their_own_hints`, `test_latches_of_one_loop_share_its_llvm_loop_id`: `break`/`continue` in the body, nested loops with different hints, and one `!llvm.loop` node shared by a loop's back edges
- `test_runtime_count_is_rejected`, `test_out_of_range_count_is_rejected` (0 and 2**31), `test_non_iterable_is_rejected`: typing errors for a runtime count, an out-of-range count, and a scalar iterable
- `test_markers_return_the_iterable_outside_compiled_code`: the functions return their argument in plain Python

Full suite: 4536 passed, 177 skipped, 300 xfailed, 0 failed (sm_89, CUDA 13, Windows).
