### PR TITLE
Fix error handling for grid runtime dim

### DIFF
--- a/src/numba_cuda_mlir/typing/cuda.py
+++ b/src/numba_cuda_mlir/typing/cuda.py
@@ -441,7 +441,12 @@ class CudaGridTemplate(AbstractTemplate):
         assert not kws
         assert len(args) == 1
         if not isinstance(args[0], types.Literal):
-            raise ForceLiteralArg(arg_indices={0})
+            # Provide a callback to fold the arguments. CUDA grid and gridsize
+            # take one positional argument.
+            def fold_arguments(fold_args, _fold_kws):
+                return tuple(fold_args)
+
+            raise ForceLiteralArg(arg_indices={0}, fold_arguments=fold_arguments)
         if not isinstance(args[0], types.Integer):
             return None
         value = args[0].literal_value

--- a/tests/test_cuda_builtins.py
+++ b/tests/test_cuda_builtins.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-from numba_cuda_mlir import cuda
+from numba_cuda_mlir import cuda, types
+from numba_cuda_mlir.errors import TypingError
 import numpy as np
+import pytest
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
@@ -45,6 +47,30 @@ def test_cuda_builtins():
     kernel[1, 1, stream, 0](x_dev)
     x_host = x_dev.copy_to_host()
     assert x_host[0] == 0
+
+
+def _grid_runtime_dim(d, out):
+    out[0] = cuda.grid(d[0])
+
+
+def _gridsize_runtime_dim(d, out):
+    out[0] = cuda.gridsize(d[0])
+
+
+@pytest.mark.parametrize(
+    "body, intrinsic",
+    [(_grid_runtime_dim, "grid"), (_gridsize_runtime_dim, "gridsize")],
+    ids=["grid", "gridsize"],
+)
+def test_grid_runtime_dimensions_error_handling(body, intrinsic):
+    """A dimension that is not a compile-time constant is rejected with a TypingError."""
+
+    with pytest.raises(TypingError) as excinfo:
+        cuda.jit(body).compile(types.void(types.int64[:], types.int64[:]))
+    msg = str(excinfo.value)
+    assert "Cannot request literal type" in msg
+    assert "During: resolving callee type: Function(<intrinsic %s>)" % intrinsic in msg
+    assert "test_cuda_builtins.py" in msg
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the missing callback `fold_arguments` on the `ForceLiteralArg` raised by `CudaGridTemplate.generic`. Report a runtime cuda.grid() dimension as a `TypingError` with better error message.



