### PR TITLE
Fix ill typed insertvalue for alloca in LLVM7 Translator

### DIFF
--- a/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70IRBuilder.h
@@ -74,6 +74,8 @@ public:
   // --- Basic blocks ---
   LLVMBasicBlockRef appendBB(LLVMValueRef fn, const char *name);
   void positionAtEnd(LLVMBasicBlockRef bb);
+  void positionBefore(LLVMValueRef inst);
+  LLVMValueRef getTerminator(LLVMBasicBlockRef bb);
   LLVMBasicBlockRef getInsertBlock();
 
   // --- Constants ---
@@ -360,6 +362,8 @@ private:
   // Builder
   LLVM_FN(LLVMBuilderRef, fnCreateBuilder, LLVMContextRef)
   LLVM_FN(void, fnPositionAtEnd, LLVMBuilderRef, LLVMBasicBlockRef)
+  LLVM_FN(void, fnPositionBefore, LLVMBuilderRef, LLVMValueRef)
+  LLVM_FN(LLVMValueRef, fnGetTerminator, LLVMBasicBlockRef)
   LLVM_FN(void, fnDisposeBuilder, LLVMBuilderRef)
 
   // Constants

--- a/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
+++ b/cext/mlir-llvm70/include/llvm70/LLVM70Target.h
@@ -112,6 +112,7 @@ private:
   // Map an MLIR value to its old-LLVM counterpart.
   void mapValue(mlir::Value v, LLVMValueRef lv) { valueMap[v] = lv; }
   LLVMValueRef lookupValue(mlir::Value v);
+  LLVMValueRef lookupValueAsDeclared(mlir::Value v);
 
   // Type conversion: MLIR type → LLVM 7 type.
   // For ptr types the element type must be recovered from context.

