### PR TITLE
Compare against zero when converting a float to bool

### DIFF
--- a/src/numba_cuda_mlir/lowering/builtins.py
+++ b/src/numba_cuda_mlir/lowering/builtins.py
@@ -465,7 +465,14 @@ def type_convert(builder, target, args, kwargs):
         builder.store_var(target, result)
         return
 
-    if isinstance(value.type, ir.BF16Type) and isinstance(to_type, ir.IntegerType):
+    # An i1 target is excluded so it falls through to `convert`, which compares against
+    # zero rather than truncating; fptosi/fptoui to i1 keeps the low bit, so bf16(0.0)
+    # came out True and bf16(2.0) came out False.
+    if (
+        isinstance(value.type, ir.BF16Type)
+        and isinstance(to_type, ir.IntegerType)
+        and to_type.width > 1
+    ):
         value = (
             arith.fptosi(out=to_type, in_=value) if signed else arith.fptoui(out=to_type, in_=value)
         )

--- a/src/numba_cuda_mlir/lowering_utilities/__init__.py
+++ b/src/numba_cuda_mlir/lowering_utilities/__init__.py
@@ -1021,6 +1021,15 @@ def unverified_basic_mlir_convert(
                 else arith.uitofp(out=target_type, in_=value)
             )
         case ((ir.FloatType() | ir.BF16Type()), ir.IntegerType()):
