### PR TITLE
Convert integer arguments to the bf16 reinterpret intrinsics numerically

### DIFF
--- a/src/numba_cuda_mlir/lowering/half_precision.py
+++ b/src/numba_cuda_mlir/lowering/half_precision.py
@@ -1044,58 +1044,28 @@ def register_bf16_lowering():
         result = arith.bitcast(T.bf16(), value)
         builder.store_var(target, result)
 
-    # Bitcast intrinsics with int64/int32 args (for when scalars are typed as int64)
-    # These truncate to i16 first, then treat that as the bf16 bit pattern
-    @lower(__bfloat16_as_short, types.int64)
-    def bfloat16_as_short_i64_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        result = arith.trunci(T.i16(), value)
-        builder.store_var(target, result)
+    # Bitcast intrinsics applied to an integer argument. The integer is not
+    # already a bf16 bit pattern, so it is converted numerically to bf16 first
+    # and only then reinterpreted, which is what numba-cuda does for the same
+    # call. Reinterpreting the integer's own bits instead would silently give
+    # a different value than the equivalent host-side computation.
+    def _int_arg_bitcast_impl(signed):
+        int_to_bf16 = arith.sitofp if signed else arith.uitofp
 
-    @lower(__bfloat16_as_short, types.int32)
-    def bfloat16_as_short_i32_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        result = arith.trunci(T.i16(), value)
-        builder.store_var(target, result)
+        def impl(builder, target, args, kwargs):
+            value = builder.load_var(args[0])
+            as_bf16 = int_to_bf16(out=T.bf16(), in_=value)
+            result = arith.bitcast(T.i16(), as_bf16)
+            builder.store_var(target, result)
 
-    @lower(__bfloat16_as_short, types.int16)
-    def bfloat16_as_short_i16_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        builder.store_var(target, value)
+        return impl
 
-    @lower(__bfloat16_as_ushort, types.int64)
-    def bfloat16_as_ushort_i64_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        result = arith.trunci(T.i16(), value)
-        builder.store_var(target, result)
+    for _fn in (__bfloat16_as_short, __bfloat16_as_ushort):
+        for _ty in (types.int64, types.int32, types.int16):
+            lower(_fn, _ty)(_int_arg_bitcast_impl(signed=True))
 
-    @lower(__bfloat16_as_ushort, types.int32)
-    def bfloat16_as_ushort_i32_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        result = arith.trunci(T.i16(), value)
-        builder.store_var(target, result)
-
-    @lower(__bfloat16_as_ushort, types.int16)
-    def bfloat16_as_ushort_i16_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        builder.store_var(target, value)
-
-    @lower(__bfloat16_as_ushort, types.uint64)
-    def bfloat16_as_ushort_u64_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        result = arith.trunci(T.i16(), value)
-        builder.store_var(target, result)
-
-    @lower(__bfloat16_as_ushort, types.uint32)
-    def bfloat16_as_ushort_u32_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        result = arith.trunci(T.i16(), value)
-        builder.store_var(target, result)
-
-    @lower(__bfloat16_as_ushort, types.uint16)
-    def bfloat16_as_ushort_u16_impl(builder, target, args, kwargs):
-        value = builder.load_var(args[0])
-        builder.store_var(target, value)
+    for _ty in (types.uint64, types.uint32, types.uint16):
+        lower(__bfloat16_as_ushort, _ty)(_int_arg_bitcast_impl(signed=False))
 
     @lower(__short_as_bfloat16, types.int64)
     def short_as_bfloat16_i64_impl(builder, target, args, kwargs):

--- a/src/numba_cuda_mlir/typing/half_precision.py
+++ b/src/numba_cuda_mlir/typing/half_precision.py
@@ -61,8 +61,9 @@ def register_bf16_globals():
             registry.register_global(func, types.Function(UnaryTemplate))
             _bf16_registered_globals.add(func)
 
-    # Register typing for bitcast functions that also accept integer types
-    # This allows passing integer bit patterns to be treated as bf16
+    # Register typing for bitcast functions that also accept integer types.
+    # An integer argument is converted numerically to bf16 before its bits are
+    # reinterpreted, matching what numba-cuda does for the same call.
     _bfloat16_as_short = getattr(mod, "__bfloat16_as_short", None)
     if _bfloat16_as_short and _bfloat16_as_short not in _bf16_registered_globals:
         _key = _bfloat16_as_short

--- a/tests/numba_cuda_tests/cudapy/test_bfloat16.py
+++ b/tests/numba_cuda_tests/cudapy/test_bfloat16.py
@@ -349,7 +349,6 @@ class TestBfloat16HighLevelBindings(NumbaCUDATestCase):
         self.assertAlmostEqual(out[2], 2.0, delta=1e-3)
         self.assertAlmostEqual(out[3], 2.0, delta=1e-3)
 
-    @pytest.mark.xfail(reason="https://github.com/NVIDIA/numba-cuda-mlir/issues/305")
     def test_bfloat16_as_bitcast(self):
         self.skip_unsupported()
 

--- a/tests/test_half_precision.py
+++ b/tests/test_half_precision.py
@@ -154,6 +154,31 @@ def test_bf16_integer_assignment_is_numeric(
     assert conversion_op in mlir
 
 
+@pytest.mark.parametrize(
+    "source_type,conversion_op",
+    [
+        (types.int16, "arith.sitofp"),
+        (types.int32, "arith.sitofp"),
+        (types.int64, "arith.sitofp"),
+        (types.uint16, "arith.uitofp"),
+        (types.uint32, "arith.uitofp"),
+        (types.uint64, "arith.uitofp"),
+    ],
+)
+def test_bf16_as_int16_converts_integer_argument_numerically(source_type, conversion_op):
+    # An integer passed to a reinterpret intrinsic is not already a bf16 bit
+    # pattern, so it must be converted numerically to bf16 before its bits are
+    # reinterpreted. Reinterpreting the integer's own bits would make
+    # bfloat16_as_uint16(x) silently disagree with numba-cuda for the same x.
+    @cuda.jit
+    def kernel(out, x):
+        out[0] = bf16.bfloat16_as_uint16(x)
+
+    mlir = compiler.compile_mlir(kernel, types.void(types.uint16[:], source_type))
+    assert conversion_op in mlir
+    assert "arith.bitcast" in mlir
+
+
 def test_bf16_fma():
     @cuda.jit
     def kernel(out, a, b, c):


### PR DESCRIPTION
`bfloat16_as_int16`/`bfloat16_as_uint16` accept integer arguments and were lowering it as if it already held a bf16 bit pattern. The 16 bit overloads stored it unchanged and the wider ones truncated it. Legacy `numba-cuda` types these intrinsics for bf16 only, so an integer argument is converted numerically to bf16 there and only then reinterpreted, and every input silently disagreed between the two.

Lower the integer overloads as `arith.sitofp`/`arith.uitofp` to bf16 followed by the bitcast, picking the conversion by the argument's signedness. This also un-xfails `test_bfloat16_as_bitcast`, whose roundtrip was asymmetric for the same reason.

Fixes #305
