### PR TITLE
Reject a value-returning kernel at compile time

### DIFF
--- a/src/numba_cuda_mlir/mlir_lowering.py
+++ b/src/numba_cuda_mlir/mlir_lowering.py
@@ -334,6 +334,14 @@ class MLIRLower(object):
             numba_type = self._poly_dbg_types.get(var_name, numba_type)
             self._di_builder.add_local_variable(var_name, var_loc, numba_type)
 
+    def _return_loc(self):
+        """Locate the first return statement, for diagnostics about the return type."""
+        for block in self.blocks.values():
+            terminator = block.terminator
+            if isinstance(terminator, numba_ir.Return):
+                return terminator.loc
+        return self.func_ir.loc
+
     def _find_var_def_line(self, var_name):
         """Find the first assignment line for a variable."""
         for block in self.blocks.values():
@@ -545,6 +553,16 @@ extern "C" __global__ void
             # A function is a kernel when device=True is not set AND it returns
             # void.  Non-void functions are always device functions (kernels
             # cannot return values).
+            if (
+                not self.targetoptions.get("device", False)
+                and restypes
+                # compile()/compile_ptx() raise their own TypeError
+                and self.targetoptions.get("_compile_output") is None
+            ):
+                raise errors.TypingError(
+                    "CUDA kernel must have void return type but got %s." % (self.fndesc.restype,),
+                    loc=self._return_loc(),
+                )
             kernel = not self.targetoptions.get("device", False) and not restypes
 
             abi_info = self.targetoptions.get("abi_info") or {}

--- a/tests/test_debuginfo.py
+++ b/tests/test_debuginfo.py
@@ -349,7 +349,8 @@ def test_mlir_bfloat16_type():
     )
 
 
-def k_complex_add(a, b):
+def d_complex_add(a, b):
+    # A device function that returns a value.
     c = a + b
     return c
 
@@ -357,10 +358,11 @@ def k_complex_add(a, b):
 def test_mlir_fusedloc_tags_complex():
     """Complex vars are tagged for deferred dbg.declare emission."""
     mlir = compiler.compile_mlir(
-        k_complex_add,
+        d_complex_add,
         (types.complex64, types.complex64),
         debug=True,
         opt=False,
+        device=True,
     )
     testing.filecheck(
         """
@@ -375,11 +377,12 @@ def test_mlir_fusedloc_tags_complex():
 def test_mlir_deferred_dbg_declare_complex():
     """Deferred pass emits dbg.declare and complex DI type."""
     optimized_mlir = compiler.compile_mlir(
-        k_complex_add,
+        d_complex_add,
         (types.complex128, types.complex128),
         optimized=True,
         debug=True,
         opt=False,
+        device=True,
     )
     testing.filecheck(
         """

--- a/tests/test_device_functions.py
+++ b/tests/test_device_functions.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from numba_cuda_mlir import cuda
+from numba_cuda_mlir.errors import TypingError
 import numpy as np
+import pytest
 
 import logging
 
@@ -22,6 +24,21 @@ def test_device_functions():
     a = a.copy_to_host()
     print(a)
     assert a[0] == 0
+
+
+def test_nonvoid_kernel_rejected_before_launch():
+    """A kernel with a non-void return type is rejected at compile time."""
+
+    @cuda.jit
+    def returns_value(a, out):
+        out[0] = a[0]
+        return 1
+
+    with pytest.raises(TypingError) as excinfo:
+        returns_value[1, 1](np.zeros(1, dtype=np.int64), np.zeros(1, dtype=np.int64))
+    msg = str(excinfo.value)
+    assert "must have void return type" in msg
+    assert "test_device_functions.py" in msg
 
 
 def test_self_recursion():

--- a/tests/test_device_functions.py
+++ b/tests/test_device_functions.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from numba_cuda_mlir import cuda
 from numba_cuda_mlir.errors import TypingError
+import inspect
 import numpy as np
 import pytest
 
@@ -34,11 +35,14 @@ def test_nonvoid_kernel_rejected_before_launch():
         out[0] = a[0]
         return 1
 
+    source, first_line = inspect.getsourcelines(returns_value.py_func)
+    return_line = first_line + next(i for i, line in enumerate(source) if "return 1" in line)
+
     with pytest.raises(TypingError) as excinfo:
         returns_value[1, 1](np.zeros(1, dtype=np.int64), np.zeros(1, dtype=np.int64))
     msg = str(excinfo.value)
     assert "must have void return type" in msg
-    assert "test_device_functions.py" in msg
+    assert 'test_device_functions.py", line %d:' % return_line in msg
 
 
 def test_self_recursion():


### PR DESCRIPTION
Non-void kernel must be rejected before launch.