+            # Special case: converting to i1 (boolean) asks whether the value is non-zero.
+            # fptosi/fptoui to i1 keeps the low bit of the truncated integer instead, so 0.0
+            # comes out True and 2.0 comes out False. `_convert_integer_to_integer` already
+            # special-cases an i1 target the same way. UNE rather than ONE so that NaN is
+            # truthy, matching bool(float("nan")) in Python.
+            if target_type.width == 1:
+                trace("converting float to i1 (boolean) via comparison against zero")
+                zero = arith.constant(value_type, value=0.0)
+                return arith.cmpf(arith.CmpFPredicate.UNE, value, zero)
             return (
                 arith.fptosi(out=target_type, in_=value)
                 if use_signed_conversion(target_type.width > 1)

--- a/tests/test_bool.py
+++ b/tests/test_bool.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import numpy as np
+import pytest
 from numba_cuda_mlir import cuda
 
 
@@ -57,3 +58,41 @@ def test_boolean_ordering_comparisons():
         a, b = bool(lhs), bool(rhs)
         expected = [int(a < b), int(a <= b), int(a > b), int(a >= b)]
         np.testing.assert_array_equal(out.copy_to_host(), expected)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_float_to_boolean_conversion(dtype):
+    """A float converts to bool by comparing against zero, not by truncating.
+
+    Lowering the conversion to fptoui/fptosi with an i1 target keeps the low bit of
+    the truncated integer, so 0.0 came out True and 2.0 came out False.
+    """
+
+    @cuda.jit
+    def k(out, a):
+        i = cuda.grid(1)
+        if i < out.size:
+            out[i] = a[i]
+
+    values = np.array([0.0, -0.0, 0.5, 1.0, 2.0, -1.0, 1e-45, np.inf, -np.inf, np.nan], dtype=dtype)
+    a = cuda.to_device(values)
+    out = cuda.to_device(np.zeros(values.size, dtype=np.bool_))
+    k[1, values.size](out, a)
+    np.testing.assert_array_equal(out.copy_to_host(), values.astype(np.bool_))
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_float_to_wider_integer_still_truncates(dtype):
+    """Only the i1 target compares against zero; wider integers keep truncation."""
+
+    @cuda.jit
+    def k(out, a):
+        i = cuda.grid(1)
+        if i < out.size:
+            out[i] = a[i]
+
+    values = np.array([0.0, 2.5, -2.5, 7.9], dtype=dtype)
+    a = cuda.to_device(values)
+    out = cuda.to_device(np.zeros(values.size, dtype=np.int32))
+    k[1, values.size](out, a)
+    np.testing.assert_array_equal(out.copy_to_host(), values.astype(np.int32))

--- a/tests/test_half_precision.py
+++ b/tests/test_half_precision.py
@@ -256,3 +256,24 @@ def test_bf16_bfloat162float():
     out = np.zeros(1, dtype=np.float32)
     kernel[1, 1](out, 3.14)
     np.testing.assert_allclose(out[0], 3.14, rtol=0.1)
+
+
+@pytest.mark.parametrize("value,expected", [(0.0, False), (2.0, True), (0.5, True), (-1.0, True)])
+def test_bf16_to_boolean_compares_against_zero(value, expected):
+    """A bfloat16 converts to bool by comparing against zero, not by truncating.
+
+    `type_convert` routed every bf16-to-integer cast through fptosi/fptoui, which for an
+    i1 target keeps the low bit of the truncated integer: bf16(0.0) came out True and
+    bf16(2.0) came out False.
+    """
+
+    @cuda.jit
+    def kernel(out, x):
+        out[0] = np.bool_(bf16.bfloat16(x))
+
+    out = np.zeros(1, dtype=np.bool_)
+    kernel[1, 1](out, np.float64(value))
+    np.testing.assert_equal(out[0], expected)
+
+    mlir = compiler.compile_mlir(kernel, types.void(types.boolean[:], types.float64))
+    assert "arith.cmpf" in mlir


### PR DESCRIPTION
## Description

Converting a float to a bool lowered to `fptosi`/`fptoui` with an `i1` target, which keeps the low bit of the value truncated to an integer instead of asking whether the value is non-zero. `0.0` came out `True` and `2.0` came out `False`.

Fixes #304.

Reproduced on an RTX 4050 (CUDA 13.3) against `59033a5`, the head of the latest green `main` CI, using that run's own wheel rather than the release:

```
input : [ 0.5  2.5  0.  -1. ]
before: [False False  True False]
after : [ True  True False  True]
```

## The fix

`_convert_integer_to_integer` already special-cases an `i1` target with a comparison against zero; the float arm of `convert` had no such case, so it now mirrors it:

```python
if target_type.width == 1:
    zero = arith.constant(value_type, value=0.0)
    return arith.cmpf(arith.CmpFPredicate.UNE, value, zero)
```

`UNE` rather than `ONE`, so NaN is truthy and matches `bool(float("nan"))` in Python. `ONE` would trade this bug for a quieter one.

## A second site

`type_convert` in `lowering/builtins.py` special-cases bf16-to-integer and bypasses `convert` entirely, so it carried its own copy of the same defect — `bf16(0.0)` was `True` and `bf16(2.0)` was `False`. I confirmed this is pre-existing rather than a consequence of the change above, by testing it on the unmodified top-of-tree wheel.

Rather than duplicate the zero-comparison there, an `i1` target is excluded from that special case so it falls through to the corrected `convert`. One implementation of the rule instead of two.

This does make the change slightly wider than the issue, which reports only the float64 path. Happy to split the bf16 half into its own issue and PR if you would prefer to keep this one to what was reported.

## Tests

- `test_float_to_boolean_conversion` — float32 and float64 across `0.0`, `-0.0`, `0.5`, `1.0`, `2.0`, `-1.0`, a subnormal, `±inf` and `nan`, with NumPy's own `astype(np.bool_)` as the oracle rather than a hand-written expectation.
- `test_bf16_to_boolean_compares_against_zero` — the bf16 path, asserting `arith.cmpf` reaches the emitted MLIR, matching the convention in the existing bf16 cast tests.
- `test_float_to_wider_integer_still_truncates` — a guard that `2.5 -> int32` remains `2`. The fix is gated on `target_type.width == 1`, and this pins that gate so it cannot widen unnoticed later.

Every one of the new conversion tests fails without the fix and passes with it; the guard passes either way, which is what it is for.

## Verification

On an RTX 4050, CUDA 13.3, built from source against the CI's prebuilt LLVM:

```
tests/test_bool.py tests/test_half_precision.py
tests/numba_cuda_tests/cudapy/test_casting.py tests/test_bitwise.py
tests/test_enum.py tests/test_vector_type_complex_cast.py tests/test_extending_lower_cast.py
-> 106 passed, 6 xfailed
```

`pre-commit run` clean on the changed files.

`test_bf16_integer_cast_preserves_signedness` asserts specific conversion ops reach the MLIR for int8/16/32/64 and uint8/16/32/64 targets, and still passes — the change only affects `width == 1`.

## Unrelated observation

While checking this I noticed #303 appears already fixed by 775039a ("Preserve signedness in integer-float conversions", #294) on 2026-09-08 — `value_to_storage` now takes and forwards `signed=`, and its reproducer passes on this build. Possibly worth closing; I have not touched it here.

This change was developed with AI assistance.