--- a/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70IRBuilder.cpp
@@ -98,6 +98,8 @@ llvm::Error LLVM70IRBuilder::resolveSymbols() {
   // Builder
   RESOLVE(fnCreateBuilder, "LLVMCreateBuilderInContext");
   RESOLVE(fnPositionAtEnd, "LLVMPositionBuilderAtEnd");
+  RESOLVE(fnPositionBefore, "LLVMPositionBuilderBefore");
+  RESOLVE(fnGetTerminator, "LLVMGetBasicBlockTerminator");
   RESOLVE(fnDisposeBuilder, "LLVMDisposeBuilder");
 
   // Constants
@@ -326,6 +328,12 @@ LLVMBasicBlockRef LLVM70IRBuilder::appendBB(LLVMValueRef fn, const char *name) {
 }
 void LLVM70IRBuilder::positionAtEnd(LLVMBasicBlockRef bb) {
   fnPositionAtEnd(builder, bb);
+}
+void LLVM70IRBuilder::positionBefore(LLVMValueRef inst) {
+  fnPositionBefore(builder, inst);
+}
+LLVMValueRef LLVM70IRBuilder::getTerminator(LLVMBasicBlockRef bb) {
+  return fnGetTerminator(bb);
 }
 LLVMBasicBlockRef LLVM70IRBuilder::getInsertBlock() {
   return fnGetInsertBlock(builder);

--- a/cext/mlir-llvm70/lib/LLVM70Target.cpp
+++ b/cext/mlir-llvm70/lib/LLVM70Target.cpp
@@ -244,6 +244,21 @@ LLVMValueRef MLIRToLLVM70::lookupValue(Value v) {
   llvm::report_fatal_error(llvm::StringRef(msg), /*GenCrashDiag=*/false);
 }
 
+LLVMValueRef MLIRToLLVM70::lookupValueAsDeclared(Value v) {
+  LLVMValueRef val = lookupValue(v);
+  // convertType renders an opaque !llvm.ptr as i8*, but not every producer
+  // hands back a value of that type: an alloca stays the elemTy* LLVM 7 gives
+  // it, so that dbg.declare still names the stack slot itself. Ops that put a
+  // pointer somewhere already typed as i8* -- an aggregate field, a pointee,
+  // the other arm of a select, a block argument -- have to reconcile the two,
+  // because LLVM 7 has no opaque pointers and libNVVM's bitcode reader rejects
+  // the mismatch. Values that already have the declared type are unaffected;
+  // a no-op bitcast folds away.
+  if (isa<LLVM::LLVMPointerType>(v.getType()))
+    val = b.buildBitCast(val, convertType(v.getType()), "");
+  return val;
+}
+
 //===----------------------------------------------------------------------===//
 // Debug info helpers
 //===----------------------------------------------------------------------===//
@@ -564,19 +579,30 @@ llvm::Error MLIRToLLVM70::translatePhiOps(Block &block) {
       if (!seen.insert(pred).second)
         continue;
       Operation *term = pred->getTerminator();
+      // A coercion for an incoming value has to live in the predecessor, ahead
+      // of its terminator, so that it dominates the phi.
+      auto incoming = [&](Value v) {
+        if (!isa<LLVM::LLVMPointerType>(v.getType()))
+          return lookupValue(v);
+        LLVMBasicBlockRef saved = b.getInsertBlock();
+        b.positionBefore(b.getTerminator(blockMap[pred]));
+        LLVMValueRef val = lookupValueAsDeclared(v);
+        b.positionAtEnd(saved);
+        return val;
+      };
       if (auto brOp = dyn_cast<LLVM::BrOp>(term)) {
-        inVals.push_back(lookupValue(brOp.getDestOperands()[argIdx]));
+        inVals.push_back(incoming(brOp.getDestOperands()[argIdx]));
         inBlocks.push_back(blockMap[pred]);
       } else if (auto condBr = dyn_cast<LLVM::CondBrOp>(term)) {
         // Skip if both branches target the same block — handled by trampolines
         if (condBr.getTrueDest() == condBr.getFalseDest())
           continue;
         if (condBr.getTrueDest() == &block) {
-          inVals.push_back(lookupValue(condBr.getTrueDestOperands()[argIdx]));
+          inVals.push_back(incoming(condBr.getTrueDestOperands()[argIdx]));
           inBlocks.push_back(blockMap[pred]);
         }
         if (condBr.getFalseDest() == &block) {
-          inVals.push_back(lookupValue(condBr.getFalseDestOperands()[argIdx]));
+          inVals.push_back(incoming(condBr.getFalseDestOperands()[argIdx]));
           inBlocks.push_back(blockMap[pred]);
         }
       }
@@ -1234,7 +1260,7 @@ llvm::Error MLIRToLLVM70::translateLoadOp(Operation *op) {
 
 llvm::Error MLIRToLLVM70::translateStoreOp(Operation *op) {
   auto storeOp = cast<LLVM::StoreOp>(op);
-  LLVMValueRef val = lookupValue(storeOp.getValue());
+  LLVMValueRef val = lookupValueAsDeclared(storeOp.getValue());
   LLVMValueRef ptr = lookupValue(storeOp.getAddr());
 
   // Reconstruct pointer type: bitcast i8* → elemTy* to match stored value
@@ -1352,9 +1378,10 @@ llvm::Error MLIRToLLVM70::translateCastOp(Operation *op) {
 
 llvm::Error MLIRToLLVM70::translateSelectOp(Operation *op) {
   auto selectOp = cast<LLVM::SelectOp>(op);
-  auto result = b.buildSelect(lookupValue(selectOp.getCondition()),
-                              lookupValue(selectOp.getTrueValue()),
-                              lookupValue(selectOp.getFalseValue()), "");
+  auto result =
+      b.buildSelect(lookupValue(selectOp.getCondition()),
+                    lookupValueAsDeclared(selectOp.getTrueValue()),
+                    lookupValueAsDeclared(selectOp.getFalseValue()), "");
   mapValue(selectOp.getResult(), result);
   return llvm::Error::success();
 }
@@ -1413,7 +1440,7 @@ llvm::Error MLIRToLLVM70::translateExtractValueOp(Operation *op) {
 llvm::Error MLIRToLLVM70::translateInsertValueOp(Operation *op) {
   auto ivOp = cast<LLVM::InsertValueOp>(op);
   LLVMValueRef agg = lookupValue(ivOp.getContainer());
-  LLVMValueRef val = lookupValue(ivOp.getValue());
+  LLVMValueRef val = lookupValueAsDeclared(ivOp.getValue());
   auto positions = ivOp.getPosition();
   if (positions.size() == 1) {
     auto result = b.buildInsertValue(agg, val, positions[0], "");

--- a/cext/mlir-llvm70/test/alloca_ptr.mlir
+++ b/cext/mlir-llvm70/test/alloca_ptr.mlir
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// RUN: llvm70-translate %s --dump-llvm 2>&1 >/dev/null | FileCheck %s
+// RUN: llvm70-translate %s --dump-ptx 2>&1 >/dev/null | FileCheck --check-prefix=CHECK-PTX %s
+
+// convertType renders an opaque !llvm.ptr as i8*, but an alloca is mapped to
+// the elemTy* LLVM 7 gives it, so that debug info still names the real stack
+// slot. LLVM 7 has no opaque pointers, so every op that puts a pointer
+// somewhere already typed as i8* has to bridge the two, or libNVVM's bitcode
+// reader refuses to parse the module.
+
+module {
+  gpu.module @kernels [#nvvm_llvm70.target<chip = "sm_75">] {
+
+    llvm.func @alloca_into_struct(%out: !llvm.ptr<1>) attributes {gpu.kernel} {
+      %c1 = llvm.mlir.constant(1 : i64) : i64
+      %p = llvm.alloca %c1 x i64 : (i64) -> !llvm.ptr
+      %u = llvm.mlir.poison : !llvm.struct<(ptr, i64)>
+      %s = llvm.insertvalue %p, %u[0] : !llvm.struct<(ptr, i64)>
+      %f = llvm.extractvalue %s[0] : !llvm.struct<(ptr, i64)>
+      %v = llvm.load %f : !llvm.ptr -> i64
+      llvm.store %v, %out : i64, !llvm.ptr<1>
+      llvm.return
+    }
+
+    llvm.func @alloca_stored_as_ptr(%out: !llvm.ptr<1>) attributes {gpu.kernel} {
+      %c1 = llvm.mlir.constant(1 : i64) : i64
+      %p = llvm.alloca %c1 x i64 : (i64) -> !llvm.ptr
+      %pp = llvm.alloca %c1 x !llvm.ptr : (i64) -> !llvm.ptr
+      llvm.store %p, %pp : !llvm.ptr, !llvm.ptr
+      %q = llvm.load %pp : !llvm.ptr -> !llvm.ptr
+      %v = llvm.load %q : !llvm.ptr -> i64
+      llvm.store %v, %out : i64, !llvm.ptr<1>
+      llvm.return
+    }
+
+    // The two arms have different element types, so a select over the typed
+    // pointers would not even agree with itself.
+    llvm.func @alloca_selected(%out: !llvm.ptr<1>, %c: i1) attributes {gpu.kernel} {
+      %c1 = llvm.mlir.constant(1 : i64) : i64
+      %a = llvm.alloca %c1 x i64 : (i64) -> !llvm.ptr
+      %b = llvm.alloca %c1 x i32 : (i64) -> !llvm.ptr
+      %s = llvm.select %c, %a, %b : i1, !llvm.ptr
+      %v = llvm.load %s : !llvm.ptr -> i64
+      llvm.store %v, %out : i64, !llvm.ptr<1>
+      llvm.return
+    }
+
+    // Block arguments are already converted to i8*, so the incoming alloca has
+    // to match or the phi is ill typed.
+    llvm.func @alloca_through_block_arg(%out: !llvm.ptr<1>) attributes {gpu.kernel} {
+      %c1 = llvm.mlir.constant(1 : i64) : i64
+      %a = llvm.alloca %c1 x i64 : (i64) -> !llvm.ptr
+      llvm.br ^bb1(%a : !llvm.ptr)
+    ^bb1(%q: !llvm.ptr):
+      %v = llvm.load %q : !llvm.ptr -> i64
+      llvm.store %v, %out : i64, !llvm.ptr<1>
+      llvm.return
+    }
+  }
+}
+
+// CHECK-LABEL: define ptx_kernel void @alloca_into_struct
+// CHECK: %[[P:.*]] = alloca i64
+// CHECK: %[[C:.*]] = bitcast i64* %[[P]] to i8*
+// CHECK: insertvalue { i8*, i64 } undef, i8* %[[C]], 0
+
+// CHECK-LABEL: define ptx_kernel void @alloca_stored_as_ptr
+// CHECK: store i8* %{{.*}}, i8** %
+
+// CHECK-LABEL: define ptx_kernel void @alloca_selected
+// CHECK: select i1 %{{.*}}, i8* %{{.*}}, i8* %
+
+// CHECK-LABEL: define ptx_kernel void @alloca_through_block_arg
+// CHECK: phi i8* [ %
+
+// CHECK-PTX: .visible .entry alloca_into_struct
+// CHECK-PTX: .visible .entry alloca_stored_as_ptr
+// CHECK-PTX: .visible .entry alloca_selected
+// CHECK-PTX: .visible .entry alloca_through_block_arg


### PR DESCRIPTION
Fixes an issue in the LLVM 7 translator where  `convertType` renders every opaque `!llvm.ptr` as `i8*`, but `translateAllocaOp` maps its result to a real `elemTy*. so any op writing a pointer into an i8* gets the wrong pointer type.